### PR TITLE
Cleaning up ots tests to not require NLP models

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
 julia 0.4.6
 JSON
-MathProgBase
+MathProgBase 0.5.4
 JuMP

--- a/test/ots.jl
+++ b/test/ots.jl
@@ -24,25 +24,9 @@ if (Pkg.installed("AmplNLWriter") != nothing && Pkg.installed("CoinOptServices")
 end
 
 
-function run_nl_ots(file, model_constructor, solver; kwargs...)
-    data = PowerModels.parse_file(file)
-
-    pm = model_constructor(data; solver = solver, kwargs...)
-
-    PowerModels.post_ots(pm)
-
-    pg = JuMP.getvariable(pm.model, :pg)[1]
-    lb = JuMP.getlowerbound(pg)
-    JuMP.@NLconstraint(pm.model, pg >= lb)
-
-    status, solve_time = solve(pm)
-
-    return PowerModels.build_solution(pm, status, solve_time; solution_builder = PowerModels.get_ots_solution)
-end
-
 @testset "test dc ots" begin
     @testset "3-bus case" begin
-        result = run_nl_ots("../test/data/case3.json", DCPPowerModel, pajarito_solver)
+        result = run_ots("../test/data/case3.json", DCPPowerModel, pajarito_solver)
 
         check_br_status(result["solution"])
 
@@ -51,7 +35,7 @@ end
     end
 
     @testset "5-bus case" begin
-        result = run_nl_ots("../test/data/case5.json", DCPPowerModel, pajarito_solver)
+        result = run_ots("../test/data/case5.json", DCPPowerModel, pajarito_solver)
 
         check_br_status(result["solution"])
 
@@ -62,7 +46,7 @@ end
 
 @testset "test dc-losses ots" begin
     @testset "3-bus case" begin
-        result = run_nl_ots("../test/data/case3.json", DCPLLPowerModel, pajarito_solver)
+        result = run_ots("../test/data/case3.json", DCPLLPowerModel, pajarito_solver)
 
         check_br_status(result["solution"])
 
@@ -71,7 +55,7 @@ end
     end
 
     @testset "5-bus case" begin
-        result = run_nl_ots("../test/data/case5.json", DCPLLPowerModel, pajarito_solver)
+        result = run_ots("../test/data/case5.json", DCPLLPowerModel, pajarito_solver)
 
         check_br_status(result["solution"])
 
@@ -82,7 +66,7 @@ end
 
 @testset "test soc ots" begin
     @testset "3-bus case" begin
-        result = run_nl_ots("../test/data/case3.json", SOCWRPowerModel, pajarito_solver)
+        result = run_ots("../test/data/case3.json", SOCWRPowerModel, pajarito_solver)
 
         check_br_status(result["solution"])
 
@@ -90,7 +74,7 @@ end
         @test isapprox(result["objective"], 5736.2; atol = 1e0)
     end
     @testset "5-bus rts case" begin
-        result = run_nl_ots("../test/data/case5.json", SOCWRPowerModel, pajarito_solver)
+        result = run_ots("../test/data/case5.json", SOCWRPowerModel, pajarito_solver)
 
         check_br_status(result["solution"])
 


### PR DESCRIPTION
Tests will fail until the next version of Pajarito.
