### PR TITLE
Refactoring Problem Formulations to use Complex Numbers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ PowerModels.jl Change Log
 - Added ability to easily inspect the JuMP model produced by PowerModels
 - Added constraint templates to provide an abstraction layer between the network data and network constraint definitions
 - Moved system wide phase angle difference bounds to the "ref" dictionary
+- Refactored model defitions to be based on complex numbers
 
 ### v0.2.3
 - Multiple improvements to Matlab file parsing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ PowerModels.jl Change Log
 - Added ability to easily inspect the JuMP model produced by PowerModels
 - Added constraint templates to provide an abstraction layer between the network data and network constraint definitions
 - Moved system wide phase angle difference bounds to the "ref" dictionary
-- Refactored model defitions to be based on complex numbers
+- Refactored model definitions to be based on complex numbers
 
 ### v0.2.3
 - Multiple improvements to Matlab file parsing

--- a/src/core/constraint.jl
+++ b/src/core/constraint.jl
@@ -89,11 +89,3 @@ function constraint_reactive_gen_setpoint{T}(pm::GenericPowerModel{T}, i, qg)
 end
 
 
-function constraint_active_loss_lb{T}(pm::GenericPowerModel{T}, f_bus, t_bus, f_idx, t_idx, c, tr)
-    p_fr = getvariable(pm.model, :p)[f_idx]
-    p_to = getvariable(pm.model, :p)[t_idx]
-
-    c = @constraint(m, p_fr + p_to >= 0)
-    return Set([c])
-end
-

--- a/src/core/constraint_template.jl
+++ b/src/core/constraint_template.jl
@@ -35,44 +35,27 @@ end
 
 ### Bus - KCL Constraints ###
 
-function constraint_active_kcl_shunt(pm::GenericPowerModel, bus)
+function constraint_kcl_shunt(pm::GenericPowerModel, bus)
     i = bus["index"]
     bus_arcs = pm.ref[:bus_arcs][i]
     bus_gens = pm.ref[:bus_gens][i]
 
-    return constraint_active_kcl_shunt(pm, i, bus_arcs, bus_gens, bus["pd"], bus["qd"], bus["gs"], bus["bs"])
+    return constraint_kcl_shunt(pm, i, bus_arcs, bus_gens, bus["pd"], bus["qd"], bus["gs"], bus["bs"])
 end
 
-function constraint_reactive_kcl_shunt(pm::GenericPowerModel, bus)
-    i = bus["index"]
-    bus_arcs = pm.ref[:bus_arcs][i]
-    bus_gens = pm.ref[:bus_gens][i]
-
-    return constraint_reactive_kcl_shunt(pm, i, bus_arcs, bus_gens, bus["pd"], bus["qd"], bus["gs"], bus["bs"])
-end
-
-function constraint_active_kcl_shunt_ne(pm::GenericPowerModel, bus)
+function constraint_kcl_shunt_ne(pm::GenericPowerModel, bus)
     i = bus["index"]
     bus_arcs = pm.ref[:bus_arcs][i]
     bus_arcs_ne = pm.ref[:ne_bus_arcs][i]
     bus_gens = pm.ref[:bus_gens][i]
 
-    return constraint_active_kcl_shunt_ne(pm, i, bus_arcs, bus_arcs_ne, bus_gens, bus["pd"], bus["qd"], bus["gs"], bus["bs"])
-end
-
-function constraint_reactive_kcl_shunt_ne(pm::GenericPowerModel, bus)
-    i = bus["index"]
-    bus_arcs = pm.ref[:bus_arcs][i]
-    bus_arcs_ne = pm.ref[:ne_bus_arcs][i]
-    bus_gens = pm.ref[:bus_gens][i]
-
-    return constraint_reactive_kcl_shunt_ne(pm, i, bus_arcs, bus_arcs_ne, bus_gens, bus["pd"], bus["qd"], bus["gs"], bus["bs"])
+    return constraint_kcl_shunt_ne(pm, i, bus_arcs, bus_arcs_ne, bus_gens, bus["pd"], bus["qd"], bus["gs"], bus["bs"])
 end
 
 
 ### Branch - Ohm's Law Constraints ### 
 
-function constraint_active_ohms_yt(pm::GenericPowerModel, branch)
+function constraint_ohms_yt_from(pm::GenericPowerModel, branch)
     i = branch["index"]
     f_bus = branch["f_bus"]
     t_bus = branch["t_bus"]
@@ -84,10 +67,10 @@ function constraint_active_ohms_yt(pm::GenericPowerModel, branch)
     c = branch["br_b"]
     tm = branch["tap"]^2
 
-    return constraint_active_ohms_yt(pm, f_bus, t_bus, f_idx, t_idx, g, b, c, tr, ti, tm)
+    return constraint_ohms_yt_from(pm, f_bus, t_bus, f_idx, t_idx, g, b, c, tr, ti, tm)
 end
 
-function constraint_reactive_ohms_yt(pm::GenericPowerModel, branch)
+function constraint_ohms_yt_to(pm::GenericPowerModel, branch)
     i = branch["index"]
     f_bus = branch["f_bus"]
     t_bus = branch["t_bus"]
@@ -99,11 +82,10 @@ function constraint_reactive_ohms_yt(pm::GenericPowerModel, branch)
     c = branch["br_b"]
     tm = branch["tap"]^2
 
-    return constraint_reactive_ohms_yt(pm, f_bus, t_bus, f_idx, t_idx, g, b, c, tr, ti, tm)
+    return constraint_ohms_yt_to(pm, f_bus, t_bus, f_idx, t_idx, g, b, c, tr, ti, tm)
 end
 
-
-function constraint_active_ohms_y(pm::GenericPowerModel, branch)
+function constraint_ohms_y_from(pm::GenericPowerModel, branch)
     i = branch["index"]
     f_bus = branch["f_bus"]
     t_bus = branch["t_bus"]
@@ -115,10 +97,10 @@ function constraint_active_ohms_y(pm::GenericPowerModel, branch)
     tr = branch["tap"]
     as = branch["shift"]
 
