### PR TITLE
Linting src/core directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.jl.*.cov
 *.jl.mem
 deps/deps.jl
+*.tags

--- a/src/core/base.jl
+++ b/src/core/base.jl
@@ -91,7 +91,7 @@ function JuMP.solve(pm::GenericPowerModel)
     try
         solve_time = getsolvetime(pm.model)
     catch
-        warn("there was an issue with getsolvetime() on the solver, falling back on @timed.  This is not a rigorous timing value.");
+        warn("there was an issue with getsolvetime() on the solver, falling back to @timed.  This is not a rigorous timing value.")
     end
 
     return status, solve_time
@@ -209,7 +209,7 @@ function make_per_unit(mva_base::Number, data::Dict{AbstractString,Any})
         if k == "gencost"
             for cost_model in data[k]
                 if cost_model["model"] != 2
-                    println("WARNING: Skipping generator cost model of tpye other than 2")
+                    warn("Skipping generator cost model of type other than 2")
                     continue
                 end
                 degree = length(cost_model["cost"])

--- a/src/core/base.jl
+++ b/src/core/base.jl
@@ -131,8 +131,8 @@ function build_sets(data :: Dict{AbstractString,Any})
     arcs = [arcs_from; arcs_to] 
 
     bus_gens = [i => [] for (i,bus) in bus_lookup]
-    for (i,gen) in gen_lookup
-        push!(bus_gens[gen["gen_bus"]], i)
+    for (i, g) in gen_lookup
+        push!(bus_gens[g["gen_bus"]], i)
     end
 
     bus_branches = [i => [] for (i,bus) in bus_lookup]

--- a/src/core/base.jl
+++ b/src/core/base.jl
@@ -1,9 +1,8 @@
 # stuff that is universal to all power models
 
-export 
+export
     GenericPowerModel,
     setdata, setsolver, solve
-
 
 type PowerDataSets
     ref_bus
@@ -26,8 +25,6 @@ abstract AbstractPowerModel
 abstract AbstractPowerFormulation
 abstract AbstractConicPowerFormulation <: AbstractPowerFormulation
 
-
-
 type GenericPowerModel{T<:AbstractPowerFormulation} <: AbstractPowerModel
     model::Model
     data::Dict{AbstractString,Any}
@@ -35,7 +32,6 @@ type GenericPowerModel{T<:AbstractPowerFormulation} <: AbstractPowerModel
     setting::Dict{AbstractString,Any}
     solution::Dict{AbstractString,Any}
 end
-
 
 # default generic constructor
 function GenericPowerModel{T}(data::Dict{AbstractString,Any}, vars::T; setting = Dict{AbstractString,Any}(), solver = JuMP.UnsetSolver())
