### PR TITLE
Travis Update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,10 @@ os:
 julia:
   - 0.5
   - 0.6
+  - nightly
+matrix:
+  allow_failures:
+    - julia: nightly
 cache:
  directories:
    - /home/travis/.julia

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -4,7 +4,5 @@ Ipopt
 SCS
 GLPKMathProgInterface
 Pajarito 0.4.0
-AmplNLWriter
-CoinOptServices
 
 Logging 0.3.1


### PR DESCRIPTION
Removing CoinOptServices and AmplNLWriter to improve travis build times.  Adding nightly as a fail-able build option.