### PR TITLE
Suppress warnings during testing

### DIFF
--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -6,3 +6,4 @@ GLPKMathProgInterface
 Pajarito
 
 BaseTestNext
+Logging

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,7 @@
 using PowerModels
+using Logging
+# suppress warnings during testing
+Logging.configure(level=ERROR)
 
 using Ipopt
 using Pajarito


### PR DESCRIPTION
[Logging.jl](https://github.com/kmsquire/Logging.jl) can override `info()` and `warn()` during testing to suppress all but the test summary messages. This makes the output of `Pkg.test()` easier to read.

After this change, any use of `info()` in test files will be ignored, so `println` must be used instead. I didn't see any `info()` calls in the test files, so this is just something to keep in mind when writing future test files.