### PR TITLE
Removed Arrays from Internal Network Data Format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ PowerModels.jl Change Log
 - Updated to JuMP v0.15 syntax
 - Replaced PowerModels set data types with "ref" dictionary
 - Refactored Matpower data processing to simplify editing network data after parsing
+- Unified solution data and network data formats
 - Replaced JSON test files with Matpower test files
 - Added documentation on internal JSON data format to DATA.md
 - Updated TNEP models to work with Matpower parsing extensions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ PowerModels.jl Change Log
 - Updated to JuMP v0.15 syntax
 - Replaced PowerModels set data types with "ref" dictionary
 - Refactored Matpower data processing to simplify editing network data after parsing
-- Unified solution data and network data formats
+- Unified network data and solution formats and made them valid JSON documents
 - Replaced JSON test files with Matpower test files
 - Added documentation on internal JSON data format to DATA.md
 - Updated TNEP models to work with Matpower parsing extensions

--- a/DATA.md
+++ b/DATA.md
@@ -63,6 +63,7 @@ The PowerModels network data dictionary differs from the Matpower format in the 
 - All PowerModels components have an `index` parameter, which can be used to uniquely identify that network element.
 - All network parameters are in per-unit and angles are in radians.
 - All non-transformer branches are given nominal transformer values (i.e. a tap of 1.0 and a shift of 0).
+- All branches have a `transformer` field indicating if they are a transformer or not.
 - When present, the `gencost` data is incorporated into the `gen` data, the column names remain the same.
 - Only quadratic active power generation cost functions are supported at this time.
 - Special treatment is given to the optional `ne_branch` matrix to support the TNEP problem.

--- a/DATA.md
+++ b/DATA.md
@@ -12,36 +12,39 @@ The network data dictionary structure is roughly as follows,
 "name":<string>,
 "version":"2",
 "baseMVA":<float>,
