### PR TITLE
Adding Deprecated constraint_theta_ref Function

### DIFF
--- a/src/core/constraint_template.jl
+++ b/src/core/constraint_template.jl
@@ -10,6 +10,7 @@
 # and should never refer to model variables
 #
 
+using Base.depwarn
 
 ### Generator Constraints ###
 ""
@@ -28,6 +29,14 @@ end
 function constraint_theta_ref(pm::GenericPowerModel, bus)
     return constraint_theta_ref(pm, bus["index"])
 end
+
+"deprecated in favor of explicit bus-based reference"
+function constraint_theta_ref(pm::GenericPowerModel)
+    (i,bus) = first(pm.ref[:ref_buses])
+    depwarn("constraint_theta_ref without an explicit bus object is deprecated, using to bus $(i) of $(length(pm.ref[:ref_buses])) specified reference buses", :constraint_theta_ref)
+    return constraint_theta_ref(pm, bus["index"])
+end
+
 
 ""
 function constraint_voltage_magnitude_setpoint(pm::GenericPowerModel, bus; epsilon = 0.0)

--- a/src/core/constraint_template.jl
+++ b/src/core/constraint_template.jl
@@ -10,7 +10,6 @@
 # and should never refer to model variables
 #
 
-using Base.depwarn
 
 ### Generator Constraints ###
 ""
@@ -33,10 +32,9 @@ end
 "deprecated in favor of explicit bus-based reference"
 function constraint_theta_ref(pm::GenericPowerModel)
     (i,bus) = first(pm.ref[:ref_buses])
-    depwarn("constraint_theta_ref without an explicit bus object is deprecated, using to bus $(i) of $(length(pm.ref[:ref_buses])) specified reference buses", :constraint_theta_ref)
+    Base.depwarn("constraint_theta_ref(pm) without an explicit bus object is deprecated use constraint_theta_ref(pm, bus) instead; using bus $(i) of $(length(pm.ref[:ref_buses])) specified reference buses", :constraint_theta_ref)
     return constraint_theta_ref(pm, bus["index"])
 end
-
 
 ""
 function constraint_voltage_magnitude_setpoint(pm::GenericPowerModel, bus; epsilon = 0.0)


### PR DESCRIPTION
Adds a depreciation warning for this function, so that this change is non-breaking in next version.