### PR TITLE
#30, fix Julia 0.5 warnings

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -2,3 +2,4 @@ julia 0.4.6
 JSON
 MathProgBase 0.5.4
 JuMP 0.14.0
+Compat

--- a/src/PowerModels.jl
+++ b/src/PowerModels.jl
@@ -5,6 +5,7 @@ module PowerModels
 using JSON
 using MathProgBase
 using JuMP
+using Compat
 
 include("io/matpower.jl")
 include("io/json.jl")

--- a/src/core/base.jl
+++ b/src/core/base.jl
@@ -102,13 +102,13 @@ function run_generic_model(file, model_constructor, solver, post_method; solutio
 end
 
 function build_sets(data::Dict{AbstractString,Any})
-    bus_lookup = [ Int(bus["index"]) => bus for bus in data["bus"] ]
-    gen_lookup = [ Int(gen["index"]) => gen for gen in data["gen"] ]
+    bus_lookup = Dict(Int(bus["index"]) => bus for bus in data["bus"])
+    gen_lookup = Dict(Int(gen["index"]) => gen for gen in data["gen"])
     for gencost in data["gencost"]
         i = Int(gencost["index"])
         gen_lookup[i] = merge(gen_lookup[i], gencost)
     end
-    branch_lookup = [ Int(branch["index"]) => branch for branch in data["branch"] ]
+    branch_lookup = Dict(Int(branch["index"]) => branch for branch in data["branch"])
 
     # filter turned off stuff
     bus_lookup = filter((i, bus) -> bus["bus_type"] != 4, bus_lookup)
@@ -119,12 +119,12 @@ function build_sets(data::Dict{AbstractString,Any})
     arcs_to   = [(i,branch["t_bus"],branch["f_bus"]) for (i,branch) in branch_lookup]
     arcs = [arcs_from; arcs_to]
 
-    bus_gens = [i => [] for (i,bus) in bus_lookup]
+    bus_gens = Dict(i => [] for (i,bus) in bus_lookup)
     for (i,gen) in gen_lookup
         push!(bus_gens[gen["gen_bus"]], i)
     end
 
-    bus_branches = [i => [] for (i,bus) in bus_lookup]
+    bus_branches = Dict(i => [] for (i,bus) in bus_lookup)
     for (l,i,j) in arcs_from
         push!(bus_branches[i], (l,i,j))
         push!(bus_branches[j], (l,j,i))
@@ -152,9 +152,9 @@ end
 
 # compute bus pair level structures
 function buspair_parameters(buspair_indexes, branches, buses)
-    bp_angmin = [bp => -Inf for bp in buspair_indexes]
-    bp_angmax = [bp =>  Inf for bp in buspair_indexes]
-    bp_line = [bp => Inf for bp in buspair_indexes]
+    bp_angmin = Dict(bp => -Inf for bp in buspair_indexes)
+    bp_angmax = Dict(bp =>  Inf for bp in buspair_indexes)
+    bp_line = Dict(bp => Inf for bp in buspair_indexes)
 
     for (l,branch) in branches
         i = branch["f_bus"]
@@ -165,7 +165,7 @@ function buspair_parameters(buspair_indexes, branches, buses)
         bp_line[(i,j)] = min(bp_line[(i,j)], l)
     end
 
-    buspairs = [(i,j) => Dict(
+    buspairs = Dict((i,j) => Dict(
         "line"=>bp_line[(i,j)],
         "angmin"=>bp_angmin[(i,j)],
         "angmax"=>bp_angmax[(i,j)],
@@ -175,7 +175,7 @@ function buspair_parameters(buspair_indexes, branches, buses)
         "v_from_max"=>buses[i]["vmax"],
         "v_to_min"=>buses[j]["vmin"],
         "v_to_max"=>buses[j]["vmax"]
-        ) for (i,j) in buspair_indexes]
+        ) for (i,j) in buspair_indexes)
     return buspairs
 end
 

--- a/src/core/base.jl
+++ b/src/core/base.jl
@@ -102,13 +102,13 @@ function run_generic_model(file, model_constructor, solver, post_method; solutio
 end
 
 function build_sets(data::Dict{AbstractString,Any})
-    bus_lookup = Dict(Int(bus["index"]) => bus for bus in data["bus"])
-    gen_lookup = Dict(Int(gen["index"]) => gen for gen in data["gen"])
+    bus_lookup = Dict([(Int(bus["index"]), bus) for bus in data["bus"]])
+    gen_lookup = Dict([(Int(gen["index"]), gen) for gen in data["gen"]])
     for gencost in data["gencost"]
         i = Int(gencost["index"])
         gen_lookup[i] = merge(gen_lookup[i], gencost)
     end
-    branch_lookup = Dict(Int(branch["index"]) => branch for branch in data["branch"])
+    branch_lookup = Dict([(Int(branch["index"]), branch) for branch in data["branch"]])
 
     # filter turned off stuff
     bus_lookup = filter((i, bus) -> bus["bus_type"] != 4, bus_lookup)
@@ -119,12 +119,12 @@ function build_sets(data::Dict{AbstractString,Any})
     arcs_to   = [(i,branch["t_bus"],branch["f_bus"]) for (i,branch) in branch_lookup]
     arcs = [arcs_from; arcs_to]
 
-    bus_gens = Dict(i => [] for (i,bus) in bus_lookup)
+    bus_gens = Dict([(i, []) for (i,bus) in bus_lookup])
     for (i,gen) in gen_lookup
         push!(bus_gens[gen["gen_bus"]], i)
     end
 
-    bus_branches = Dict(i => [] for (i,bus) in bus_lookup)
+    bus_branches = Dict([(i, []) for (i,bus) in bus_lookup])
     for (l,i,j) in arcs_from
         push!(bus_branches[i], (l,i,j))
         push!(bus_branches[j], (l,j,i))
@@ -152,9 +152,9 @@ end
 
 # compute bus pair level structures
 function buspair_parameters(buspair_indexes, branches, buses)
-    bp_angmin = Dict(bp => -Inf for bp in buspair_indexes)
-    bp_angmax = Dict(bp =>  Inf for bp in buspair_indexes)
-    bp_line = Dict(bp => Inf for bp in buspair_indexes)
+    bp_angmin = Dict([(bp, -Inf) for bp in buspair_indexes])
+    bp_angmax = Dict([(bp, Inf) for bp in buspair_indexes])
+    bp_line = Dict([(bp, Inf) for bp in buspair_indexes])
 
     for (l,branch) in branches
         i = branch["f_bus"]
@@ -165,7 +165,7 @@ function buspair_parameters(buspair_indexes, branches, buses)
         bp_line[(i,j)] = min(bp_line[(i,j)], l)
     end
 
-    buspairs = Dict((i,j) => Dict(
+    buspairs = Dict([((i,j), Dict(
         "line"=>bp_line[(i,j)],
         "angmin"=>bp_angmin[(i,j)],
         "angmax"=>bp_angmax[(i,j)],
@@ -175,7 +175,7 @@ function buspair_parameters(buspair_indexes, branches, buses)
         "v_from_max"=>buses[i]["vmax"],
         "v_to_min"=>buses[j]["vmin"],
         "v_to_max"=>buses[j]["vmax"]
-        ) for (i,j) in buspair_indexes)
+        )) for (i,j) in buspair_indexes])
     return buspairs
 end
 

--- a/src/core/solution.jl
+++ b/src/core/solution.jl
@@ -3,7 +3,7 @@ function build_solution{T}(pm::GenericPowerModel{T}, status, solve_time; objecti
 
     if status != :Error
         objective = getobjectivevalue(pm.model)
-        status = solver_status_dict(symbol(typeof(pm.model.solver).name.module), status)
+        status = solver_status_dict(Symbol(typeof(pm.model.solver).name.module), status)
     end
 
     solution = Dict{AbstractString,Any}(

--- a/src/core/variable.jl
+++ b/src/core/variable.jl
@@ -93,10 +93,10 @@ function compute_voltage_product_bounds{T}(pm::GenericPowerModel{T})
     buspairs = pm.set.buspairs
     buspair_indexes = pm.set.buspair_indexes
 
-    wr_min = Dict(bp => -Inf for bp in buspair_indexes)
-    wr_max = Dict(bp =>  Inf for bp in buspair_indexes)
-    wi_min = Dict(bp => -Inf for bp in buspair_indexes)
-    wi_max = Dict(bp =>  Inf for bp in buspair_indexes)
+    wr_min = Dict([(bp, -Inf) for bp in buspair_indexes])
+    wr_max = Dict([(bp,  Inf) for bp in buspair_indexes])
+    wi_min = Dict([(bp, -Inf) for bp in buspair_indexes])
+    wi_max = Dict([(bp,  Inf) for bp in buspair_indexes])
 
     for bp in buspair_indexes
         i,j = bp
@@ -140,7 +140,7 @@ end
 function variable_complex_voltage_product_on_off{T}(pm::GenericPowerModel{T})
     wr_min, wr_max, wi_min, wi_max = compute_voltage_product_bounds(pm)
 
-    bi_bp = Dict(i => (b["f_bus"], b["t_bus"]) for (i,b) in pm.set.branches)
+    bi_bp = Dict([(i, (b["f_bus"], b["t_bus"])) for (i,b) in pm.set.branches])
 
     @variable(pm.model, min(0, wr_min[bi_bp[b]]) <= wr[b in pm.set.branch_indexes] <= max(0, wr_max[bi_bp[b]]), start = getstart(pm.set.buspairs, bi_bp[b], "wr_start", 1.0))
     @variable(pm.model, min(0, wi_min[bi_bp[b]]) <= wi[b in pm.set.branch_indexes] <= max(0, wi_max[bi_bp[b]]), start = getstart(pm.set.buspairs, bi_bp[b], "wr_start"))
@@ -152,7 +152,7 @@ function variable_complex_voltage_product_matrix{T}(pm::GenericPowerModel{T})
     wr_min, wr_max, wi_min, wi_max = compute_voltage_product_bounds(pm)
 
     w_index = 1:length(pm.set.bus_indexes)
-    lookup_w_index = Dict(bi => i for (i,bi) in enumerate(pm.set.bus_indexes))
+    lookup_w_index = Dict([(bi, i) for (i,bi) in enumerate(pm.set.bus_indexes)])
 
     @variable(pm.model, WR[1:length(pm.set.bus_indexes), 1:length(pm.set.bus_indexes)], Symmetric)
     @variable(pm.model, WI[1:length(pm.set.bus_indexes), 1:length(pm.set.bus_indexes)])
@@ -195,16 +195,16 @@ end
 
 # Creates the voltage magnitude product variables
 function variable_voltage_magnitude_product{T}(pm::GenericPowerModel{T})
-    vv_min = Dict(bp => pm.set.buspairs[bp]["v_from_min"]*pm.set.buspairs[bp]["v_to_min"] for bp in pm.set.buspair_indexes)
-    vv_max = Dict(bp => pm.set.buspairs[bp]["v_from_max"]*pm.set.buspairs[bp]["v_to_max"] for bp in pm.set.buspair_indexes)
+    vv_min = Dict([(bp, pm.set.buspairs[bp]["v_from_min"]*pm.set.buspairs[bp]["v_to_min"]) for bp in pm.set.buspair_indexes])
+    vv_max = Dict([(bp, pm.set.buspairs[bp]["v_from_max"]*pm.set.buspairs[bp]["v_to_max"]) for bp in pm.set.buspair_indexes])
 
     @variable(pm.model,  vv_min[bp] <= vv[bp in pm.set.buspair_indexes] <=  vv_max[bp], start = getstart(pm.set.buspairs, bp, "vv_start", 1.0))
     return vv
 end
 
 function variable_cosine{T}(pm::GenericPowerModel{T})
-    cos_min = Dict(bp => -Inf for bp in pm.set.buspair_indexes)
-    cos_max = Dict(bp =>  Inf for bp in pm.set.buspair_indexes)
+    cos_min = Dict([(bp, -Inf) for bp in pm.set.buspair_indexes])
+    cos_max = Dict([(bp,  Inf) for bp in pm.set.buspair_indexes])
 
     for bp in pm.set.buspair_indexes
         buspair = pm.set.buspairs[bp]
@@ -233,8 +233,8 @@ end
 
 function variable_current_magnitude_sqr{T}(pm::GenericPowerModel{T})
     buspairs = pm.set.buspairs
-    cm_min = Dict(bp => 0 for bp in pm.set.buspair_indexes)
-    cm_max = Dict(bp => (buspairs[bp]["rate_a"]*buspairs[bp]["tap"]/buspairs[bp]["v_from_min"])^2 for bp in pm.set.buspair_indexes)
+    cm_min = Dict([(bp, 0) for bp in pm.set.buspair_indexes])
+    cm_max = Dict([(bp, (buspairs[bp]["rate_a"]*buspairs[bp]["tap"]/buspairs[bp]["v_from_min"])^2) for bp in pm.set.buspair_indexes])
 
     @variable(pm.model, cm_min[bp] <= cm[bp in pm.set.buspair_indexes] <=  cm_max[bp], start = getstart(pm.set.buspairs, bp, "cm_start"))
     return cm

--- a/src/core/variable.jl
+++ b/src/core/variable.jl
@@ -93,10 +93,10 @@ function compute_voltage_product_bounds{T}(pm::GenericPowerModel{T})
     buspairs = pm.set.buspairs
     buspair_indexes = pm.set.buspair_indexes
 
-    wr_min = [bp => -Inf for bp in buspair_indexes]
-    wr_max = [bp =>  Inf for bp in buspair_indexes]
-    wi_min = [bp => -Inf for bp in buspair_indexes]
-    wi_max = [bp =>  Inf for bp in buspair_indexes]
+    wr_min = Dict(bp => -Inf for bp in buspair_indexes)
+    wr_max = Dict(bp =>  Inf for bp in buspair_indexes)
+    wi_min = Dict(bp => -Inf for bp in buspair_indexes)
+    wi_max = Dict(bp =>  Inf for bp in buspair_indexes)
 
     for bp in buspair_indexes
         i,j = bp
@@ -140,7 +140,7 @@ end
 function variable_complex_voltage_product_on_off{T}(pm::GenericPowerModel{T})
     wr_min, wr_max, wi_min, wi_max = compute_voltage_product_bounds(pm)
 
-    bi_bp = [i => (b["f_bus"], b["t_bus"]) for (i,b) in pm.set.branches]
+    bi_bp = Dict(i => (b["f_bus"], b["t_bus"]) for (i,b) in pm.set.branches)
 
     @variable(pm.model, min(0, wr_min[bi_bp[b]]) <= wr[b in pm.set.branch_indexes] <= max(0, wr_max[bi_bp[b]]), start = getstart(pm.set.buspairs, bi_bp[b], "wr_start", 1.0))
     @variable(pm.model, min(0, wi_min[bi_bp[b]]) <= wi[b in pm.set.branch_indexes] <= max(0, wi_max[bi_bp[b]]), start = getstart(pm.set.buspairs, bi_bp[b], "wr_start"))
@@ -152,7 +152,7 @@ function variable_complex_voltage_product_matrix{T}(pm::GenericPowerModel{T})
     wr_min, wr_max, wi_min, wi_max = compute_voltage_product_bounds(pm)
 
     w_index = 1:length(pm.set.bus_indexes)
-    lookup_w_index = [bi => i for (i,bi) in enumerate(pm.set.bus_indexes)]
+    lookup_w_index = Dict(bi => i for (i,bi) in enumerate(pm.set.bus_indexes))
 
     @variable(pm.model, WR[1:length(pm.set.bus_indexes), 1:length(pm.set.bus_indexes)], Symmetric)
     @variable(pm.model, WI[1:length(pm.set.bus_indexes), 1:length(pm.set.bus_indexes)])
@@ -195,16 +195,16 @@ end
 
 # Creates the voltage magnitude product variables
 function variable_voltage_magnitude_product{T}(pm::GenericPowerModel{T})
-    vv_min = [bp => pm.set.buspairs[bp]["v_from_min"]*pm.set.buspairs[bp]["v_to_min"] for bp in pm.set.buspair_indexes]
-    vv_max = [bp => pm.set.buspairs[bp]["v_from_max"]*pm.set.buspairs[bp]["v_to_max"] for bp in pm.set.buspair_indexes]
+    vv_min = Dict(bp => pm.set.buspairs[bp]["v_from_min"]*pm.set.buspairs[bp]["v_to_min"] for bp in pm.set.buspair_indexes)
+    vv_max = Dict(bp => pm.set.buspairs[bp]["v_from_max"]*pm.set.buspairs[bp]["v_to_max"] for bp in pm.set.buspair_indexes)
 
     @variable(pm.model,  vv_min[bp] <= vv[bp in pm.set.buspair_indexes] <=  vv_max[bp], start = getstart(pm.set.buspairs, bp, "vv_start", 1.0))
     return vv
 end
 
 function variable_cosine{T}(pm::GenericPowerModel{T})
-    cos_min = [bp => -Inf for bp in pm.set.buspair_indexes]
-    cos_max = [bp =>  Inf for bp in pm.set.buspair_indexes]
+    cos_min = Dict(bp => -Inf for bp in pm.set.buspair_indexes)
+    cos_max = Dict(bp =>  Inf for bp in pm.set.buspair_indexes)
 
     for bp in pm.set.buspair_indexes
         buspair = pm.set.buspairs[bp]
@@ -233,8 +233,8 @@ end
 
 function variable_current_magnitude_sqr{T}(pm::GenericPowerModel{T})
     buspairs = pm.set.buspairs
-    cm_min = [bp => 0 for bp in pm.set.buspair_indexes]
-    cm_max = [bp => (buspairs[bp]["rate_a"]*buspairs[bp]["tap"]/buspairs[bp]["v_from_min"])^2 for bp in pm.set.buspair_indexes]
+    cm_min = Dict(bp => 0 for bp in pm.set.buspair_indexes)
+    cm_max = Dict(bp => (buspairs[bp]["rate_a"]*buspairs[bp]["tap"]/buspairs[bp]["v_from_min"])^2 for bp in pm.set.buspair_indexes)
 
     @variable(pm.model, cm_min[bp] <= cm[bp in pm.set.buspair_indexes] <=  cm_max[bp], start = getstart(pm.set.buspairs, bp, "cm_start"))
     return cm

--- a/src/form/dcp.jl
+++ b/src/form/dcp.jl
@@ -1,4 +1,4 @@
-export 
+export
     DCPPowerModel, StandardDCPForm,
     DCPLLPowerModel, StandardDCPLLForm
 
@@ -32,8 +32,8 @@ function variable_active_line_flow{T <: StandardDCPForm}(pm::GenericPowerModel{T
         @variable(pm.model, p[(l,i,j) in pm.set.arcs_from], start = getstart(pm.set.branches, l, "p_start"))
     end
 
-    p_expr = [(l,i,j) => 1.0*p[(l,i,j)] for (l,i,j) in pm.set.arcs_from]
-    p_expr = merge(p_expr, [(l,j,i) => -1.0*p[(l,i,j)] for (l,i,j) in pm.set.arcs_from])
+    p_expr = Dict((l,i,j) => 1.0*p[(l,i,j)] for (l,i,j) in pm.set.arcs_from)
+    p_expr = merge(p_expr, Dict((l,j,i) => -1.0*p[(l,i,j)] for (l,i,j) in pm.set.arcs_from))
 
     pm.model.ext[:p_expr] = p_expr
 end
@@ -112,7 +112,7 @@ function constraint_phase_angle_difference{T <: AbstractDCPForm}(pm::GenericPowe
     return Set([c1, c2])
 end
 
-function constraint_thermal_limit_from{T <: AbstractDCPForm}(pm::GenericPowerModel{T}, branch) 
+function constraint_thermal_limit_from{T <: AbstractDCPForm}(pm::GenericPowerModel{T}, branch)
     i = branch["index"]
     f_bus = branch["f_bus"]
     t_bus = branch["t_bus"]
@@ -132,7 +132,7 @@ function constraint_thermal_limit_from{T <: AbstractDCPForm}(pm::GenericPowerMod
     return Set()
 end
 
-function constraint_thermal_limit_to{T <: AbstractDCPForm}(pm::GenericPowerModel{T}, branch) 
+function constraint_thermal_limit_to{T <: AbstractDCPForm}(pm::GenericPowerModel{T}, branch)
     # nothing to do, from handles both sides
     return Set()
 end
@@ -296,7 +296,3 @@ function constraint_thermal_limit_to_on_off{T <: AbstractDCPLLForm}(pm::GenericP
     c2 = @constraint(pm.model, p_to >= getlowerbound(p_to)*z)
     return Set([c1, c2])
 end
-
-
-
-

--- a/src/form/dcp.jl
+++ b/src/form/dcp.jl
@@ -32,8 +32,8 @@ function variable_active_line_flow{T <: StandardDCPForm}(pm::GenericPowerModel{T
         @variable(pm.model, p[(l,i,j) in pm.set.arcs_from], start = getstart(pm.set.branches, l, "p_start"))
     end
 
-    p_expr = Dict((l,i,j) => 1.0*p[(l,i,j)] for (l,i,j) in pm.set.arcs_from)
-    p_expr = merge(p_expr, Dict((l,j,i) => -1.0*p[(l,i,j)] for (l,i,j) in pm.set.arcs_from))
+    p_expr = Dict([((l,i,j), 1.0*p[(l,i,j)]) for (l,i,j) in pm.set.arcs_from])
+    p_expr = merge(p_expr, Dict([((l,j,i), -1.0*p[(l,i,j)]) for (l,i,j) in pm.set.arcs_from]))
 
     pm.model.ext[:p_expr] = p_expr
 end

--- a/src/form/wr.jl
+++ b/src/form/wr.jl
@@ -226,7 +226,7 @@ end
 function constraint_complex_voltage_product_on_off{T}(pm::GenericPowerModel{T})
     wr_min, wr_max, wi_min, wi_max = compute_voltage_product_bounds(pm)
 
-    bi_bp = Dict(i => (b["f_bus"], b["t_bus"]) for (i,b) in pm.set.branches)
+    bi_bp = Dict([(i, (b["f_bus"], b["t_bus"])) for (i,b) in pm.set.branches])
 
     wr = getvariable(pm.model, :wr)
     wi = getvariable(pm.model, :wi)

--- a/src/form/wr.jl
+++ b/src/form/wr.jl
@@ -1,4 +1,4 @@
-export 
+export
     SOCWRPowerModel, SOCWRForm,
     QCWRPowerModel, QCWRForm
 
@@ -21,7 +21,7 @@ function constraint_complex_voltage{T <: AbstractWRForm}(pm::GenericPowerModel{T
     w = getvariable(pm.model, :w)
     wr = getvariable(pm.model, :wr)
     wi = getvariable(pm.model, :wi)
-    
+
     for (i,j) in pm.set.buspair_indexes
         relaxation_complex_product(pm.model, w[i], w[j], wr[(i,j)], wi[(i,j)])
     end
@@ -93,7 +93,7 @@ function constraint_active_ohms_yt{T <: AbstractWRForm}(pm::GenericPowerModel{T}
     c = branch["br_b"]
     tr = branch["tr"]
     ti = branch["ti"]
-    tm = tr^2 + ti^2 
+    tm = tr^2 + ti^2
 
     c1 = @constraint(pm.model, p_fr == g/tm*w_fr + (-g*tr+b*ti)/tm*(wr) + (-b*tr-g*ti)/tm*( wi) )
     c2 = @constraint(pm.model, p_to ==    g*w_to + (-g*tr-b*ti)/tm*(wr) + (-b*tr+g*ti)/tm*(-wi) )
@@ -119,7 +119,7 @@ function constraint_reactive_ohms_yt{T <: AbstractWRForm}(pm::GenericPowerModel{
     c = branch["br_b"]
     tr = branch["tr"]
     ti = branch["ti"]
-    tm = tr^2 + ti^2 
+    tm = tr^2 + ti^2
 
     c1 = @constraint(pm.model, q_fr == -(b+c/2)/tm*w_fr - (-b*tr-g*ti)/tm*(wr) + (-g*tr+b*ti)/tm*( wi) )
     c2 = @constraint(pm.model, q_to ==    -(b+c/2)*w_to - (-b*tr+g*ti)/tm*(wr) + (-g*tr-b*ti)/tm*(-wi) )
@@ -168,7 +168,7 @@ function constraint_complex_voltage_on_off{T <: AbstractWRForm}(pm::GenericPower
     wr = getvariable(pm.model, :wr)
     wi = getvariable(pm.model, :wi)
     z = getvariable(pm.model, :line_z)
-    
+
     w_from = getvariable(pm.model, :w_from)
     w_to = getvariable(pm.model, :w_to)
 
@@ -226,7 +226,7 @@ end
 function constraint_complex_voltage_product_on_off{T}(pm::GenericPowerModel{T})
     wr_min, wr_max, wi_min, wi_max = compute_voltage_product_bounds(pm)
 
-    bi_bp = [i => (b["f_bus"], b["t_bus"]) for (i,b) in pm.set.branches]
+    bi_bp = Dict(i => (b["f_bus"], b["t_bus"]) for (i,b) in pm.set.branches)
 
     wr = getvariable(pm.model, :wr)
     wi = getvariable(pm.model, :wi)
@@ -266,7 +266,7 @@ function constraint_active_ohms_yt_on_off{T <: AbstractWRForm}(pm::GenericPowerM
     c = branch["br_b"]
     tr = branch["tr"]
     ti = branch["ti"]
-    tm = tr^2 + ti^2 
+    tm = tr^2 + ti^2
 
     c1 = @constraint(pm.model, p_fr == g/tm*w_fr + (-g*tr+b*ti)/tm*(wr) + (-b*tr-g*ti)/tm*( wi) )
     c2 = @constraint(pm.model, p_to ==    g*w_to + (-g*tr-b*ti)/tm*(wr) + (-b*tr+g*ti)/tm*(-wi) )
@@ -292,7 +292,7 @@ function constraint_reactive_ohms_yt_on_off{T <: AbstractWRForm}(pm::GenericPowe
     c = branch["br_b"]
     tr = branch["tr"]
     ti = branch["ti"]
-    tm = tr^2 + ti^2 
+    tm = tr^2 + ti^2
 
     c1 = @constraint(pm.model, q_fr == -(b+c/2)/tm*w_fr - (-b*tr-g*ti)/tm*(wr) + (-g*tr+b*ti)/tm*( wi) )
     c2 = @constraint(pm.model, q_to ==    -(b+c/2)*w_to - (-b*tr+g*ti)/tm*(wr) + (-g*tr-b*ti)/tm*(-wi) )
@@ -346,11 +346,11 @@ function constraint_complex_voltage(pm::QCWRPowerModel)
     si = getvariable(pm.model, :si)
     cs = getvariable(pm.model, :cs)
     vv = getvariable(pm.model, :vv)
-    
+
     w = getvariable(pm.model, :w)
     wr = getvariable(pm.model, :wr)
     wi = getvariable(pm.model, :wi)
-    
+
     const_set = Set()
     for (i,b) in pm.set.buses
         cs1 = relaxation_sqr(pm.model, v[i], w[i])
@@ -403,7 +403,7 @@ function constraint_power_magnitude_sqr(pm::QCWRPowerModel, branch)
 
     tr = branch["tr"]
     ti = branch["ti"]
-    tm = tr^2 + ti^2 
+    tm = tr^2 + ti^2
 
     c = @constraint(pm.model, p_fr^2 + q_fr^2 <= w_i/tm*cm)
     return Set([c])
@@ -428,7 +428,7 @@ function constraint_power_magnitude_link(pm::QCWRPowerModel, branch)
     c = branch["br_b"]
     tr = branch["tr"]
     ti = branch["ti"]
-    tm = tr^2 + ti^2 
+    tm = tr^2 + ti^2
 
     c = @constraint(pm.model, cm == (g^2 + b^2)*(w_fr/tm + w_to - 2*(tr*wr + ti*wi)/tm) - c*q_fr - ((c/2)/tm)^2*w_fr)
     return Set([c])
@@ -472,8 +472,3 @@ function add_bus_voltage_setpoint(sol, pm::QCWRPowerModel)
     add_setpoint(sol, pm, "bus", "bus_i", "vm", :v)
     add_setpoint(sol, pm, "bus", "bus_i", "va", :t)
 end
-
-
-
-
-

--- a/src/io/json.jl
+++ b/src/io/json.jl
@@ -1,5 +1,5 @@
 
 function parse_json(file_string)
-    data_string = readall(open(file_string))
+    data_string = readstring(open(file_string))
     return JSON.parse(data_string, dicttype = Dict{AbstractString,Any})
 end

--- a/src/io/matpower.jl
+++ b/src/io/matpower.jl
@@ -24,7 +24,7 @@ function parse_matrix(lines, index)
     matrix_body_lines = [matrix_assignment_rhs]
     found_close_bracket = contains(matrix_assignment_rhs, "]")
 
-    while index + line_count < last_index && !found_close_bracket 
+    while index + line_count < last_index && !found_close_bracket
         line = strip(lines[index+line_count])
 
         if length(line) == 0 || line[1] == '%'
@@ -73,7 +73,7 @@ end
 
 
 function parse_matpower(file_string)
-    data_string = readall(open(file_string))
+    data_string = readstring(open(file_string))
     data = parse_matpower_data(data_string)
 
     for branch in data["branch"]
@@ -88,8 +88,8 @@ function parse_matpower(file_string)
     end
 
     mva_base = data["baseMVA"]
-    vmax_lookup = [ bus["index"] => bus["vmax"] for bus in data["bus"] ]
-    vmin_lookup = [ bus["index"] => bus["vmin"] for bus in data["bus"] ]
+    vmax_lookup = Dict(bus["index"] => bus["vmax"] for bus in data["bus"])
+    vmin_lookup = Dict(bus["index"] => bus["vmin"] for bus in data["bus"])
 
     for branch in data["branch"]
         if branch["rate_a"] <= 0.0
@@ -143,7 +143,7 @@ function parse_matpower_data(data_string)
 
     last_index = length(data_lines)
     index = 1
-    while index <= last_index 
+    while index <= last_index
         line = strip(data_lines[index])
 
         if length(line) <= 0 || strip(line)[1] == '%'
@@ -166,10 +166,10 @@ function parse_matpower_data(data_string)
     end
 
     case = Dict{AbstractString,Any}(
-        "name" => name, 
-        "version" => version, 
+        "name" => name,
+        "version" => version,
         "baseMVA" => baseMVA,
-        "dcline" => [], 
+        "dcline" => [],
         "gencost" => []
     )
 
@@ -192,9 +192,9 @@ function parse_matpower_data(data_string)
                     "vm" => parse(Float64, bus_row[8]),
                     "va" => parse(Float64, bus_row[9]),
                     "base_kv" => parse(Float64, bus_row[10]),
-                    "zone" => parse(Int, bus_row[11]), 
-                    "vmax" => parse(Float64, bus_row[12]), 
-                    "vmin" => parse(Float64, bus_row[13]), 
+                    "zone" => parse(Int, bus_row[11]),
+                    "vmax" => parse(Float64, bus_row[12]),
+                    "vmin" => parse(Float64, bus_row[13]),
                 )
                 if length(bus_row) > 13
                     bus_data["lam_p"] = parse(Float64, bus_row[14])
@@ -224,17 +224,17 @@ function parse_matpower_data(data_string)
                     "gen_status" => parse(Int, gen_row[8]),
                     "pmax" => parse(Float64, gen_row[9]),
                     "pmin" => parse(Float64, gen_row[10]),
-                    "pc1" => parse(Float64, gen_row[11]), 
-                    "pc2" => parse(Float64, gen_row[12]), 
-                    "qc1min" => parse(Float64, gen_row[13]), 
+                    "pc1" => parse(Float64, gen_row[11]),
+                    "pc2" => parse(Float64, gen_row[12]),
+                    "qc1min" => parse(Float64, gen_row[13]),
                     "qc1max" => parse(Float64, gen_row[14]),
-                    "qc2min" => parse(Float64, gen_row[15]), 
-                    "qc2max" => parse(Float64, gen_row[16]), 
+                    "qc2min" => parse(Float64, gen_row[15]),
+                    "qc2max" => parse(Float64, gen_row[16]),
                     "ramp_agc" => parse(Float64, gen_row[17]),
-                    "ramp_10" => parse(Float64, gen_row[18]), 
-                    "ramp_30" => parse(Float64, gen_row[19]), 
-                    "ramp_q" => parse(Float64, gen_row[20]), 
-                    "apf" => parse(Float64, gen_row[21]), 
+                    "ramp_10" => parse(Float64, gen_row[18]),
+                    "ramp_30" => parse(Float64, gen_row[19]),
+                    "ramp_q" => parse(Float64, gen_row[20]),
+                    "apf" => parse(Float64, gen_row[21]),
                 )
                 if length(gen_row) > 21
                     gen_data["mu_pmax"] = parse(Float64, gen_row[22])
@@ -264,9 +264,9 @@ function parse_matpower_data(data_string)
                     "rate_c" => parse(Float64, branch_row[8]),
                     "tap" => parse(Float64, branch_row[9]),
                     "shift" => parse(Float64, branch_row[10]),
-                    "br_status" => parse(Int, branch_row[11]), 
-                    "angmin" => parse(Float64, branch_row[12]), 
-                    "angmax" => parse(Float64, branch_row[13]), 
+                    "br_status" => parse(Int, branch_row[11]),
+                    "angmin" => parse(Float64, branch_row[12]),
+                    "angmax" => parse(Float64, branch_row[13]),
                 )
                 if length(branch_row) > 13
                     branch_data["pf"] = parse(Float64, gen_row[14])
@@ -301,7 +301,7 @@ function parse_matpower_data(data_string)
 
             case["gencost"] = gencost
 
-        elseif parsed_matrix["name"] == "mpc.dcline" 
+        elseif parsed_matrix["name"] == "mpc.dcline"
             dclines = []
 
             for (i, dcline_row) in enumerate(parsed_matrix["data"])
@@ -318,12 +318,12 @@ function parse_matpower_data(data_string)
                     "vt" => parse(Float64, dcline_row[9]),
                     "pmin" => parse(Float64, dcline_row[10]),
                     "pmax" => parse(Float64, dcline_row[11]),
-                    "qminf" => parse(Float64, dcline_row[12]), 
-                    "qmaxf" => parse(Float64, dcline_row[13]), 
-                    "qmint" => parse(Float64, dcline_row[14]), 
-                    "qmaxt" => parse(Float64, dcline_row[15]), 
-                    "loss0" => parse(Float64, dcline_row[16]), 
-                    "loss1" => parse(Float64, dcline_row[17]), 
+                    "qminf" => parse(Float64, dcline_row[12]),
+                    "qmaxf" => parse(Float64, dcline_row[13]),
+                    "qmint" => parse(Float64, dcline_row[14]),
+                    "qmaxt" => parse(Float64, dcline_row[15]),
+                    "loss0" => parse(Float64, dcline_row[16]),
+                    "loss1" => parse(Float64, dcline_row[17]),
                 )
                 if length(dcline_row) > 17
                     branch_data["mu_pmin"] = parse(Float64, dcline_row[18])
@@ -350,5 +350,3 @@ function parse_matpower_data(data_string)
 
     return case
 end
-
-

--- a/src/io/matpower.jl
+++ b/src/io/matpower.jl
@@ -88,8 +88,8 @@ function parse_matpower(file_string)
     end
 
     mva_base = data["baseMVA"]
-    vmax_lookup = Dict(bus["index"] => bus["vmax"] for bus in data["bus"])
-    vmin_lookup = Dict(bus["index"] => bus["vmin"] for bus in data["bus"])
+    vmax_lookup = Dict([(bus["index"], bus["vmax"]) for bus in data["bus"]])
+    vmin_lookup = Dict([(bus["index"], bus["vmin"]) for bus in data["bus"]])
 
     for branch in data["branch"]
         if branch["rate_a"] <= 0.0

--- a/src/prob/misc.jl
+++ b/src/prob/misc.jl
@@ -73,10 +73,10 @@ function post_sad_opf{T <: Union{AbstractACPForm, AbstractDCPForm}}(pm::GenericP
     end
 
     for (i,branch) in pm.set.branches
-        constraint_active_ohms_y(pm, branch)
-        constraint_reactive_ohms_y(pm, branch)
+        constraint_active_ohms_yt(pm, branch)
+        constraint_reactive_ohms_yt(pm, branch)
 
-        #constraint_phase_angle_difference_flexible(pm, branch)
+        constraint_phase_angle_difference(pm, branch)
         theta_fr = getvariable(pm.model, :t)[branch["f_bus"]]
         theta_to = getvariable(pm.model, :t)[branch["t_bus"]]
 


### PR DESCRIPTION
Fixes #30:
* replace [...=>...for...] with Dict(...=>...for...)
* replace readall with readstring
* replace symbol with Symbol

After changes, no warnings are printed during pre-compilation, and Pkg.test() output is clean on 0.5.

All other changes are due to my text editor automatically removing trailing whitespace and whitespace on empty lines.