@@ -52,7 +48,6 @@ function GenericPowerModel{T}(data::Dict{AbstractString,Any}, vars::T; setting =
     return pm
 end
 
-
 function process_raw_data(data::Dict{AbstractString,Any})
     make_per_unit(data)
     unify_transformer_taps(data)
@@ -63,8 +58,6 @@ function process_raw_data(data::Dict{AbstractString,Any})
 
     return data, sets
 end
-
-
 
 #
 # Just seems too hard to maintain with the default constructor
@@ -78,7 +71,6 @@ end
 #    pm.data = data
 
 #end
-
 
 # TODO Ask Miles, why do we need to put JuMP. here?  using at top level should bring it in
 function JuMP.setsolver(pm::GenericPowerModel, solver::MathProgBase.AbstractMathProgSolver)
@@ -97,7 +89,6 @@ function JuMP.solve(pm::GenericPowerModel)
     return status, solve_time
 end
 
-
 function run_generic_model(file, model_constructor, solver, post_method; solution_builder = get_solution, kwargs...)
     data = PowerModels.parse_file(file)
 
@@ -110,8 +101,7 @@ function run_generic_model(file, model_constructor, solver, post_method; solutio
     return build_solution(pm, status, solve_time; solution_builder = solution_builder)
 end
 
-
-function build_sets(data :: Dict{AbstractString,Any})
+function build_sets(data::Dict{AbstractString,Any})
     bus_lookup = [ Int(bus["index"]) => bus for bus in data["bus"] ]
     gen_lookup = [ Int(gen["index"]) => gen for gen in data["gen"] ]
     for gencost in data["gencost"]
@@ -120,15 +110,14 @@ function build_sets(data :: Dict{AbstractString,Any})
     end
     branch_lookup = [ Int(branch["index"]) => branch for branch in data["branch"] ]
 
-    # filter turned off stuff 
+    # filter turned off stuff
     bus_lookup = filter((i, bus) -> bus["bus_type"] != 4, bus_lookup)
     gen_lookup = filter((i, gen) -> gen["gen_status"] == 1 && gen["gen_bus"] in keys(bus_lookup), gen_lookup)
     branch_lookup = filter((i, branch) -> branch["br_status"] == 1 && branch["f_bus"] in keys(bus_lookup) && branch["t_bus"] in keys(bus_lookup), branch_lookup)
 
-
     arcs_from = [(i,branch["f_bus"],branch["t_bus"]) for (i,branch) in branch_lookup]
     arcs_to   = [(i,branch["t_bus"],branch["f_bus"]) for (i,branch) in branch_lookup]
-    arcs = [arcs_from; arcs_to] 
+    arcs = [arcs_from; arcs_to]
 
     bus_gens = [i => [] for (i,bus) in bus_lookup]
     for (i, g) in gen_lookup
@@ -154,18 +143,16 @@ function build_sets(data :: Dict{AbstractString,Any})
     gen_idxs = collect(keys(gen_lookup))
     branch_idxs = collect(keys(branch_lookup))
 
-
     buspair_indexes = collect(Set([(i,j) for (l,i,j) in arcs_from]))
-    buspairs = buspair_parameters(buspair_indexes, branch_lookup, bus_lookup)  
+    buspairs = buspair_parameters(buspair_indexes, branch_lookup, bus_lookup)
 
     return PowerDataSets(ref_bus, bus_lookup, bus_idxs, gen_lookup, gen_idxs, branch_lookup, branch_idxs, bus_gens, arcs_from, arcs_to, arcs, bus_branches, buspairs, buspair_indexes)
 end
 
-
 # compute bus pair level structures
 function buspair_parameters(buspair_indexes, branches, buses)
-    bp_angmin = [bp => -Inf for bp in buspair_indexes] 
-    bp_angmax = [bp =>  Inf for bp in buspair_indexes] 
+    bp_angmin = [bp => -Inf for bp in buspair_indexes]
+    bp_angmax = [bp =>  Inf for bp in buspair_indexes]
     bp_line = [bp => Inf for bp in buspair_indexes]
 
     for (l,branch) in branches
@@ -178,8 +165,8 @@ function buspair_parameters(buspair_indexes, branches, buses)
     end
 
     buspairs = [(i,j) => Dict(
-        "line"=>bp_line[(i,j)], 
-        "angmin"=>bp_angmin[(i,j)], 
+        "line"=>bp_line[(i,j)],
+        "angmin"=>bp_angmin[(i,j)],
         "angmax"=>bp_angmax[(i,j)],
         "rate_a"=>branches[bp_line[(i,j)]]["rate_a"],
         "tap"=>branches[bp_line[(i,j)]]["tap"],
@@ -190,9 +177,6 @@ function buspair_parameters(buspair_indexes, branches, buses)
         ) for (i,j) in buspair_indexes]
     return buspairs
 end
-
-
-
 
 not_pu = Set(["rate_a","rate_b","rate_c","bs","gs","pd","qd","pg","qg","pmax","pmin","qmax","qmin"])
 not_rad = Set(["angmax","angmin","shift","va"])
@@ -255,10 +239,8 @@ function unify_transformer_taps(data::Dict{AbstractString,Any})
     end
 end
 
-
-
 # NOTE, this function assumes all values are p.u. and angles are in radians
-function add_branch_parameters(data :: Dict{AbstractString,Any})
+function add_branch_parameters(data::Dict{AbstractString,Any})
     min_theta_delta = calc_min_phase_angle(data)
     max_theta_delta = calc_max_phase_angle(data)
 
@@ -278,7 +260,7 @@ function add_branch_parameters(data :: Dict{AbstractString,Any})
     end
 end
 
-function standardize_cost_order(data :: Dict{AbstractString,Any})
+function standardize_cost_order(data::Dict{AbstractString,Any})
     for gencost in data["gencost"]
         if gencost["model"] == 2 && length(gencost["cost"]) < 3
             println("std gen cost: ",gencost["cost"])
@@ -289,8 +271,7 @@ function standardize_cost_order(data :: Dict{AbstractString,Any})
     end
 end
 
-
-function calc_max_phase_angle(data :: Dict{AbstractString,Any})
+function calc_max_phase_angle(data::Dict{AbstractString,Any})
     bus_count = length(data["bus"])
     angle_max = [branch["angmax"] for branch in data["branch"]]
     sort!(angle_max, rev=true)
@@ -298,17 +279,10 @@ function calc_max_phase_angle(data :: Dict{AbstractString,Any})
     return sum(angle_max[1:bus_count-1])
 end
 
-function calc_min_phase_angle(data :: Dict{AbstractString,Any})
+function calc_min_phase_angle(data::Dict{AbstractString,Any})
     bus_count = length(data["bus"])
     angle_min = [branch["angmin"] for branch in data["branch"]]
     sort!(angle_min)
 
     return sum(angle_min[1:bus_count-1])
 end
-
-
-
-
-
-
-

--- a/src/core/constraint.jl
+++ b/src/core/constraint.jl
@@ -1,8 +1,8 @@
-##########################################################################################################
-# The purpose of this file is to define commonly used and created constraints used in power flow models
+################################################################################
+# The purpose of this file is to define commonly used and created constraints
+# used in power flow models
 # This will hopefully make everything more compositional
-##########################################################################################################
-
+################################################################################
 
 # Generic thermal limit constraint
 function constraint_thermal_limit_from{T}(pm::GenericPowerModel{T}, branch; scale = 1.0)
@@ -86,7 +86,6 @@ function constraint_thermal_limit_to_on_off{T}(pm::GenericPowerModel{T}, branch;
     return Set([c])
 end
 
-
 function constraint_active_gen_setpoint{T}(pm::GenericPowerModel{T}, gen)
     i = gen["index"]
     pg = getvariable(pm.model, :pg)[gen["index"]]
@@ -101,7 +100,6 @@ function constraint_reactive_gen_setpoint{T}(pm::GenericPowerModel{T}, gen)
     c = @constraint(pm.model, qg == gen["qg"])
     return Set([c])
 end
-
 
 function constraint_active_loss_lb{T}(pm::GenericPowerModel{T}, branch)
     @assert branch["br_r"] >= 0
@@ -137,5 +135,3 @@ function constraint_reactive_loss_lb{T}(pm::GenericPowerModel{T}, branch)
     c = @constraint(m, q_fr + q_to >= -branch["br_b"]/2*(v_fr^2/branch["tap"]^2 + v_to^2))
     return Set([c])
 end
-
-

--- a/src/core/objective.jl
+++ b/src/core/objective.jl
@@ -1,15 +1,13 @@
-##########################################################################################################
-# The purpose of this file is to define commonly used and created constraints used in power flow models
+################################################################################
+# The purpose of this file is to define common objectives for power flow models
 # This will hopefully make everything more compositional
-##########################################################################################################
-
+################################################################################
 
 function objective_min_fuel_cost{T}(pm::GenericPowerModel{T})
     pg = getvariable(pm.model, :pg)
-    cost = (i) -> pm.set.gens[i]["cost"]
+    cost(i) = pm.set.gens[i]["cost"]
     return @objective(pm.model, Min, sum{ cost(i)[1]*pg[i]^2 + cost(i)[2]*pg[i] + cost(i)[3], i in pm.set.gen_indexes} )
 end
-
 
 function objective_min_fuel_cost{T <: AbstractConicPowerFormulation}(pm::GenericPowerModel{T})
     @variable(pm.model, pm.set.gens[i]["pmin"]^2 <= pg_sqr[i in pm.set.gen_indexes] <= pm.set.gens[i]["pmax"]^2)
@@ -17,11 +15,9 @@ function objective_min_fuel_cost{T <: AbstractConicPowerFormulation}(pm::Generic
     pg = getvariable(pm.model, :pg)
 
     for (i, gen) in pm.set.gens
-    @constraint(pm.model, norm([2*pg[i], pg_sqr[i]-1]) <= pg_sqr[i]+1)
+        @constraint(pm.model, norm([2*pg[i], pg_sqr[i]-1]) <= pg_sqr[i]+1)
     end
 
-    cost = (i) -> pm.set.gens[i]["cost"]
+    cost(i) = pm.set.gens[i]["cost"]
     return @objective(pm.model, Min, sum{ cost(i)[1]*pg_sqr[i] + cost(i)[2]*pg[i] + cost(i)[3], i in pm.set.gen_indexes} )
 end
-
-

--- a/src/core/relaxation_scheme.jl
+++ b/src/core/relaxation_scheme.jl
@@ -1,17 +1,14 @@
-
-
 function relaxation_complex_product(m, a, b, c, d)
-    # TODO add LNC cuts to this 
+    # TODO add LNC cuts to this
     c = @constraint(m, c^2 + d^2 <= a*b)
     return Set([c])
 end
 
-
 function relaxation_complex_product_on_off(m, a, b, c, d, z)
-    # TODO add LNC cuts to this 
+    # TODO add LNC cuts to this
     @assert getlowerbound(c) <= 0 && getupperbound(c) >= 0
     @assert getlowerbound(d) <= 0 && getupperbound(d) >= 0
-    # assume c and d are already linked to z in other constraints 
+    # assume c and d are already linked to z in other constraints
     # and will be forced to 0 when z is 0
 
     a_ub = getupperbound(a)
@@ -23,7 +20,6 @@ function relaxation_complex_product_on_off(m, a, b, c, d, z)
     c3 = @constraint(m, c^2 + d^2 <= a*b_ub*z)
     return Set([c1, c2, c3])
 end
-
 
 function relaxation_equality_on_off(m, x, y, z)
     # assumes 0 is in the domain of y when z is 0
@@ -37,14 +33,12 @@ function relaxation_equality_on_off(m, x, y, z)
     return Set([c1, c2])
 end
 
-
 # general relaxation of a square term
 function relaxation_sqr(m, x, y)
     c1 = @constraint(m, y >= x^2)
     c2 = @constraint(m, y <= (getupperbound(x)+getlowerbound(x))*x - getupperbound(x)*getlowerbound(x))
     return Set([c1, c2])
 end
-
 
 # general relaxation of a sin term
 function relaxation_sin(m, x, y)
@@ -53,7 +47,7 @@ function relaxation_sin(m, x, y)
     @assert lb >= -pi/2 && ub <= pi/2
 
     max_ad = max(abs(lb),abs(ub))
-    
+
     if lb < 0 && ub > 0
         c1 = @constraint(m, y <= cos(max_ad/2)*(x - max_ad/2) + sin(max_ad/2))
         c2 = @constraint(m, y >= cos(max_ad/2)*(x + max_ad/2) - sin(max_ad/2))
@@ -69,7 +63,6 @@ function relaxation_sin(m, x, y)
     return Set([c1, c2])
 end
 
-
 # general relaxation of a cosine term
 function relaxation_cos(m, x, y)
     ub = getupperbound(x)
@@ -77,12 +70,11 @@ function relaxation_cos(m, x, y)
     @assert lb >= -pi/2 && ub <= pi/2
 
     max_ad = max(abs(lb),abs(ub))
-    
+
     c1 = @constraint(m, y <= 1 - (1-cos(max_ad))/(max_ad*max_ad)*(x^2))
     c2 = @constraint(m, y >= (cos(lb) - cos(ub))/(lb-ub)*(x - lb) + cos(lb))
     return Set([c1, c2])
 end
-
 
 # general relaxation of binlinear term (McCormick)
 function relaxation_product(m, x, y, z)
@@ -98,5 +90,3 @@ function relaxation_product(m, x, y, z)
 
     return Set([c1, c2, c3, c4])
 end
-
-

--- a/src/core/solution.jl
+++ b/src/core/solution.jl
@@ -1,16 +1,15 @@
-
 function build_solution{T}(pm::GenericPowerModel{T}, status, solve_time; objective = NaN, solution_builder = get_solution)
     # TODO assert that the model is solved
 
     if status != :Error
         objective = getobjectivevalue(pm.model)
-        status = solver_status_dict(symbol(typeof(pm.model.solver).name.module), status)
+        status = solver_status_dict(Symbol(typeof(pm.model.solver).name.module), status)
     end
 
     solution = Dict{AbstractString,Any}(
-        "solver" => string(typeof(pm.model.solver)), 
-        "status" => status, 
-        "objective" => objective, 
+        "solver" => string(typeof(pm.model.solver)),
+        "status" => status,
+        "objective" => objective,
         "objective_lb" => guard_getobjbound(pm.model),
         "solve_time" => solve_time,
         "solution" => solution_builder(pm),
@@ -100,8 +99,6 @@ function add_setpoint{T}(sol, pm::GenericPowerModel{T}, dict_name, index_name, p
     end
 end
 
-
-
 solver_status_lookup = Dict{Any, Dict{Symbol, Symbol}}()
 
 solver_status_lookup[:Ipopt] = Dict(:Optimal => :LocalOptimal, :Infeasible => :LocalInfeasible)
@@ -109,7 +106,6 @@ solver_status_lookup[:ConicNonlinearBridge] = Dict(:Optimal => :LocalOptimal, :I
 
 # note that AmplNLWriter.AmplNLSolver is the solver type of bonmin
 solver_status_lookup[:AmplNLWriter] = Dict(:Optimal => :LocalOptimal, :Infeasible => :LocalInfeasible)
-
 
 # translates solver status codes to our status codes
 function solver_status_dict(solver_module_symbol, status)
@@ -132,6 +128,3 @@ function guard_getobjbound(model)
         -Inf
     end
 end
-
-
-

--- a/src/core/variable.jl
+++ b/src/core/variable.jl
@@ -1,7 +1,7 @@
-##########################################################################################################
-# The purpose of this file is to define commonly used and created variables used in power flow models
+################################################################################
+# This file defines commonly used variables for power flow models
 # This will hopefully make everything more compositional
-##########################################################################################################
+################################################################################
 
 # extracts the start value fro,
 function getstart(set, item_key, value_key, default = 0.0)
@@ -35,7 +35,6 @@ function variable_voltage_magnitude_sqr{T}(pm::GenericPowerModel{T}; bounded = t
     return w
 end
 
-
 function variable_voltage_magnitude_sqr_from_on_off{T}(pm::GenericPowerModel{T})
     buses = pm.set.buses
     branches = pm.set.branches
@@ -53,8 +52,6 @@ function variable_voltage_magnitude_sqr_to_on_off{T}(pm::GenericPowerModel{T})
 
     return w_to
 end
-
-
 
 function variable_active_generation{T}(pm::GenericPowerModel{T}; bounded = true)
     if bounded
@@ -96,10 +93,10 @@ function compute_voltage_product_bounds{T}(pm::GenericPowerModel{T})
     buspairs = pm.set.buspairs
     buspair_indexes = pm.set.buspair_indexes
 
-    wr_min = [bp => -Inf for bp in buspair_indexes] 
-    wr_max = [bp =>  Inf for bp in buspair_indexes] 
+    wr_min = [bp => -Inf for bp in buspair_indexes]
+    wr_max = [bp =>  Inf for bp in buspair_indexes]
     wi_min = [bp => -Inf for bp in buspair_indexes]
-    wi_max = [bp =>  Inf for bp in buspair_indexes] 
+    wi_max = [bp =>  Inf for bp in buspair_indexes]
 
     for bp in buspair_indexes
         i,j = bp
@@ -131,10 +128,10 @@ function variable_complex_voltage_product{T}(pm::GenericPowerModel{T}; bounded =
     if bounded
         wr_min, wr_max, wi_min, wi_max = compute_voltage_product_bounds(pm)
 
-        @variable(pm.model, wr_min[bp] <= wr[bp in pm.set.buspair_indexes] <= wr_max[bp], start = getstart(pm.set.buspairs, bp, "wr_start", 1.0)) 
+        @variable(pm.model, wr_min[bp] <= wr[bp in pm.set.buspair_indexes] <= wr_max[bp], start = getstart(pm.set.buspairs, bp, "wr_start", 1.0))
         @variable(pm.model, wi_min[bp] <= wi[bp in pm.set.buspair_indexes] <= wi_max[bp], start = getstart(pm.set.buspairs, bp, "wi_start"))
     else
-        @variable(pm.model, wr[bp in pm.set.buspair_indexes], start = getstart(pm.set.buspairs, bp, "wr_start", 1.0)) 
+        @variable(pm.model, wr[bp in pm.set.buspair_indexes], start = getstart(pm.set.buspairs, bp, "wr_start", 1.0))
         @variable(pm.model, wi[bp in pm.set.buspair_indexes], start = getstart(pm.set.buspairs, bp, "wi_start"))
     end
     return wr, wi
@@ -145,12 +142,11 @@ function variable_complex_voltage_product_on_off{T}(pm::GenericPowerModel{T})
 
     bi_bp = [i => (b["f_bus"], b["t_bus"]) for (i,b) in pm.set.branches]
 
-    @variable(pm.model, min(0, wr_min[bi_bp[b]]) <= wr[b in pm.set.branch_indexes] <= max(0, wr_max[bi_bp[b]]), start = getstart(pm.set.buspairs, bi_bp[b], "wr_start", 1.0)) 
+    @variable(pm.model, min(0, wr_min[bi_bp[b]]) <= wr[b in pm.set.branch_indexes] <= max(0, wr_max[bi_bp[b]]), start = getstart(pm.set.buspairs, bi_bp[b], "wr_start", 1.0))
     @variable(pm.model, min(0, wi_min[bi_bp[b]]) <= wi[b in pm.set.branch_indexes] <= max(0, wi_max[bi_bp[b]]), start = getstart(pm.set.buspairs, bi_bp[b], "wr_start"))
 
     return wr, wi
 end
-
 
 function variable_complex_voltage_product_matrix{T}(pm::GenericPowerModel{T})
     wr_min, wr_max, wi_min, wi_max = compute_voltage_product_bounds(pm)
@@ -191,7 +187,6 @@ function variable_complex_voltage_product_matrix{T}(pm::GenericPowerModel{T})
     return WR, WI
 end
 
-
 # Creates variables associated with differences in phase angles
 function variable_phase_angle_difference{T}(pm::GenericPowerModel{T})
     @variable(pm.model, pm.set.buspairs[bp]["angmin"] <= td[bp in pm.set.buspair_indexes] <= pm.set.buspairs[bp]["angmax"], start = getstart(pm.set.buspairs, bp, "td_start"))
@@ -201,7 +196,7 @@ end
 # Creates the voltage magnitude product variables
 function variable_voltage_magnitude_product{T}(pm::GenericPowerModel{T})
     vv_min = [bp => pm.set.buspairs[bp]["v_from_min"]*pm.set.buspairs[bp]["v_to_min"] for bp in pm.set.buspair_indexes]
-    vv_max = [bp => pm.set.buspairs[bp]["v_from_max"]*pm.set.buspairs[bp]["v_to_max"] for bp in pm.set.buspair_indexes] 
+    vv_max = [bp => pm.set.buspairs[bp]["v_from_max"]*pm.set.buspairs[bp]["v_to_max"] for bp in pm.set.buspair_indexes]
 
     @variable(pm.model,  vv_min[bp] <= vv[bp in pm.set.buspair_indexes] <=  vv_max[bp], start = getstart(pm.set.buspairs, bp, "vv_start", 1.0))
     return vv
@@ -209,7 +204,7 @@ end
 
 function variable_cosine{T}(pm::GenericPowerModel{T})
     cos_min = [bp => -Inf for bp in pm.set.buspair_indexes]
-    cos_max = [bp =>  Inf for bp in pm.set.buspair_indexes] 
+    cos_max = [bp =>  Inf for bp in pm.set.buspair_indexes]
 
     for bp in pm.set.buspair_indexes
         buspair = pm.set.buspairs[bp]
@@ -236,23 +231,16 @@ function variable_sine{T}(pm::GenericPowerModel{T})
     return si
 end
 
-function variable_current_magnitude_sqr{T}(pm::GenericPowerModel{T}) 
+function variable_current_magnitude_sqr{T}(pm::GenericPowerModel{T})
     buspairs = pm.set.buspairs
-    cm_min = [bp => 0 for bp in pm.set.buspair_indexes] 
-    cm_max = [bp => (buspairs[bp]["rate_a"]*buspairs[bp]["tap"]/buspairs[bp]["v_from_min"])^2 for bp in pm.set.buspair_indexes]       
+    cm_min = [bp => 0 for bp in pm.set.buspair_indexes]
+    cm_max = [bp => (buspairs[bp]["rate_a"]*buspairs[bp]["tap"]/buspairs[bp]["v_from_min"])^2 for bp in pm.set.buspair_indexes]
 
     @variable(pm.model, cm_min[bp] <= cm[bp in pm.set.buspair_indexes] <=  cm_max[bp], start = getstart(pm.set.buspairs, bp, "cm_start"))
     return cm
 end
 
-
-
 function variable_line_indicator{T}(pm::GenericPowerModel{T})
     @variable(pm.model, 0 <= line_z[l in pm.set.branch_indexes] <= 1, Int, start = getstart(pm.set.branches, l, "line_z_start", 1.0))
     return line_z
 end
-
-
-
-
-


### PR DESCRIPTION
Cosmetic changes in src/core directory. Mostly removing trailing spaces and blank lines. Functionality should be unaltered: the only syntax changes are e2ae40b (rename `gen` to `g` to prevent confusion with outer scope `gen`) and d02c15a (rewrite to avoid declaring unused var `l`).