### PR TITLE
provide a fallback option for non-Dict items in `build_ref`

### DIFF
--- a/src/core/base.jl
+++ b/src/core/base.jl
@@ -163,6 +163,8 @@ function build_ref(data::Dict{String,Any})
         if isa(item, Dict)
             item_lookup = Dict([(parse(Int, k), v) for (k,v) in item])
             ref[Symbol(key)] = item_lookup
+        else
+            ref[Symbol(key)] = item
         end
     end
 

--- a/test/matpower.jl
+++ b/test/matpower.jl
@@ -153,5 +153,14 @@ end
         @test data["ne_branch"]["1"]["construction_cost"] == 1
         @test isa(JSON.json(data), String)
     end
+
+    @testset "`build_ref` for 3-bus tnep case" begin
+        data = PowerModels.parse_file("../test/data/case3_tnep.m")
+        ref = PowerModels.build_ref(data)
+        
+        @test haskey(data, "name")
+        @test haskey(ref, :name)
+        @test data["name"] == ref[:name]
+    end
 end
 


### PR DESCRIPTION
needed for some current extensions to PowerModels