-    return constraint_active_ohms_y(pm, f_bus, t_bus, f_idx, t_idx, g, b, c, tr, as)
+    return constraint_ohms_y_from(pm, f_bus, t_bus, f_idx, t_idx, g, b, c, tr, as)
 end
 
-function constraint_reactive_ohms_y(pm::GenericPowerModel, branch)
+function constraint_ohms_y_to(pm::GenericPowerModel, branch)
     i = branch["index"]
     f_bus = branch["f_bus"]
     t_bus = branch["t_bus"]
@@ -130,13 +112,14 @@ function constraint_reactive_ohms_y(pm::GenericPowerModel, branch)
     tr = branch["tap"]
     as = branch["shift"]
 
-    return constraint_reactive_ohms_y(pm, f_bus, t_bus, f_idx, t_idx, g, b, c, tr, as)
+    return constraint_ohms_y_to(pm, f_bus, t_bus, f_idx, t_idx, g, b, c, tr, as)
 end
+
 
 
 ### Branch - On/Off Ohm's Law Constraints ### 
 
-function constraint_active_ohms_yt_on_off(pm::GenericPowerModel, branch)
+function constraint_ohms_yt_from_on_off(pm::GenericPowerModel, branch)
     i = branch["index"]
     f_bus = branch["f_bus"]
     t_bus = branch["t_bus"]
@@ -151,10 +134,10 @@ function constraint_active_ohms_yt_on_off(pm::GenericPowerModel, branch)
     t_min = pm.ref[:off_angmin]
     t_max = pm.ref[:off_angmax]
 
-    return constraint_active_ohms_yt_on_off(pm, i, f_bus, t_bus, f_idx, t_idx, g, b, c, tr, ti, tm, t_min, t_max)
+    return constraint_ohms_yt_from_on_off(pm, i, f_bus, t_bus, f_idx, t_idx, g, b, c, tr, ti, tm, t_min, t_max)
 end
 
-function constraint_reactive_ohms_yt_on_off(pm::GenericPowerModel, branch)
+function constraint_ohms_yt_to_on_off(pm::GenericPowerModel, branch)
     i = branch["index"]
     f_bus = branch["f_bus"]
     t_bus = branch["t_bus"]
@@ -169,11 +152,11 @@ function constraint_reactive_ohms_yt_on_off(pm::GenericPowerModel, branch)
     t_min = pm.ref[:off_angmin]
     t_max = pm.ref[:off_angmax]
 
-    return constraint_reactive_ohms_yt_on_off(pm, i, f_bus, t_bus, f_idx, t_idx, g, b, c, tr, ti, tm, t_min, t_max)
+    return constraint_ohms_yt_to_on_off(pm, i, f_bus, t_bus, f_idx, t_idx, g, b, c, tr, ti, tm, t_min, t_max)
 end
 
 
-function constraint_active_ohms_yt_ne(pm::GenericPowerModel, branch)
+function constraint_ohms_yt_from_ne(pm::GenericPowerModel, branch)
     i = branch["index"]
     f_bus = branch["f_bus"]
     t_bus = branch["t_bus"]
@@ -188,10 +171,10 @@ function constraint_active_ohms_yt_ne(pm::GenericPowerModel, branch)
     t_min = pm.ref[:off_angmin]
     t_max = pm.ref[:off_angmax]
 
-    return constraint_active_ohms_yt_ne(pm, i, f_bus, t_bus, f_idx, t_idx, g, b, c, tr, ti, tm, t_min, t_max)
+    return constraint_ohms_yt_from_ne(pm, i, f_bus, t_bus, f_idx, t_idx, g, b, c, tr, ti, tm, t_min, t_max)
 end
 
-function constraint_reactive_ohms_yt_ne(pm::GenericPowerModel, branch)
+function constraint_ohms_yt_to_ne(pm::GenericPowerModel, branch)
     i = branch["index"]
     f_bus = branch["f_bus"]
     t_bus = branch["t_bus"]
@@ -206,7 +189,7 @@ function constraint_reactive_ohms_yt_ne(pm::GenericPowerModel, branch)
     t_min = pm.ref[:off_angmin]
     t_max = pm.ref[:off_angmax]
 
-    return constraint_reactive_ohms_yt_ne(pm, i, f_bus, t_bus, f_idx, t_idx, g, b, c, tr, ti, tm, t_min, t_max)
+    return constraint_ohms_yt_to_ne(pm, i, f_bus, t_bus, f_idx, t_idx, g, b, c, tr, ti, tm, t_min, t_max)
 end
 
 
@@ -338,8 +321,9 @@ end
 
 ### Branch - Loss Constraints ### 
 
-function constraint_active_loss_lb(pm::GenericPowerModel, branch)
+function constraint_loss_lb(pm::GenericPowerModel, branch)
     @assert branch["br_r"] >= 0
+    @assert branch["br_x"] >= 0
     i = branch["index"]
     f_bus = branch["f_bus"]
     t_bus = branch["t_bus"]
@@ -349,17 +333,7 @@ function constraint_active_loss_lb(pm::GenericPowerModel, branch)
     c = branch["br_b"]
     tr = branch["tr"]
 
-    return constraint_active_loss_lb(pm, f_bus, t_bus, f_idx, t_idx, c, tr)
+    return constraint_loss_lb(pm, f_bus, t_bus, f_idx, t_idx, c, tr)
 end
 
-function constraint_reactive_loss_lb(pm::GenericPowerModel, branch)
-    @assert branch["br_x"] >= 0
-    i = branch["index"]
-    f_bus = branch["f_bus"]
-    t_bus = branch["t_bus"]
-    f_idx = (i, f_bus, t_bus)
-    t_idx = (i, t_bus, f_bus)
-
-    return constraint_reactive_loss_lb(pm, f_bus, t_bus, f_idx, t_idx, c, tr)
-end
 

--- a/src/core/variable.jl
+++ b/src/core/variable.jl
@@ -12,6 +12,7 @@ function getstart(set, item_key, value_key, default = 0.0)
     end
 end
 
+
 function variable_phase_angle{T}(pm::GenericPowerModel{T}; bounded = true)
     @variable(pm.model, t[i in keys(pm.ref[:bus])], start = getstart(pm.ref[:bus], i, "t_start"))
     return t