-"bus":[
-    {
+"bus":{
+    "1":{
         "index":<int>,
         "bus_type":<int>,
         "pd":<float>,
         "qd":<float>,
         ...
     },
+    "2":{...},
     ...
-],
-"gen":[
-    {
+},
+"gen":{
+    "1":{
         "index":<int>,
         "gen_bus":<int>,
         "pg":<float>,
         "qg":<float>,
         ...
     },
+    "2":{...},
     ...
-],
-"branch":[
-    {
+},
+"branch":{
+    "1":{
         "index":<int>,
         "f_bus":<int>,
         "t_bus":<int>,
         "br_r":<int>,
         ...
     },
+    "2":{...},
     ...
-]
+}
 }
 ```
 
@@ -67,8 +70,7 @@ The PowerModels network data dictionary differs from the Matpower format in the 
 
 ## Working with Matpower Data Files
 
-The data exchange via JSON files is ideal for building algorithms, however it is hard to for humans to read and process.
-To that end PowerModels also has extensive support for parsing Matpower network files in the `.m` format.
+The data exchange via JSON files is ideal for building algorithms, however it is hard to for humans to read and process.  To that end PowerModels also has extensive support for parsing Matpower network files in the `.m` format.
 
 
 ### User Extensions
@@ -98,18 +100,18 @@ mpc.areas = [
 becomes,
 ```
 {
-"areas":[
-    {
+"areas":{
+    "1":{
         "index":1,
         "col_1":1,
         "col_2":1
     },
-    {
+    "2":{
         "index":1,
         "col_1":2,
         "col_2":3
     }
-]
+}
 }
 ```
 
@@ -125,18 +127,18 @@ mpc.areas_named = [
 becomes,
 ```
 {
-"areas":[
-    {
+"areas":{
+    "1":{
         "index":1,
         "area":4,
         "refbus":5
     },
-    {
-        "index":1,
+    "2":{
+        "index":2,
         "area":5,
         "refbus":6
     }
-]
+}
 }
 ```
 
@@ -154,26 +156,26 @@ mpc.branch_limit = [
 becomes,
 ```
 {
-"branch":[
-    {
+"branch":{
+    "1":{
         "index":1,
         ...(all pre existing fields)...
         "rate_i":50.2,
         "rate_p":45
     },
-    {
+    "2":{
         "index":2,
         ...(all pre existing fields)...
         "rate_i":36,
         "rate_p":60.1
     },
-    {
+    "3":{
         "index":3,
         ...(all pre existing fields)...
         "rate_i":12,
         "rate_p":30
     }
-]
+}
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -82,8 +82,8 @@ network_data = PowerModels.parse_file("nesta_case3_lmbd.m")
 
 run_opf(network_data, ACPPowerModel, IpoptSolver())
 
-network_data["bus"][3]["pd"] = 0.0
-network_data["bus"][3]["qd"] = 0.0
+network_data["bus"]["3"]["pd"] = 0.0
+network_data["bus"]["3"]["qd"] = 0.0
 
 run_opf(network_data, ACPPowerModel, IpoptSolver())
 ```

--- a/src/core/base.jl
+++ b/src/core/base.jl
@@ -113,8 +113,8 @@ end
 function build_ref(data::Dict{AbstractString,Any})
     ref = Dict{Symbol,Any}()
     for (key, item) in data
-        if isa(item, Array)
-            item_lookup = Dict([(Int(value["index"]), value) for value in item])
+        if isa(item, Dict)
+            item_lookup = Dict([(parse(Int, k), v) for (k,v) in item])
             ref[Symbol(key)] = item_lookup
         end
     end

--- a/src/core/data.jl
+++ b/src/core/data.jl
@@ -86,6 +86,127 @@ function check_keys(data, keys)
     end
 end
 
+function apply_func(data::Dict{AbstractString,Any}, key::AbstractString, func)
+    if haskey(data, key)
+        data[key] = func(data[key])
+    end
+end
+
+function make_per_unit(data::Dict{AbstractString,Any})
+    if !haskey(data, "per_unit") || data["per_unit"] == false
+        data["per_unit"] = true
+        mva_base = data["baseMVA"]
+
+        rescale = x -> x/mva_base
+
+        for (i, bus) in data["bus"]
+            apply_func(bus, "pd", rescale)
+            apply_func(bus, "qd", rescale)
+
+            apply_func(bus, "gs", rescale)
+            apply_func(bus, "bs", rescale)
+
+            apply_func(bus, "va", deg2rad)
+        end
+
+        branches = [branch for branch in values(data["branch"])]
+        if haskey(data, "ne_branch")
+            append!(branches, values(data["ne_branch"]))
+        end
+
+        for branch in branches
+            apply_func(branch, "rate_a", rescale)
+            apply_func(branch, "rate_b", rescale)
+            apply_func(branch, "rate_c", rescale)
+
+            apply_func(branch, "shift", deg2rad)
+            apply_func(branch, "angmax", deg2rad)
+            apply_func(branch, "angmin", deg2rad)
+        end
+
+        for (i, gen) in data["gen"]
+            apply_func(gen, "pg", rescale)
+            apply_func(gen, "qg", rescale)
+
+            apply_func(gen, "pmax", rescale)
+            apply_func(gen, "pmin", rescale)
+
+            apply_func(gen, "qmax", rescale)
+            apply_func(gen, "qmin", rescale)
+
+            if "model" in keys(gen) && "cost" in keys(gen)
+                if gen["model"] != 2
+                    warn("Skipping generator cost model of type other than 2")
+                else
+                    degree = length(gen["cost"])
+                    for (i, item) in enumerate(gen["cost"])
+                        gen["cost"][i] = item*mva_base^(degree-i)
+                    end
+                end
+            end
+        end
+
+    end
+end
+
+
+function make_mixed_unit(data::Dict{AbstractString,Any})
+    if haskey(data, "per_unit") && data["per_unit"] == true
+        data["per_unit"] = false
+        mva_base = data["baseMVA"]
+
+        rescale = x -> x*mva_base
+
+        for (i, bus) in data["bus"]
+            apply_func(bus, "pd", rescale)
+            apply_func(bus, "qd", rescale)
+
+            apply_func(bus, "gs", rescale)
+            apply_func(bus, "bs", rescale)
+
+            apply_func(bus, "va", rad2deg)
+        end
+
+        branches = [branch for branch in values(data["branch"])]
+        if haskey(data, "ne_branch")
+            append!(branches, values(data["ne_branch"]))
+        end
+
+        for branch in branches
+            apply_func(branch, "rate_a", rescale)
+            apply_func(branch, "rate_b", rescale)
+            apply_func(branch, "rate_c", rescale)
+
+            apply_func(branch, "shift", rad2deg)
+            apply_func(branch, "angmax", rad2deg)
+            apply_func(branch, "angmin", rad2deg)
+        end
+
+        for (i, gen) in data["gen"]
+            apply_func(gen, "pg", rescale)
+            apply_func(gen, "qg", rescale)
+
+            apply_func(gen, "pmax", rescale)
+            apply_func(gen, "pmin", rescale)
+
+            apply_func(gen, "qmax", rescale)
+            apply_func(gen, "qmin", rescale)
+
+            if "model" in keys(gen) && "cost" in keys(gen)
+                if gen["model"] != 2
+                    warn("Skipping generator cost model of type other than 2")
+                else
+                    degree = length(gen["cost"])
+                    for (i, item) in enumerate(gen["cost"])
+                        gen["cost"][i] = item/mva_base^(degree-i)
+                    end
+                end
+            end
+        end
+
+    end
+end
+
 
 # checks that phase angle differences are within 90 deg., if not tightens
 function check_phase_angle_differences(data, default_pad = 1.0472)

--- a/src/core/data.jl
+++ b/src/core/data.jl
@@ -116,17 +116,22 @@ function make_per_unit(data::Dict{AbstractString,Any})
 
         rescale = x -> x/mva_base
 
-        for (i, bus) in data["bus"]
-            apply_func(bus, "pd", rescale)
-            apply_func(bus, "qd", rescale)
+        if haskey(data, "bus")
+            for (i, bus) in data["bus"]
+                apply_func(bus, "pd", rescale)
+                apply_func(bus, "qd", rescale)
 
-            apply_func(bus, "gs", rescale)
-            apply_func(bus, "bs", rescale)
+                apply_func(bus, "gs", rescale)
+                apply_func(bus, "bs", rescale)
 
-            apply_func(bus, "va", deg2rad)
+                apply_func(bus, "va", deg2rad)
+            end
         end
 
-        branches = [branch for branch in values(data["branch"])]
+        branches = []
+        if haskey(data, "branch")
+            append!(branches, values(data["branch"]))
+        end
         if haskey(data, "ne_branch")
             append!(branches, values(data["ne_branch"]))
         end
@@ -141,23 +146,25 @@ function make_per_unit(data::Dict{AbstractString,Any})
             apply_func(branch, "angmin", deg2rad)
         end
 
-        for (i, gen) in data["gen"]
-            apply_func(gen, "pg", rescale)
-            apply_func(gen, "qg", rescale)
+        if haskey(data, "gen")
+            for (i, gen) in data["gen"]
+                apply_func(gen, "pg", rescale)
+                apply_func(gen, "qg", rescale)
 
-            apply_func(gen, "pmax", rescale)
-            apply_func(gen, "pmin", rescale)
+                apply_func(gen, "pmax", rescale)
+                apply_func(gen, "pmin", rescale)
 
-            apply_func(gen, "qmax", rescale)
-            apply_func(gen, "qmin", rescale)
+                apply_func(gen, "qmax", rescale)
+                apply_func(gen, "qmin", rescale)
 
-            if "model" in keys(gen) && "cost" in keys(gen)
-                if gen["model"] != 2
-                    warn("Skipping generator cost model of type other than 2")
-                else
-                    degree = length(gen["cost"])
-                    for (i, item) in enumerate(gen["cost"])
-                        gen["cost"][i] = item*mva_base^(degree-i)
+                if "model" in keys(gen) && "cost" in keys(gen)
+                    if gen["model"] != 2
+                        warn("Skipping generator cost model of type other than 2")
+                    else
+                        degree = length(gen["cost"])
+                        for (i, item) in enumerate(gen["cost"])
+                            gen["cost"][i] = item*mva_base^(degree-i)
+                        end
                     end
                 end
             end
@@ -175,17 +182,22 @@ function make_mixed_units(data::Dict{AbstractString,Any})
 
         rescale = x -> x*mva_base
 
-        for (i, bus) in data["bus"]
-            apply_func(bus, "pd", rescale)
-            apply_func(bus, "qd", rescale)
+        if haskey(data, "bus")
+            for (i, bus) in data["bus"]
+                apply_func(bus, "pd", rescale)
+                apply_func(bus, "qd", rescale)
 
-            apply_func(bus, "gs", rescale)
-            apply_func(bus, "bs", rescale)
+                apply_func(bus, "gs", rescale)
+                apply_func(bus, "bs", rescale)
 
-            apply_func(bus, "va", rad2deg)
+                apply_func(bus, "va", rad2deg)
+            end
         end
 
-        branches = [branch for branch in values(data["branch"])]
+        branches = []
+        if haskey(data, "branch")
+            append!(branches, values(data["branch"]))
+        end
         if haskey(data, "ne_branch")
             append!(branches, values(data["ne_branch"]))
         end
@@ -200,23 +212,25 @@ function make_mixed_units(data::Dict{AbstractString,Any})
             apply_func(branch, "angmin", rad2deg)
         end
 
-        for (i, gen) in data["gen"]
-            apply_func(gen, "pg", rescale)
-            apply_func(gen, "qg", rescale)
+        if haskey(data, "gen")
+            for (i, gen) in data["gen"]
+                apply_func(gen, "pg", rescale)
+                apply_func(gen, "qg", rescale)
 
-            apply_func(gen, "pmax", rescale)
-            apply_func(gen, "pmin", rescale)
+                apply_func(gen, "pmax", rescale)
+                apply_func(gen, "pmin", rescale)
 
-            apply_func(gen, "qmax", rescale)
-            apply_func(gen, "qmin", rescale)
+                apply_func(gen, "qmax", rescale)
+                apply_func(gen, "qmin", rescale)
 
-            if "model" in keys(gen) && "cost" in keys(gen)
-                if gen["model"] != 2
-                    warn("Skipping generator cost model of type other than 2")
-                else
-                    degree = length(gen["cost"])
-                    for (i, item) in enumerate(gen["cost"])
-                        gen["cost"][i] = item/mva_base^(degree-i)
+                if "model" in keys(gen) && "cost" in keys(gen)
+                    if gen["model"] != 2
+                        warn("Skipping generator cost model of type other than 2")
+                    else
+                        degree = length(gen["cost"])
+                        for (i, item) in enumerate(gen["cost"])
+                            gen["cost"][i] = item/mva_base^(degree-i)
+                        end
                     end
                 end
             end

--- a/src/core/data.jl
+++ b/src/core/data.jl
@@ -86,12 +86,29 @@ function check_keys(data, keys)
     end
 end
 
+# Recusivly applies new_data to data, overwritting information
+function update_data(data::Dict{AbstractString,Any}, new_data::Dict{AbstractString,Any})
+    for (key, new_v) in new_data
+        if haskey(data, key)
+            v = data[key]
+            if isa(v, Dict) && isa(new_v, Dict)
+                update_data(v, new_v)
+            else
+                data[key] = new_v
+            end
+        else
+            data[key] = new_v
+        end
+    end
+end
+
 function apply_func(data::Dict{AbstractString,Any}, key::AbstractString, func)
     if haskey(data, key)
         data[key] = func(data[key])
     end
 end
 
+# Transforms network data into per-unit
 function make_per_unit(data::Dict{AbstractString,Any})
     if !haskey(data, "per_unit") || data["per_unit"] == false
         data["per_unit"] = true
@@ -150,7 +167,8 @@ function make_per_unit(data::Dict{AbstractString,Any})
 end
 
 
-function make_mixed_unit(data::Dict{AbstractString,Any})
+# Transforms network data into mixed-units (inverse of per-unit)
+function make_mixed_units(data::Dict{AbstractString,Any})
     if haskey(data, "per_unit") && data["per_unit"] == true
         data["per_unit"] = false
         mva_base = data["baseMVA"]

--- a/src/core/data.jl
+++ b/src/core/data.jl
@@ -34,9 +34,9 @@ end
 
 function calc_theta_delta_bounds(data::Dict{AbstractString,Any})
     bus_count = length(data["bus"])
-    branches = [branch for branch in data["branch"]]
+    branches = [branch for branch in values(data["branch"])]
     if haskey(data, "ne_branch")
-        append!(branches, data["ne_branch"])
+        append!(branches, values(data["ne_branch"]))
     end
 
     angle_mins = [branch["angmin"] for branch in branches]

--- a/src/core/data.jl
+++ b/src/core/data.jl
@@ -1,5 +1,6 @@
 # tools for working with PowerModels internal data format
 
+
 function calc_voltage_product_bounds(buspairs)
     wr_min = Dict([(bp, -Inf) for bp in keys(buspairs)])
     wr_max = Dict([(bp,  Inf) for bp in keys(buspairs)])
@@ -83,5 +84,89 @@ function check_keys(data, keys)
             error("attempting to overwrite value of $(key) in PowerModels data,\n$(data)")
         end
     end
+end
+
+
+# checks that phase angle differences are within 90 deg., if not tightens
+function check_phase_angle_differences(data, default_pad = 1.0472)
+    assert("per_unit" in keys(data) && data["per_unit"])
+
+    for (i, branch) in data["branch"]
+        if branch["angmin"] <= -pi/2
+            warn("this code only supports angmin values in -90 deg. to 90 deg., tightening the value on branch $(branch["index"]) from $(rad2deg(branch["angmin"])) to -$(rad2deg(default_pad)) deg.")
+            branch["angmin"] = -default_pad
+        end
+        if branch["angmax"] >= pi/2
+            warn("this code only supports angmax values in -90 deg. to 90 deg., tightening the value on branch $(branch["index"]) from $(rad2deg(branch["angmax"])) to $(rad2deg(default_pad)) deg.")
+            branch["angmax"] = default_pad
+        end
+        if branch["angmin"] == 0.0 && branch["angmax"] == 0.0
+            warn("angmin and angmax values are 0, widening these values on branch $(branch["index"]) to +/- $(rad2deg(default_pad)) deg.")
+            branch["angmin"] = -rad2deg(default_pad)
+            branch["angmax"] = rad2deg(default_pad)
+        end
+    end
+end
+
+
+# checks that each line has a reasonable line thermal rating, if not computes one
+function check_thermal_limits(data)
+    assert("per_unit" in keys(data) && data["per_unit"])
+    mva_base = data["baseMVA"]
+
+    for (i, branch) in data["branch"]
+        if branch["rate_a"] <= 0.0
+            theta_max = max(abs(branch["angmin"]), abs(branch["angmax"]))
+
+            r = branch["br_r"]
+            x = branch["br_x"]
+            g =  r / (r^2 + x^2)
+            b = -x / (r^2 + x^2)
+
+            y_mag = sqrt(g^2 + b^2)
+
+            fr_vmax = data["bus"][string(branch["f_bus"])]["vmax"]
+            to_vmax = data["bus"][string(branch["t_bus"])]["vmax"]
+            m_vmax = max(fr_vmax, to_vmax)
+
+            c_max = sqrt(fr_vmax^2 + to_vmax^2 - 2*fr_vmax*to_vmax*cos(theta_max))
+
+            new_rate = y_mag*m_vmax*c_max
+
+            warn("this code only supports positive rate_a values, changing the value on branch $(branch["index"]) from $(mva_base*branch["rate_a"]) to $(mva_base*new_rate)")
+            branch["rate_a"] = new_rate
+        end
+    end
+end
+
+
+# checks bus types are consistent with generator connections, if not, fixes them
+function check_bus_types(data)
+    bus_gens = Dict([(i, []) for (i,bus) in data["bus"]])
+
+    for (i,gen) in data["gen"]
+        #println(gen)
+        if gen["gen_status"] == 1
+            push!(bus_gens[string(gen["gen_bus"])], i)
+        end
+    end
+
+    for (i, bus) in data["bus"]
+        if bus["bus_type"] != 4 && bus["bus_type"] != 3
+            bus_gens_count = length(bus_gens[i])
+
+            if bus_gens_count == 0 && bus["bus_type"] != 1
+                warn("no active generators found at bus $(bus["bus_i"]), updating to bus type from $(bus["bus_type"]) to 1")
+                bus["bus_type"] = 1
+            end
+
+            if bus_gens_count != 0 && bus["bus_type"] != 2
+                warn("active generators found at bus $(bus["bus_i"]), updating to bus type from $(bus["bus_type"]) to 2")
+                bus["bus_type"] = 2
+            end
+
+        end
+    end
+
 end
 

--- a/src/core/solution.jl
+++ b/src/core/solution.jl
@@ -6,13 +6,16 @@ function build_solution{T}(pm::GenericPowerModel{T}, status, solve_time; objecti
         status = solver_status_dict(Symbol(typeof(pm.model.solver).name.module), status)
     end
 
+    sol = solution_builder(pm)
+    make_mixed_units(sol)
+
     solution = Dict{AbstractString,Any}(
         "solver" => string(typeof(pm.model.solver)),
         "status" => status,
         "objective" => objective,
         "objective_lb" => guard_getobjbound(pm.model),
         "solve_time" => solve_time,
-        "solution" => solution_builder(pm),
+        "solution" => sol,
         "machine" => Dict(
             "cpu" => Sys.cpu_info()[1].model,
             "memory" => string(Sys.total_memory()/2^30, " Gb")
@@ -29,8 +32,16 @@ function build_solution{T}(pm::GenericPowerModel{T}, status, solve_time; objecti
     return solution
 end
 
-function get_solution{T}(pm::GenericPowerModel{T})
+function init_solution{T}(pm::GenericPowerModel{T})
     sol = Dict{AbstractString,Any}()
+    for key in ["per_unit", "baseMVA"]
+        sol[key] = pm.data[key]
+    end
+    return sol
+end
+
+function get_solution{T}(pm::GenericPowerModel{T})
+    sol = init_solution(pm)
     add_bus_voltage_setpoint(sol, pm)
     add_generator_power_setpoint(sol, pm)
     add_branch_flow_setpoint(sol, pm)
@@ -39,19 +50,19 @@ end
 
 function add_bus_voltage_setpoint{T}(sol, pm::GenericPowerModel{T})
     add_setpoint(sol, pm, "bus", "bus_i", "vm", :v)
-    add_setpoint(sol, pm, "bus", "bus_i", "va", :t; scale = (x,item) -> x*180/pi)
+    add_setpoint(sol, pm, "bus", "bus_i", "va", :t)
 end
 
 function add_generator_power_setpoint{T}(sol, pm::GenericPowerModel{T})
     mva_base = pm.data["baseMVA"]
-    add_setpoint(sol, pm, "gen", "index", "pg", :pg; scale = (x,item) -> x*mva_base)
-    add_setpoint(sol, pm, "gen", "index", "qg", :qg; scale = (x,item) -> x*mva_base)
+    add_setpoint(sol, pm, "gen", "index", "pg", :pg)
+    add_setpoint(sol, pm, "gen", "index", "qg", :qg)
 end
 
 function add_bus_demand_setpoint{T}(sol, pm::GenericPowerModel{T})
     mva_base = pm.data["baseMVA"]
-    add_setpoint(sol, pm, "bus", "bus_i", "pd", :pd; default_value = (item) -> item["pd"]*mva_base, scale = (x,item) -> x*mva_base)
-    add_setpoint(sol, pm, "bus", "bus_i", "qd", :qd; default_value = (item) -> item["qd"]*mva_base, scale = (x,item) -> x*mva_base)
+    add_setpoint(sol, pm, "bus", "bus_i", "pd", :pd; default_value = (item) -> item["pd"]*mva_base)
+    add_setpoint(sol, pm, "bus", "bus_i", "qd", :qd; default_value = (item) -> item["qd"]*mva_base)
 end
 
 function add_branch_flow_setpoint{T}(sol, pm::GenericPowerModel{T})
@@ -90,7 +101,7 @@ end
 function add_setpoint{T}(sol, pm::GenericPowerModel{T}, dict_name, index_name, param_name, variable_symbol; default_value = (item) -> NaN, scale = (x,item) -> x, extract_var = (var,idx,item) -> var[idx])
     sol_dict = nothing
     if !haskey(sol, dict_name)
-        sol_dict = Dict{Int,Any}()
+        sol_dict = Dict{AbstractString,Any}()
         sol[dict_name] = sol_dict
     else
         sol_dict = sol[dict_name]
@@ -100,11 +111,11 @@ function add_setpoint{T}(sol, pm::GenericPowerModel{T}, dict_name, index_name, p
         idx = Int(item[index_name])
 
         sol_item = nothing
-        if !haskey(sol_dict, idx)
+        if !haskey(sol_dict, i)
             sol_item = Dict{AbstractString,Any}()
-            sol_dict[idx] = sol_item
+            sol_dict[i] = sol_item
         else
-            sol_item = sol_dict[idx]
+            sol_item = sol_dict[i]
         end
         sol_item[param_name] = default_value(item)
 

--- a/src/core/solution.jl
+++ b/src/core/solution.jl
@@ -96,7 +96,7 @@ function add_setpoint{T}(sol, pm::GenericPowerModel{T}, dict_name, index_name, p
         sol_dict = sol[dict_name]
     end
 
-    for item in pm.data[dict_name]
+    for (i,item) in pm.data[dict_name]
         idx = Int(item[index_name])
 
         sol_item = nothing

--- a/src/form/acp.jl
+++ b/src/form/acp.jl
@@ -327,7 +327,7 @@ end
 
 function get_solution(pm::APIACPPowerModel)
     # super fallback
-    sol = Dict{AbstractString,Any}()
+    sol = init_solution(pm)
     add_bus_voltage_setpoint(sol, pm)
     add_generator_power_setpoint(sol, pm)
     add_branch_flow_setpoint(sol, pm)
@@ -340,8 +340,8 @@ end
 
 function add_bus_demand_setpoint(sol, pm::APIACPPowerModel)
     mva_base = pm.data["baseMVA"]
-    add_setpoint(sol, pm, "bus", "bus_i", "pd", :load_factor; default_value = (item) -> item["pd"]*mva_base, scale = (x,item) -> item["pd"] > 0 && item["qd"] > 0 ? x*item["pd"]*mva_base : item["pd"]*mva_base, extract_var = (var,idx,item) -> var)
-    add_setpoint(sol, pm, "bus", "bus_i", "qd", :load_factor; default_value = (item) -> item["qd"]*mva_base, scale = (x,item) -> item["qd"]*mva_base, extract_var = (var,idx,item) -> var)
+    add_setpoint(sol, pm, "bus", "bus_i", "pd", :load_factor; default_value = (item) -> item["pd"], scale = (x,item) -> item["pd"] > 0 && item["qd"] > 0 ? x*item["pd"] : item["pd"], extract_var = (var,idx,item) -> var)
+    add_setpoint(sol, pm, "bus", "bus_i", "qd", :load_factor; default_value = (item) -> item["qd"], scale = (x,item) -> item["qd"], extract_var = (var,idx,item) -> var)
 end
 
 

--- a/src/form/dcp.jl
+++ b/src/form/dcp.jl
@@ -169,7 +169,7 @@ end
 
 function add_bus_voltage_setpoint{T <: AbstractDCPForm}(sol, pm::GenericPowerModel{T})
     add_setpoint(sol, pm, "bus", "bus_i", "vm", :v; default_value = (item) -> 1)
-    add_setpoint(sol, pm, "bus", "bus_i", "va", :t; scale = (x,item) -> x*180/pi)
+    add_setpoint(sol, pm, "bus", "bus_i", "va", :t)
 end
 
 function add_branch_flow_setpoint{T <: AbstractDCPForm}(sol, pm::GenericPowerModel{T})

--- a/src/io/common.jl
+++ b/src/io/common.jl
@@ -1,8 +1,18 @@
 function parse_file(file)
     if endswith(file, ".m")
-        return PowerModels.parse_matpower(file)
+        pm_data = PowerModels.parse_matpower(file)
     else
-        network_data = PowerModels.parse_json(file)
-        return network_data
+        pm_data = PowerModels.parse_json(file)
     end
+
+    check_network_data(pm_data)
+
+    return pm_data
 end
+
+function check_network_data(data::Dict{AbstractString,Any})
+    make_per_unit(data)
+    check_phase_angle_differences(data)
+    check_thermal_limits(data)
+    check_bus_types(data)
+end 

--- a/src/io/matpower.jl
+++ b/src/io/matpower.jl
@@ -554,12 +554,6 @@ function parse_matpower_data(data_string)
                 error("incorrect Matpower file, the number of bus names ($(length(parsed_cell["data"]))) is inconsistent with the number of buses ($(length(case["bus"]))).\n")
             end
 
-            #for (i, bus) in enumerate(case["bus"])
-            #    # note striping the single quotes is not necessary in general, column typing takes care of this
-            #    bus["bus_name"] = strip(parsed_cell["data"][i][1], '\'')
-            #    #println(bus["bus_name"])
-            #end
-
             typed_dict_data = build_typed_dict(parsed_cell["data"], ["bus_name"])
             case["bus_name"] = typed_dict_data
         else

--- a/src/io/matpower.jl
+++ b/src/io/matpower.jl
@@ -537,7 +537,6 @@ function parse_matpower_data(data_string)
                     bus_data["mu_vmin"] = parse(Float64, bus_row[17])
                 end
 
-                bus_data["bus_name"] = "Bus $(bus_data["bus_i"])"
                 push!(buses, bus_data)
             end
 

--- a/src/prob/ots.jl
+++ b/src/prob/ots.jl
@@ -37,7 +37,7 @@ function post_ots{T}(pm::GenericPowerModel{T})
 end
 
 function get_ots_solution{T}(pm::GenericPowerModel{T})
-    sol = Dict{AbstractString,Any}()
+    sol = init_solution(pm)
     add_bus_voltage_setpoint(sol, pm)
     add_generator_power_setpoint(sol, pm)
     add_branch_flow_setpoint(sol, pm)

--- a/src/prob/tnep.jl
+++ b/src/prob/tnep.jl
@@ -49,7 +49,7 @@ function post_tnep{T}(pm::GenericPowerModel{T})
 end
 
 function get_tnep_solution{T}(pm::GenericPowerModel{T})
-    sol = Dict{AbstractString,Any}()
+    sol = init_solution(pm)
     add_bus_voltage_setpoint(sol, pm)
     add_generator_power_setpoint(sol, pm)
     add_branch_flow_setpoint(sol, pm)

--- a/test/docs.jl
+++ b/test/docs.jl
@@ -15,8 +15,8 @@
         @test result["status"] == :LocalOptimal
         @test isapprox(result["objective"], 5812.64; atol = 1e0)
 
-        network_data["bus"][3]["pd"] = 0.0
-        network_data["bus"][3]["qd"] = 0.0
+        network_data["bus"]["3"]["pd"] = 0.0
+        network_data["bus"]["3"]["qd"] = 0.0
 
         result = run_opf(network_data, ACPPowerModel, IpoptSolver(print_level=0))
 

--- a/test/matpower.jl
+++ b/test/matpower.jl
@@ -20,7 +20,7 @@ using JSON
 
     @testset "14-bus case file with names" begin
         data = PowerModels.parse_file("../test/data/case14.m")
-        @test data["bus"][1]["bus_name"] == "Bus 1     HV"
+        @test data["bus"]["1"]["bus_name"] == "Bus 1     HV"
         @test isa(JSON.json(data), String)
     end
 
@@ -68,10 +68,10 @@ end
         data = PowerModels.parse_file("../test/data/case3.m")
 
         @test haskey(data, "areas")
-        @test data["areas"][1]["col_1"] == 1
-        @test data["areas"][1]["col_2"] == 1
-        @test data["areas"][2]["col_1"] == 2
-        @test data["areas"][2]["col_2"] == 3
+        @test data["areas"]["1"]["col_1"] == 1
+        @test data["areas"]["1"]["col_2"] == 1
+        @test data["areas"]["2"]["col_1"] == 2
+        @test data["areas"]["2"]["col_2"] == 3
         @test isa(JSON.json(data), String)
     end
 
@@ -79,10 +79,10 @@ end
         data = PowerModels.parse_file("../test/data/case3.m")
 
         @test haskey(data, "areas_named")
-        @test data["areas_named"][1]["area"] == 4
-        @test data["areas_named"][1]["refbus"] == 5
-        @test data["areas_named"][2]["area"] == 5
-        @test data["areas_named"][2]["refbus"] == 6
+        @test data["areas_named"]["1"]["area"] == 4
+        @test data["areas_named"]["1"]["refbus"] == 5
+        @test data["areas_named"]["2"]["area"] == 5
+        @test data["areas_named"]["2"]["refbus"] == 6
         @test isa(JSON.json(data), String)
     end
 
@@ -90,12 +90,12 @@ end
         data = PowerModels.parse_file("../test/data/case3.m")
 
         @test haskey(data, "areas_named")
-        @test data["branch"][1]["rate_i"] == 50.2
-        @test data["branch"][1]["rate_p"] == 45
-        @test data["branch"][2]["rate_i"] == 36
-        @test data["branch"][2]["rate_p"] == 60.1
-        @test data["branch"][3]["rate_i"] == 12
-        @test data["branch"][3]["rate_p"] == 30
+        @test data["branch"]["1"]["rate_i"] == 50.2
+        @test data["branch"]["1"]["rate_p"] == 45
+        @test data["branch"]["2"]["rate_i"] == 36
+        @test data["branch"]["2"]["rate_p"] == 60.1
+        @test data["branch"]["3"]["rate_i"] == 12
+        @test data["branch"]["3"]["rate_p"] == 30
         @test isa(JSON.json(data), String)
     end
 
@@ -104,14 +104,14 @@ end
         data = PowerModels.parse_file("../test/data/case3.m")
 
         @test haskey(data, "areas_cells")
-        @test data["areas_cells"][1]["col_1"] == "Area 1"
-        @test data["areas_cells"][1]["col_2"] == 123
-        @test data["areas_cells"][1]["col_4"] == "Slack 'Bus' 1"
-        @test data["areas_cells"][1]["col_5"] == 1.23
-        @test data["areas_cells"][2]["col_1"] == "Area 2"
-        @test data["areas_cells"][2]["col_2"] == 456
-        @test data["areas_cells"][2]["col_4"] == "Slack Bus 3"
-        @test data["areas_cells"][2]["col_5"] == 4.56
+        @test data["areas_cells"]["1"]["col_1"] == "Area 1"
+        @test data["areas_cells"]["1"]["col_2"] == 123
+        @test data["areas_cells"]["1"]["col_4"] == "Slack 'Bus' 1"
+        @test data["areas_cells"]["1"]["col_5"] == 1.23
+        @test data["areas_cells"]["2"]["col_1"] == "Area 2"
+        @test data["areas_cells"]["2"]["col_2"] == 456
+        @test data["areas_cells"]["2"]["col_4"] == "Slack Bus 3"
+        @test data["areas_cells"]["2"]["col_5"] == 4.56
         @test isa(JSON.json(data), String)
     end
 
@@ -119,16 +119,16 @@ end
         data = PowerModels.parse_file("../test/data/case3.m")
 
         @test haskey(data, "areas_named_cells")
-        @test data["areas_named_cells"][1]["area_name"] == "Area 1"
-        @test data["areas_named_cells"][1]["area"] == 123
-        @test data["areas_named_cells"][1]["area2"] == 987
-        @test data["areas_named_cells"][1]["refbus_name"] == "Slack Bus 1"
-        @test data["areas_named_cells"][1]["refbus"] == 1.23
-        @test data["areas_named_cells"][2]["area_name"] == "Area 2"
-        @test data["areas_named_cells"][2]["area"] == 456
-        @test data["areas_named_cells"][2]["area2"] == 987
-        @test data["areas_named_cells"][2]["refbus_name"] == "Slack Bus 3"
-        @test data["areas_named_cells"][2]["refbus"] == 4.56
+        @test data["areas_named_cells"]["1"]["area_name"] == "Area 1"
+        @test data["areas_named_cells"]["1"]["area"] == 123
+        @test data["areas_named_cells"]["1"]["area2"] == 987
+        @test data["areas_named_cells"]["1"]["refbus_name"] == "Slack Bus 1"
+        @test data["areas_named_cells"]["1"]["refbus"] == 1.23
+        @test data["areas_named_cells"]["2"]["area_name"] == "Area 2"
+        @test data["areas_named_cells"]["2"]["area"] == 456
+        @test data["areas_named_cells"]["2"]["area2"] == 987
+        @test data["areas_named_cells"]["2"]["refbus_name"] == "Slack Bus 3"
+        @test data["areas_named_cells"]["2"]["refbus"] == 4.56
         @test isa(JSON.json(data), String)
     end
 
@@ -136,12 +136,12 @@ end
         data = PowerModels.parse_file("../test/data/case3.m")
 
         @test haskey(data, "areas_named")
-        @test data["branch"][1]["name"] == "Branch 1"
-        @test data["branch"][1]["number_id"] == 123
-        @test data["branch"][2]["name"] == "Branch 2"
-        @test data["branch"][2]["number_id"] == 456
-        @test data["branch"][3]["name"] == "Branch 3"
-        @test data["branch"][3]["number_id"] == 789
+        @test data["branch"]["1"]["name"] == "Branch 1"
+        @test data["branch"]["1"]["number_id"] == 123
+        @test data["branch"]["2"]["name"] == "Branch 2"
+        @test data["branch"]["2"]["number_id"] == 456
+        @test data["branch"]["3"]["name"] == "Branch 3"
+        @test data["branch"]["3"]["number_id"] == 789
         @test isa(JSON.json(data), String)
     end
 
@@ -149,8 +149,8 @@ end
         data = PowerModels.parse_file("../test/data/case3_tnep.m")
 
         @test haskey(data, "ne_branch")
-        @test data["ne_branch"][1]["f_bus"] == 1
-        @test data["ne_branch"][1]["construction_cost"] == 1
+        @test data["ne_branch"]["1"]["f_bus"] == 1
+        @test data["ne_branch"]["1"]["construction_cost"] == 1
         @test isa(JSON.json(data), String)
     end
 end

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -6,21 +6,21 @@
 
         @test result["status"] == :LocalOptimal
         @test isapprox(result["objective"], 1.3371; atol = 1e-3)
-        @test isapprox(result["solution"]["bus"][1]["pd"], 147.1; atol = 1e0)
+        @test isapprox(result["solution"]["bus"]["1"]["pd"], 147.1; atol = 1e0)
     end
     @testset "5-bus pjm case" begin
         result = run_api_opf("../test/data/case5.m", APIACPPowerModel, ipopt_solver)
 
         @test result["status"] == :LocalOptimal
         @test isapprox(result["objective"], 2.6872; atol = 1e-3)
-        @test isapprox(result["solution"]["bus"][4]["pd"], 1075.4; atol = 1e0)
+        @test isapprox(result["solution"]["bus"]["4"]["pd"], 1075.4; atol = 1e0)
     end
     @testset "30-bus ieee case" begin
         result = run_api_opf("../test/data/case30.m", APIACPPowerModel, ipopt_solver)
 
         @test result["status"] == :LocalOptimal
         @test isapprox(result["objective"], 1.6628; atol = 1e-3)
-        @test isapprox(result["solution"]["bus"][2]["pd"], 36.1; atol = 1e0)
+        @test isapprox(result["solution"]["bus"]["2"]["pd"], 36.1; atol = 1e0)
     end
 end
 

--- a/test/modify.jl
+++ b/test/modify.jl
@@ -7,20 +7,20 @@
         @test result["status"] == :LocalOptimal
         @test isapprox(result["objective"], 204.96; atol = 1e-1)
 
-        data["branch"][6]["br_status"] = 0
+        data["branch"]["6"]["br_status"] = 0
 
         result = run_opf(data, ACPPowerModel, ipopt_solver)
         @test result["status"] == :LocalOptimal
         @test isapprox(result["objective"], 195.25; atol = 1e-1)
 
-        data["gen"][6]["gen_status"] = 0
+        data["gen"]["6"]["gen_status"] = 0
 
         result = run_opf(data, ACPPowerModel, ipopt_solver)
         @test result["status"] == :LocalOptimal
         @test isapprox(result["objective"], 195.896; atol = 1e-1)
 
-        data["bus"][5]["pd"] = 0
-        data["bus"][5]["qd"] = 0
+        data["bus"]["5"]["pd"] = 0
+        data["bus"]["5"]["qd"] = 0
 
         result = run_opf(data, ACPPowerModel, ipopt_solver)
         @test result["status"] == :LocalOptimal

--- a/test/modify.jl
+++ b/test/modify.jl
@@ -1,6 +1,6 @@
 
 @testset "data modification tests" begin
-    @testset "30-bus case file" begin
+    @testset "30-bus case file incremental" begin
         data = PowerModels.parse_file("../test/data/case30.m")
 
         result = run_opf(data, ACPPowerModel, ipopt_solver)
@@ -21,6 +21,36 @@
 
         data["bus"]["5"]["pd"] = 0
         data["bus"]["5"]["qd"] = 0
+
+        result = run_opf(data, ACPPowerModel, ipopt_solver)
+        @test result["status"] == :LocalOptimal
+        @test isapprox(result["objective"], 104.428; atol = 1e-1)
+    end
+
+    @testset "30-bus case file batch" begin
+        data = PowerModels.parse_file("../test/data/case30.m")
+
+        data_delta = JSON.parse("
+        {
+            \"branch\":{
+                \"6\":{
+                    \"br_status\":0
+                }
+            },
+            \"gen\":{
+                \"6\":{
+                    \"gen_status\":0
+                }
+            },
+            \"bus\":{
+                \"5\":{
+                    \"pd\":0,
+                    \"qd\":0
+                }
+            }
+        }", dicttype = Dict{AbstractString,Any})
+
+        PowerModels.update_data(data, data_delta)
 
         result = run_opf(data, ACPPowerModel, ipopt_solver)
         @test result["status"] == :LocalOptimal

--- a/test/output.jl
+++ b/test/output.jl
@@ -40,10 +40,10 @@ end
 
         branches = result["solution"]["branch"]
 
-        @test isapprox(branches[2]["p_from"],  20.01; atol = 1e-1)
-        @test isapprox(branches[2]["p_to"],   -19.80; atol = 1e-1)
-        @test isapprox(branches[2]["q_from"],   0.55; atol = 1e-1)
-        @test isapprox(branches[2]["q_to"],    -5.71; atol = 1e-1)
+        @test isapprox(branches["2"]["p_from"],  20.01; atol = 1e-1)
+        @test isapprox(branches["2"]["p_to"],   -19.80; atol = 1e-1)
+        @test isapprox(branches["2"]["q_from"],   0.55; atol = 1e-1)
+        @test isapprox(branches["2"]["q_to"],    -5.71; atol = 1e-1)
     end
 
     # A DCPPowerModel test is important because it does have variables for the reverse side of the lines
@@ -59,9 +59,9 @@ end
 
         branches = result["solution"]["branch"]
 
-        @test isapprox(branches[3]["p_from"], -10.34; atol = 1e-1)
-        @test isapprox(branches[3]["p_to"],    10.34; atol = 1e-1)
-        @test isnan(branches[3]["q_from"])
-        @test isnan(branches[3]["q_to"])
+        @test isapprox(branches["3"]["p_from"], -10.34; atol = 1e-1)
+        @test isapprox(branches["3"]["p_to"],    10.34; atol = 1e-1)
+        @test isnan(branches["3"]["q_from"])
+        @test isnan(branches["3"]["q_to"])
     end
 end

--- a/test/pf.jl
+++ b/test/pf.jl
@@ -7,17 +7,17 @@
         @test result["status"] == :LocalOptimal
         @test isapprox(result["objective"], 0; atol = 1e-2)
 
-        @test isapprox(result["solution"]["gen"][1]["pg"], 148.0; atol = 1e-1)
-        @test isapprox(result["solution"]["gen"][1]["qg"], 54.6; atol = 1e-1)
+        @test isapprox(result["solution"]["gen"]["1"]["pg"], 148.0; atol = 1e-1)
+        @test isapprox(result["solution"]["gen"]["1"]["qg"], 54.6; atol = 1e-1)
 
-        @test isapprox(result["solution"]["bus"][1]["vm"], 1.10000; atol = 1e-3)
-        @test isapprox(result["solution"]["bus"][1]["va"], 0.00000; atol = 1e-3)
+        @test isapprox(result["solution"]["bus"]["1"]["vm"], 1.10000; atol = 1e-3)
+        @test isapprox(result["solution"]["bus"]["1"]["va"], 0.00000; atol = 1e-3)
 
-        @test isapprox(result["solution"]["bus"][2]["vm"], 0.92617; atol = 1e-3)
-        @test isapprox(result["solution"]["bus"][2]["va"], 7.25886; atol = 1e-3)
+        @test isapprox(result["solution"]["bus"]["2"]["vm"], 0.92617; atol = 1e-3)
+        @test isapprox(result["solution"]["bus"]["2"]["va"], 7.25886; atol = 1e-3)
 
-        @test isapprox(result["solution"]["bus"][3]["vm"], 0.90000; atol = 1e-3)
-        @test isapprox(result["solution"]["bus"][3]["va"], -17.26711; atol = 1e-3)
+        @test isapprox(result["solution"]["bus"]["3"]["vm"], 0.90000; atol = 1e-3)
+        @test isapprox(result["solution"]["bus"]["3"]["va"], -17.26711; atol = 1e-3)
     end
     @testset "24-bus rts case" begin
         result = run_pf("../test/data/case24.m", ACPPowerModel, ipopt_solver)
@@ -35,11 +35,11 @@ end
         @test result["status"] == :LocalOptimal
         @test isapprox(result["objective"], 0; atol = 1e-2)
 
-        @test isapprox(result["solution"]["gen"][1]["pg"], 144.99; atol = 1e-1)
+        @test isapprox(result["solution"]["gen"]["1"]["pg"], 144.99; atol = 1e-1)
 
-        @test isapprox(result["solution"]["bus"][1]["va"], 0.00000; atol = 1e-3)
-        @test isapprox(result["solution"]["bus"][2]["va"], 5.24122; atol = 1e-3)
-        @test isapprox(result["solution"]["bus"][3]["va"], -16.21006; atol = 1e-3)
+        @test isapprox(result["solution"]["bus"]["1"]["va"], 0.00000; atol = 1e-3)
+        @test isapprox(result["solution"]["bus"]["2"]["va"], 5.24122; atol = 1e-3)
+        @test isapprox(result["solution"]["bus"]["3"]["va"], -16.21006; atol = 1e-3)
     end
     @testset "24-bus rts case" begin
         result = run_pf("../test/data/case24.m", DCPPowerModel, ipopt_solver)
@@ -54,11 +54,11 @@ end
     @testset "3-bus case" begin
         result = run_pf("../test/data/case3.m", SOCWRPowerModel, ipopt_solver)
 
-        @test result["solution"]["gen"][1]["pg"] >= 148.0
+        @test result["solution"]["gen"]["1"]["pg"] >= 148.0
 
-        @test isapprox(result["solution"]["bus"][1]["vm"], 1.09999; atol = 1e-3)
-        @test isapprox(result["solution"]["bus"][2]["vm"], 0.92616; atol = 1e-3)
-        @test isapprox(result["solution"]["bus"][3]["vm"], 0.89999; atol = 1e-3)
+        @test isapprox(result["solution"]["bus"]["1"]["vm"], 1.09999; atol = 1e-3)
+        @test isapprox(result["solution"]["bus"]["2"]["vm"], 0.92616; atol = 1e-3)
+        @test isapprox(result["solution"]["bus"]["3"]["vm"], 0.89999; atol = 1e-3)
 
         @test result["status"] == :LocalOptimal
         @test isapprox(result["objective"], 0; atol = 1e-2)


### PR DESCRIPTION
The arrays in the internal network format are replaced by dictionaries with the component "index" as the key value.  This enables sparse updates to the network data.

Other minor updates
- reworked how per-unit conversion is done
- make solution building utilize per-unit/mixed-unit conversion tools
- generalized some data wrangling code so it can be applied to both Matpower and JSON documents 