@@ -53,6 +54,12 @@ function variable_voltage_magnitude_sqr_to_on_off{T}(pm::GenericPowerModel{T})
     return w_to
 end
 
+
+function variable_generation{T}(pm::GenericPowerModel{T}; kwargs...)
+    variable_active_generation(pm; kwargs...)
+    variable_reactive_generation(pm; kwargs...)
+end
+
 function variable_active_generation{T}(pm::GenericPowerModel{T}; bounded = true)
     if bounded
         @variable(pm.model, pm.ref[:gen][i]["pmin"] <= pg[i in keys(pm.ref[:gen])] <= pm.ref[:gen][i]["pmax"], start = getstart(pm.ref[:gen], i, "pg_start"))
@@ -71,6 +78,12 @@ function variable_reactive_generation{T}(pm::GenericPowerModel{T}; bounded = tru
     return qg
 end
 
+
+function variable_line_flow{T}(pm::GenericPowerModel{T}; kwargs...)
+    variable_active_line_flow(pm; kwargs...)
+    variable_reactive_line_flow(pm; kwargs...)
+end
+
 function variable_active_line_flow{T}(pm::GenericPowerModel{T}; bounded = true)
     if bounded
         @variable(pm.model, -pm.ref[:branch][l]["rate_a"] <= p[(l,i,j) in pm.ref[:arcs]] <= pm.ref[:branch][l]["rate_a"], start = getstart(pm.ref[:branch], l, "p_start"))
@@ -80,12 +93,6 @@ function variable_active_line_flow{T}(pm::GenericPowerModel{T}; bounded = true)
     return p
 end
 
-function variable_active_line_flow_ne{T}(pm::GenericPowerModel{T})
-    @variable(pm.model, -pm.ref[:ne_branch][l]["rate_a"] <= p_ne[(l,i,j) in pm.ref[:ne_arcs]] <= pm.ref[:ne_branch][l]["rate_a"], start = getstart(pm.ref[:ne_branch], l, "p_start"))
-    return p_ne
-end
-
-
 function variable_reactive_line_flow{T}(pm::GenericPowerModel{T}; bounded = true)
     if bounded
         @variable(pm.model, -pm.ref[:branch][l]["rate_a"] <= q[(l,i,j) in pm.ref[:arcs]] <= pm.ref[:branch][l]["rate_a"], start = getstart(pm.ref[:branch], l, "q_start"))
@@ -93,6 +100,17 @@ function variable_reactive_line_flow{T}(pm::GenericPowerModel{T}; bounded = true
         @variable(pm.model, q[(l,i,j) in pm.ref[:arcs]], start = getstart(pm.ref[:branch], l, "q_start"))
     end
     return q
+end
+
+
+function variable_line_flow_ne{T}(pm::GenericPowerModel{T}; kwargs...)
+    variable_active_line_flow_ne(pm; kwargs...)
+    variable_reactive_line_flow_ne(pm; kwargs...)
+end
+
+function variable_active_line_flow_ne{T}(pm::GenericPowerModel{T})
+    @variable(pm.model, -pm.ref[:ne_branch][l]["rate_a"] <= p_ne[(l,i,j) in pm.ref[:ne_arcs]] <= pm.ref[:ne_branch][l]["rate_a"], start = getstart(pm.ref[:ne_branch], l, "p_start"))
+    return p_ne
 end
 
 function variable_reactive_line_flow_ne{T}(pm::GenericPowerModel{T})

--- a/src/form/acp.jl
+++ b/src/form/acp.jl
@@ -12,24 +12,19 @@ function ACPPowerModel(data::Dict{AbstractString,Any}; kwargs...)
     return GenericPowerModel(data, StandardACPForm(); kwargs...)
 end
 
-function variable_complex_voltage{T <: AbstractACPForm}(pm::GenericPowerModel{T}; kwargs...)
+function variable_voltage{T <: AbstractACPForm}(pm::GenericPowerModel{T}; kwargs...)
     variable_phase_angle(pm; kwargs...)
     variable_voltage_magnitude(pm; kwargs...)
 end
 
-function variable_complex_voltage_ne{T <: AbstractACPForm}(pm::GenericPowerModel{T}; kwargs...)
+function variable_voltage_ne{T <: AbstractACPForm}(pm::GenericPowerModel{T}; kwargs...)
 end
 
-function constraint_complex_voltage{T <: AbstractACPForm}(pm::GenericPowerModel{T})
+
+function constraint_voltage{T <: AbstractACPForm}(pm::GenericPowerModel{T})
     # do nothing, this model does not have complex voltage constraints
     return Set()
 end
-
-function constraint_complex_voltage_ne{T <: AbstractACPForm}(pm::GenericPowerModel{T})
-    # do nothing, this model does not have complex voltage constraints
-    return Set()
-end
-
 
 function constraint_theta_ref{T <: AbstractACPForm}(pm::GenericPowerModel{T}, ref_bus)
     c = @constraint(pm.model, getvariable(pm.model, :t)[ref_bus] == 0)
@@ -50,101 +45,86 @@ function constraint_voltage_magnitude_setpoint{T <: AbstractACPForm}(pm::Generic
 end
 
 
-function constraint_active_kcl_shunt{T <: AbstractACPForm}(pm::GenericPowerModel{T}, i, bus_arcs, bus_gens, pd, qd, gs, bs)
+function constraint_kcl_shunt{T <: AbstractACPForm}(pm::GenericPowerModel{T}, i, bus_arcs, bus_gens, pd, qd, gs, bs)
     v = getvariable(pm.model, :v)[i]
     p = getvariable(pm.model, :p)
+    q = getvariable(pm.model, :q)
     pg = getvariable(pm.model, :pg)
+    qg = getvariable(pm.model, :qg)
 
-    c = @constraint(pm.model, sum(p[a] for a in bus_arcs) == sum(pg[g] for g in bus_gens) - pd - gs*v^2)
-    return Set([c])
+    c1 = @constraint(pm.model, sum(p[a] for a in bus_arcs) == sum(pg[g] for g in bus_gens) - pd - gs*v^2)
+    c2 = @constraint(pm.model, sum(q[a] for a in bus_arcs) == sum(qg[g] for g in bus_gens) - qd + bs*v^2)
+    return Set([c1, c2])
 end
 
-function constraint_active_kcl_shunt_ne{T <: AbstractACPForm}(pm::GenericPowerModel{T}, i, bus_arcs, bus_arcs_ne, bus_gens, pd, qd, gs, bs)
+function constraint_kcl_shunt_ne{T <: AbstractACPForm}(pm::GenericPowerModel{T}, i, bus_arcs, bus_arcs_ne, bus_gens, pd, qd, gs, bs)
     v = getvariable(pm.model, :v)[i]
     p = getvariable(pm.model, :p)
+    q = getvariable(pm.model, :q)
     p_ne = getvariable(pm.model, :p_ne)
-    pg = getvariable(pm.model, :pg)
-
-    c = @constraint(pm.model, sum(p[a] for a in bus_arcs) + sum(p_ne[a] for a in bus_arcs_ne) == sum(pg[g] for g in bus_gens) - pd - gs*v^2)
-    return Set([c])
-end
-
-
-function constraint_reactive_kcl_shunt{T <: AbstractACPForm}(pm::GenericPowerModel{T}, i, bus_arcs, bus_gens, pd, qd, gs, bs)
-    v = getvariable(pm.model, :v)[i]
-    q = getvariable(pm.model, :q)
-    qg = getvariable(pm.model, :qg)
-
-    c = @constraint(pm.model, sum(q[a] for a in bus_arcs) == sum(qg[g] for g in bus_gens) - qd + bs*v^2)
-    return Set([c])
-end
-
-function constraint_reactive_kcl_shunt_ne{T <: AbstractACPForm}(pm::GenericPowerModel{T}, i, bus_arcs, bus_arcs_ne, bus_gens, pd, qd, gs, bs)
-    v = getvariable(pm.model, :v)[i]
-    q = getvariable(pm.model, :q)
     q_ne = getvariable(pm.model, :q_ne)
+    pg = getvariable(pm.model, :pg)
     qg = getvariable(pm.model, :qg)
 
-    c = @constraint(pm.model, sum(q[a] for a in bus_arcs) + sum(q_ne[a] for a in bus_arcs_ne) == sum(qg[g] for g in bus_gens) - qd + bs*v^2)
-    return Set([c])
+    c1 = @constraint(pm.model, sum(p[a] for a in bus_arcs) + sum(p_ne[a] for a in bus_arcs_ne) == sum(pg[g] for g in bus_gens) - pd - gs*v^2)
+    c2 = @constraint(pm.model, sum(q[a] for a in bus_arcs) + sum(q_ne[a] for a in bus_arcs_ne) == sum(qg[g] for g in bus_gens) - qd + bs*v^2)
+    return Set([c1, c2])
 end
+
 
 # Creates Ohms constraints (yt post fix indicates that Y and T values are in rectangular form)
-function constraint_active_ohms_yt{T <: AbstractACPForm}(pm::GenericPowerModel{T}, f_bus, t_bus, f_idx, t_idx, g, b, c, tr, ti, tm)
+function constraint_ohms_yt_from{T <: AbstractACPForm}(pm::GenericPowerModel{T}, f_bus, t_bus, f_idx, t_idx, g, b, c, tr, ti, tm)
     p_fr = getvariable(pm.model, :p)[f_idx]
-    p_to = getvariable(pm.model, :p)[t_idx]
+    q_fr = getvariable(pm.model, :q)[f_idx]
     v_fr = getvariable(pm.model, :v)[f_bus]
     v_to = getvariable(pm.model, :v)[t_bus]
     t_fr = getvariable(pm.model, :t)[f_bus]
     t_to = getvariable(pm.model, :t)[t_bus]
 
     c1 = @NLconstraint(pm.model, p_fr == g/tm*v_fr^2 + (-g*tr+b*ti)/tm*(v_fr*v_to*cos(t_fr-t_to)) + (-b*tr-g*ti)/tm*(v_fr*v_to*sin(t_fr-t_to)) )
-    c2 = @NLconstraint(pm.model, p_to ==    g*v_to^2 + (-g*tr-b*ti)/tm*(v_to*v_fr*cos(t_to-t_fr)) + (-b*tr+g*ti)/tm*(v_to*v_fr*sin(t_to-t_fr)) )
+    c2 = @NLconstraint(pm.model, q_fr == -(b+c/2)/tm*v_fr^2 - (-b*tr-g*ti)/tm*(v_fr*v_to*cos(t_fr-t_to)) + (-g*tr+b*ti)/tm*(v_fr*v_to*sin(t_fr-t_to)) )
     return Set([c1, c2])
 end
 
-
-function constraint_reactive_ohms_yt{T <: AbstractACPForm}(pm::GenericPowerModel{T}, f_bus, t_bus, f_idx, t_idx, g, b, c, tr, ti, tm)
-    q_fr = getvariable(pm.model, :q)[f_idx]
+function constraint_ohms_yt_to{T <: AbstractACPForm}(pm::GenericPowerModel{T}, f_bus, t_bus, f_idx, t_idx, g, b, c, tr, ti, tm)
+    p_to = getvariable(pm.model, :p)[t_idx]
     q_to = getvariable(pm.model, :q)[t_idx]
     v_fr = getvariable(pm.model, :v)[f_bus]
     v_to = getvariable(pm.model, :v)[t_bus]
     t_fr = getvariable(pm.model, :t)[f_bus]
     t_to = getvariable(pm.model, :t)[t_bus]
 
-    c1 = @NLconstraint(pm.model, q_fr == -(b+c/2)/tm*v_fr^2 - (-b*tr-g*ti)/tm*(v_fr*v_to*cos(t_fr-t_to)) + (-g*tr+b*ti)/tm*(v_fr*v_to*sin(t_fr-t_to)) )
+    c1 = @NLconstraint(pm.model, p_to ==    g*v_to^2 + (-g*tr-b*ti)/tm*(v_to*v_fr*cos(t_to-t_fr)) + (-b*tr+g*ti)/tm*(v_to*v_fr*sin(t_to-t_fr)) )
     c2 = @NLconstraint(pm.model, q_to ==    -(b+c/2)*v_to^2 - (-b*tr+g*ti)/tm*(v_to*v_fr*cos(t_fr-t_to)) + (-g*tr-b*ti)/tm*(v_to*v_fr*sin(t_to-t_fr)) )
     return Set([c1, c2])
 end
 
 # Creates Ohms constraints for AC models (y post fix indicates that Y values are in rectangular form)
-function constraint_active_ohms_y{T <: AbstractACPForm}(pm::GenericPowerModel{T}, f_bus, t_bus, f_idx, t_idx, g, b, c, tr, as)
+function constraint_ohms_y_from{T <: AbstractACPForm}(pm::GenericPowerModel{T}, f_bus, t_bus, f_idx, t_idx, g, b, c, tr, as)
     p_fr = getvariable(pm.model, :p)[f_idx]
-    p_to = getvariable(pm.model, :p)[t_idx]
+    q_fr = getvariable(pm.model, :q)[f_idx]
     v_fr = getvariable(pm.model, :v)[f_bus]
     v_to = getvariable(pm.model, :v)[t_bus]
     t_fr = getvariable(pm.model, :t)[f_bus]
     t_to = getvariable(pm.model, :t)[t_bus]
 
     c1 = @NLconstraint(pm.model, p_fr == g*(v_fr/tr)^2 + -g*v_fr/tr*v_to*cos(t_fr-t_to-as) + -b*v_fr/tr*v_to*sin(t_fr-t_to-as) )
-    c2 = @NLconstraint(pm.model, p_to ==      g*v_to^2 + -g*v_to*v_fr/tr*cos(t_to-t_fr+as) + -b*v_to*v_fr/tr*sin(t_to-t_fr+as) )
+    c2 = @NLconstraint(pm.model, q_fr == -(b+c/2)*(v_fr/tr)^2 + b*v_fr/tr*v_to*cos(t_fr-t_to-as) + -g*v_fr/tr*v_to*sin(t_fr-t_to-as) )
     return Set([c1, c2])
 end
 
-function constraint_reactive_ohms_y{T <: AbstractACPForm}(pm::GenericPowerModel{T}, f_bus, t_bus, f_idx, t_idx, g, b, c, tr, as)
-    q_fr = getvariable(pm.model, :q)[f_idx]
+function constraint_ohms_y_to{T <: AbstractACPForm}(pm::GenericPowerModel{T}, f_bus, t_bus, f_idx, t_idx, g, b, c, tr, as)
+    p_to = getvariable(pm.model, :p)[t_idx]
     q_to = getvariable(pm.model, :q)[t_idx]
     v_fr = getvariable(pm.model, :v)[f_bus]
     v_to = getvariable(pm.model, :v)[t_bus]
     t_fr = getvariable(pm.model, :t)[f_bus]
     t_to = getvariable(pm.model, :t)[t_bus]
 
-    c1 = @NLconstraint(pm.model, q_fr == -(b+c/2)*(v_fr/tr)^2 + b*v_fr/tr*v_to*cos(t_fr-t_to-as) + -g*v_fr/tr*v_to*sin(t_fr-t_to-as) )
-    c2 = @NLconstraint(pm.model, q_to ==      -(b+c/2)*v_to^2 + b*v_to*v_fr/tr*cos(t_fr-t_to+as) + -g*v_to*v_fr/tr*sin(t_to-t_fr+as) )
+    c1 = @NLconstraint(pm.model, p_to == g*v_to^2 + -g*v_to*v_fr/tr*cos(t_to-t_fr+as) + -b*v_to*v_fr/tr*sin(t_to-t_fr+as) )
+    c2 = @NLconstraint(pm.model, q_to == -(b+c/2)*v_to^2 + b*v_to*v_fr/tr*cos(t_fr-t_to+as) + -g*v_to*v_fr/tr*sin(t_to-t_fr+as) )
     return Set([c1, c2])
 end
-
-
 
 
 function constraint_phase_angle_difference{T <: AbstractACPForm}(pm::GenericPowerModel{T}, f_bus, t_bus, angmin, angmax)
@@ -159,19 +139,19 @@ end
 
 
 
-function variable_complex_voltage_on_off{T <: AbstractACPForm}(pm::GenericPowerModel{T}; kwargs...)
+function variable_voltage_on_off{T <: AbstractACPForm}(pm::GenericPowerModel{T}; kwargs...)
     variable_phase_angle(pm; kwargs...)
     variable_voltage_magnitude(pm; kwargs...)
 end
 
-function constraint_complex_voltage_on_off{T <: AbstractACPForm}(pm::GenericPowerModel{T})
+function constraint_voltage_on_off{T <: AbstractACPForm}(pm::GenericPowerModel{T})
     # do nothing, this model does not have complex voltage constraints
     return Set()
 end
 
-function constraint_active_ohms_yt_on_off{T <: AbstractACPForm}(pm::GenericPowerModel{T}, i, f_bus, t_bus, f_idx, t_idx, g, b, c, tr, ti, tm, t_min, t_max)
+function constraint_ohms_yt_from_on_off{T <: AbstractACPForm}(pm::GenericPowerModel{T}, i, f_bus, t_bus, f_idx, t_idx, g, b, c, tr, ti, tm, t_min, t_max)
     p_fr = getvariable(pm.model, :p)[f_idx]
-    p_to = getvariable(pm.model, :p)[t_idx]
+    q_fr = getvariable(pm.model, :q)[f_idx]
     v_fr = getvariable(pm.model, :v)[f_bus]
     v_to = getvariable(pm.model, :v)[t_bus]
     t_fr = getvariable(pm.model, :t)[f_bus]
@@ -179,27 +159,12 @@ function constraint_active_ohms_yt_on_off{T <: AbstractACPForm}(pm::GenericPower
     z = getvariable(pm.model, :line_z)[i]
 
     c1 = @NLconstraint(pm.model, p_fr == z*(g/tm*v_fr^2 + (-g*tr+b*ti)/tm*(v_fr*v_to*cos(t_fr-t_to)) + (-b*tr-g*ti)/tm*(v_fr*v_to*sin(t_fr-t_to))) )
-    c2 = @NLconstraint(pm.model, p_to ==    z*(g*v_to^2 + (-g*tr-b*ti)/tm*(v_to*v_fr*cos(t_to-t_fr)) + (-b*tr+g*ti)/tm*(v_to*v_fr*sin(t_to-t_fr))) )
+    c2 = @NLconstraint(pm.model, q_fr == z*(-(b+c/2)/tm*v_fr^2 - (-b*tr-g*ti)/tm*(v_fr*v_to*cos(t_fr-t_to)) + (-g*tr+b*ti)/tm*(v_fr*v_to*sin(t_fr-t_to))) )
     return Set([c1, c2])
 end
 
-function constraint_active_ohms_yt_ne{T <: AbstractACPForm}(pm::GenericPowerModel{T}, i, f_bus, t_bus, f_idx, t_idx, g, b, c, tr, ti, tm, t_min, t_max)
-    p_fr = getvariable(pm.model, :p_ne)[f_idx]
-    p_to = getvariable(pm.model, :p_ne)[t_idx]
-    v_fr = getvariable(pm.model, :v)[f_bus]
-    v_to = getvariable(pm.model, :v)[t_bus]
-    t_fr = getvariable(pm.model, :t)[f_bus]
-    t_to = getvariable(pm.model, :t)[t_bus]
-    z = getvariable(pm.model, :line_ne)[i]
-
-    c1 = @NLconstraint(pm.model, p_fr == z*(g/tm*v_fr^2 + (-g*tr+b*ti)/tm*(v_fr*v_to*cos(t_fr-t_to)) + (-b*tr-g*ti)/tm*(v_fr*v_to*sin(t_fr-t_to))) )
-    c2 = @NLconstraint(pm.model, p_to ==    z*(g*v_to^2 + (-g*tr-b*ti)/tm*(v_to*v_fr*cos(t_to-t_fr)) + (-b*tr+g*ti)/tm*(v_to*v_fr*sin(t_to-t_fr))) )      
-    return Set([c1, c2])
-end
-
-
-function constraint_reactive_ohms_yt_on_off{T <: AbstractACPForm}(pm::GenericPowerModel{T}, i, f_bus, t_bus, f_idx, t_idx, g, b, c, tr, ti, tm, t_min, t_max)
-    q_fr = getvariable(pm.model, :q)[f_idx]
+function constraint_ohms_yt_to_on_off{T <: AbstractACPForm}(pm::GenericPowerModel{T}, i, f_bus, t_bus, f_idx, t_idx, g, b, c, tr, ti, tm, t_min, t_max)
+    p_to = getvariable(pm.model, :p)[t_idx]
     q_to = getvariable(pm.model, :q)[t_idx]
     v_fr = getvariable(pm.model, :v)[f_bus]
     v_to = getvariable(pm.model, :v)[t_bus]
@@ -207,13 +172,27 @@ function constraint_reactive_ohms_yt_on_off{T <: AbstractACPForm}(pm::GenericPow
     t_to = getvariable(pm.model, :t)[t_bus]
     z = getvariable(pm.model, :line_z)[i]
 
-    c1 = @NLconstraint(pm.model, q_fr == z*(-(b+c/2)/tm*v_fr^2 - (-b*tr-g*ti)/tm*(v_fr*v_to*cos(t_fr-t_to)) + (-g*tr+b*ti)/tm*(v_fr*v_to*sin(t_fr-t_to))) )
+    c1 = @NLconstraint(pm.model, p_to ==    z*(g*v_to^2 + (-g*tr-b*ti)/tm*(v_to*v_fr*cos(t_to-t_fr)) + (-b*tr+g*ti)/tm*(v_to*v_fr*sin(t_to-t_fr))) )
     c2 = @NLconstraint(pm.model, q_to ==    z*(-(b+c/2)*v_to^2 - (-b*tr+g*ti)/tm*(v_to*v_fr*cos(t_fr-t_to)) + (-g*tr-b*ti)/tm*(v_to*v_fr*sin(t_to-t_fr))) )
     return Set([c1, c2])
 end
 
-function constraint_reactive_ohms_yt_ne{T <: AbstractACPForm}(pm::GenericPowerModel{T}, i, f_bus, t_bus, f_idx, t_idx, g, b, c, tr, ti, tm, t_min, t_max)
+function constraint_ohms_yt_from_ne{T <: AbstractACPForm}(pm::GenericPowerModel{T}, i, f_bus, t_bus, f_idx, t_idx, g, b, c, tr, ti, tm, t_min, t_max)
+    p_fr = getvariable(pm.model, :p_ne)[f_idx]
     q_fr = getvariable(pm.model, :q_ne)[f_idx]
+    v_fr = getvariable(pm.model, :v)[f_bus]
+    v_to = getvariable(pm.model, :v)[t_bus]
+    t_fr = getvariable(pm.model, :t)[f_bus]
+    t_to = getvariable(pm.model, :t)[t_bus]
+    z = getvariable(pm.model, :line_ne)[i]
+
+    c1 = @NLconstraint(pm.model, p_fr == z*(g/tm*v_fr^2 + (-g*tr+b*ti)/tm*(v_fr*v_to*cos(t_fr-t_to)) + (-b*tr-g*ti)/tm*(v_fr*v_to*sin(t_fr-t_to))) )
+    c2 = @NLconstraint(pm.model, q_fr == z*(-(b+c/2)/tm*v_fr^2 - (-b*tr-g*ti)/tm*(v_fr*v_to*cos(t_fr-t_to)) + (-g*tr+b*ti)/tm*(v_fr*v_to*sin(t_fr-t_to))) )
+    return Set([c1, c2])
+end
+
+function constraint_ohms_yt_to_ne{T <: AbstractACPForm}(pm::GenericPowerModel{T}, i, f_bus, t_bus, f_idx, t_idx, g, b, c, tr, ti, tm, t_min, t_max)
+    p_to = getvariable(pm.model, :p_ne)[t_idx]
     q_to = getvariable(pm.model, :q_ne)[t_idx]
     v_fr = getvariable(pm.model, :v)[f_bus]
     v_to = getvariable(pm.model, :v)[t_bus]
@@ -221,7 +200,7 @@ function constraint_reactive_ohms_yt_ne{T <: AbstractACPForm}(pm::GenericPowerMo
     t_to = getvariable(pm.model, :t)[t_bus]
     z = getvariable(pm.model, :line_ne)[i]
 
-    c1 = @NLconstraint(pm.model, q_fr == z*(-(b+c/2)/tm*v_fr^2 - (-b*tr-g*ti)/tm*(v_fr*v_to*cos(t_fr-t_to)) + (-g*tr+b*ti)/tm*(v_fr*v_to*sin(t_fr-t_to))) )
+    c1 = @NLconstraint(pm.model, p_to ==    z*(g*v_to^2 + (-g*tr-b*ti)/tm*(v_to*v_fr*cos(t_to-t_fr)) + (-b*tr+g*ti)/tm*(v_to*v_fr*sin(t_to-t_fr))) )      
     c2 = @NLconstraint(pm.model, q_to ==    z*(-(b+c/2)*v_to^2 - (-b*tr+g*ti)/tm*(v_to*v_fr*cos(t_fr-t_to)) + (-g*tr-b*ti)/tm*(v_to*v_fr*sin(t_to-t_fr))) )
     return Set([c1, c2])
 end
@@ -248,14 +227,17 @@ function constraint_phase_angle_difference_ne{T <: AbstractACPForm}(pm::GenericP
 end
 
 
-function constraint_reactive_loss_lb{T <: AbstractACPForm}(pm::GenericPowerModel{T}, f_bus, t_bus, f_idx, t_idx, c, tr)
+function constraint_loss_lb{T <: AbstractACPForm}(pm::GenericPowerModel{T}, f_bus, t_bus, f_idx, t_idx, c, tr)
     v_fr = getvariable(pm.model, :v)[f_bus]
     v_to = getvariable(pm.model, :v)[t_bus]
+    p_fr = getvariable(pm.model, :p)[f_idx]
     q_fr = getvariable(pm.model, :q)[f_idx]
+    p_to = getvariable(pm.model, :p)[t_idx]
     q_to = getvariable(pm.model, :q)[t_idx]
 
-    c = @constraint(m, q_fr + q_to >= -c/2*(v_fr^2/tr^2 + v_to^2))
-    return Set([c])
+    c1 = @constraint(m, p_fr + p_to >= 0)
+    c2 = @constraint(m, q_fr + q_to >= -c/2*(v_fr^2/tr^2 + v_to^2))
+    return Set([c1, c2])
 end
 
 
@@ -273,7 +255,6 @@ end
 function variable_load_factor{T}(pm::GenericPowerModel{T})
     @variable(pm.model, load_factor >= 1.0, start = 1.0)
 end
-
 
 function objective_max_loading{T}(pm::GenericPowerModel{T})
     load_factor = getvariable(pm.model, :load_factor)
@@ -320,7 +301,7 @@ function upperbound_negative_active_generation(pm::APIACPPowerModel)
     end
 end
 
-function constraint_active_kcl_shunt_scaled(pm::APIACPPowerModel, bus)
+function constraint_kcl_shunt_scaled(pm::APIACPPowerModel, bus)
     i = bus["index"]
     bus_arcs = pm.ref[:bus_arcs][i]
     bus_gens = pm.ref[:bus_gens][i]
@@ -328,16 +309,20 @@ function constraint_active_kcl_shunt_scaled(pm::APIACPPowerModel, bus)
     load_factor = getvariable(pm.model, :load_factor)
     v = getvariable(pm.model, :v)
     p = getvariable(pm.model, :p)
+    q = getvariable(pm.model, :q)
     pg = getvariable(pm.model, :pg)
+    qg = getvariable(pm.model, :qg)
 
     if bus["pd"] > 0 && bus["qd"] > 0
-        c = @constraint(pm.model, sum(p[a] for a in bus_arcs) == sum(pg[g] for g in bus_gens) - bus["pd"]*load_factor - bus["gs"]*v[i]^2)
+        c1 = @constraint(pm.model, sum(p[a] for a in bus_arcs) == sum(pg[g] for g in bus_gens) - bus["pd"]*load_factor - bus["gs"]*v[i]^2)
     else
         # super fallback impl
-        c = @constraint(pm.model, sum(p[a] for a in bus_arcs) == sum(pg[g] for g in bus_gens) - bus["pd"] - bus["gs"]*v[i]^2)
+        c1 = @constraint(pm.model, sum(p[a] for a in bus_arcs) == sum(pg[g] for g in bus_gens) - bus["pd"] - bus["gs"]*v[i]^2)
     end
 
-    return Set([c])
+    c2 = @constraint(pm.model, sum(q[a] for a in bus_arcs) == sum(qg[g] for g in bus_gens) - bus["qd"] + bus["bs"]*v[i]^2)
+
+    return Set([c1, c2])
 end
 
 function get_solution(pm::APIACPPowerModel)

--- a/src/prob/opf.jl
+++ b/src/prob/opf.jl
@@ -13,29 +13,22 @@ function run_opf(file, model_constructor, solver; kwargs...)
 end
 
 function post_opf{T}(pm::GenericPowerModel{T})
-    variable_complex_voltage(pm)
-
-    variable_active_generation(pm)
-    variable_reactive_generation(pm)
-
-    variable_active_line_flow(pm)
-    variable_reactive_line_flow(pm)
-
+    variable_voltage(pm)
+    variable_generation(pm)
+    variable_line_flow(pm)
 
     objective_min_fuel_cost(pm)
 
-
     constraint_theta_ref(pm)
-    constraint_complex_voltage(pm)
+    constraint_voltage(pm)
 
     for (i,bus) in pm.ref[:bus]
-        constraint_active_kcl_shunt(pm, bus)
-        constraint_reactive_kcl_shunt(pm, bus)
+        constraint_kcl_shunt(pm, bus)
     end
 
     for (i,branch) in pm.ref[:branch]
-        constraint_active_ohms_yt(pm, branch)
-        constraint_reactive_ohms_yt(pm, branch)
+        constraint_ohms_yt_from(pm, branch)
+        constraint_ohms_yt_to(pm, branch)
 
         constraint_phase_angle_difference(pm, branch)
 

--- a/src/prob/ots.jl
+++ b/src/prob/ots.jl
@@ -12,29 +12,22 @@ end
 
 function post_ots{T}(pm::GenericPowerModel{T})
     variable_line_indicator(pm)
-    variable_complex_voltage_on_off(pm)
-
-    variable_active_generation(pm)
-    variable_reactive_generation(pm)
-
-    variable_active_line_flow(pm)
-    variable_reactive_line_flow(pm)
-
+    variable_voltage_on_off(pm)
+    variable_generation(pm)
+    variable_line_flow(pm)
 
     objective_min_fuel_cost(pm)
 
-
     constraint_theta_ref(pm)
-    constraint_complex_voltage_on_off(pm)
+    constraint_voltage_on_off(pm)
 
     for (i,bus) in pm.ref[:bus]
-        constraint_active_kcl_shunt(pm, bus)
-        constraint_reactive_kcl_shunt(pm, bus)
+        constraint_kcl_shunt(pm, bus)
     end
 
     for (i,branch) in pm.ref[:branch]
-        constraint_active_ohms_yt_on_off(pm, branch)
-        constraint_reactive_ohms_yt_on_off(pm, branch)
+        constraint_ohms_yt_from_on_off(pm, branch)
+        constraint_ohms_yt_to_on_off(pm, branch)
 
         constraint_phase_angle_difference_on_off(pm, branch)
 

--- a/src/prob/pf.jl
+++ b/src/prob/pf.jl
@@ -13,22 +13,16 @@ function run_pf(file, model_constructor, solver; kwargs...)
 end
 
 function post_pf{T}(pm::GenericPowerModel{T})
-    variable_complex_voltage(pm, bounded = false)
-
-    variable_active_generation(pm, bounded = false)
-    variable_reactive_generation(pm, bounded = false)
-
-    variable_active_line_flow(pm, bounded = false)
-    variable_reactive_line_flow(pm, bounded = false)
-
+    variable_voltage(pm, bounded = false)
+    variable_generation(pm, bounded = false)
+    variable_line_flow(pm, bounded = false)
 
     constraint_theta_ref(pm)
     constraint_voltage_magnitude_setpoint(pm, pm.ref[:bus][pm.ref[:ref_bus]])
-    constraint_complex_voltage(pm)
+    constraint_voltage(pm)
 
     for (i,bus) in pm.ref[:bus]
-        constraint_active_kcl_shunt(pm, bus)
-        constraint_reactive_kcl_shunt(pm, bus)
+        constraint_kcl_shunt(pm, bus)
 
         # PV Bus Constraints
         if length(pm.ref[:bus_gens][i]) > 0 && i != pm.ref[:ref_bus]
@@ -44,8 +38,8 @@ function post_pf{T}(pm::GenericPowerModel{T})
     end
 
     for (i,branch) in pm.ref[:branch]
-        constraint_active_ohms_yt(pm, branch)
-        constraint_reactive_ohms_yt(pm, branch)
+        constraint_ohms_yt_from(pm, branch)
+        constraint_ohms_yt_to(pm, branch)
     end
 end
 

--- a/src/prob/tnep.jl
+++ b/src/prob/tnep.jl
@@ -11,47 +11,41 @@ end
 # the general form of the tnep optimization model
 function post_tnep{T}(pm::GenericPowerModel{T})
     variable_line_ne(pm) 
-
-    variable_complex_voltage(pm)
-    variable_complex_voltage_ne(pm)
-
-    variable_active_generation(pm)
-    variable_reactive_generation(pm)
-
-    variable_active_line_flow(pm)
-    variable_active_line_flow_ne(pm)
-    variable_reactive_line_flow(pm)
-    variable_reactive_line_flow_ne(pm)
+    variable_voltage(pm)
+    variable_voltage_ne(pm)
+    variable_generation(pm)
+    variable_line_flow(pm)
+    variable_line_flow_ne(pm)
 
     objective_tnep_cost(pm)
        
     constraint_theta_ref(pm)
-
-    constraint_complex_voltage(pm)
-    constraint_complex_voltage_ne(pm)
+    constraint_voltage(pm)
+    constraint_voltage_ne(pm)
 
     for (i,bus) in pm.ref[:bus]
-        constraint_active_kcl_shunt_ne(pm, bus)
-        constraint_reactive_kcl_shunt_ne(pm, bus)
+        constraint_kcl_shunt_ne(pm, bus)
     end
-    
+
+    for (i,branch) in pm.ref[:branch]
+        constraint_ohms_yt_from(pm, branch)
+        constraint_ohms_yt_to(pm, branch)
+
+        constraint_phase_angle_difference(pm, branch)
+
+        constraint_thermal_limit_from(pm, branch)
+        constraint_thermal_limit_to(pm, branch)
+    end 
+
     for (i,branch) in pm.ref[:ne_branch]
-        constraint_active_ohms_yt_ne(pm, branch)
-        constraint_reactive_ohms_yt_ne(pm, branch) 
+        constraint_ohms_yt_from_ne(pm, branch)
+        constraint_ohms_yt_to_ne(pm, branch) 
 
         constraint_phase_angle_difference_ne(pm, branch)
+
         constraint_thermal_limit_from_ne(pm, branch)
         constraint_thermal_limit_to_ne(pm, branch)
     end
-        
-    for (i,branch) in pm.ref[:branch]
-        constraint_active_ohms_yt(pm, branch)
-        constraint_reactive_ohms_yt(pm, branch)
-
-        constraint_phase_angle_difference(pm, branch)
-        constraint_thermal_limit_from(pm, branch)
-        constraint_thermal_limit_to(pm, branch)
-    end  
 end
 
 function get_tnep_solution{T}(pm::GenericPowerModel{T})


### PR DESCRIPTION
Previously constructors and constraints had annotations like "active", "reactive", and "complex" to indicate the space they operated on.  In this PR I am experimenting with making all constructors and constraints implicitly "complex", with a few explicitly calling out "active"/"reactive" if they only apply to a specific subset.

I think this approach will help the code match the math.  For example, it is nearly one-to-one with the formulations presented [here](https://arxiv.org/abs/1502.07847).

I am not 100% confident this is the best way to go, will wait a few days to merge in.  Discussion is welcome. @rb004f @kersulis @kaarthiksundar @mlubin @bluejuniper