### PR TITLE
Relaxing logging version in test REQUIRE

### DIFF
--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -5,4 +5,4 @@ SCS
 GLPKMathProgInterface
 Pajarito 0.4.0
 
-Logging 0.3.1
+Logging 0.1.0

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -5,4 +5,4 @@ SCS
 GLPKMathProgInterface
 Pajarito 0.4.0
 
-Logging 0.1.0
+Logging 0.2.0


### PR DESCRIPTION
This is the lowest version that has the correct terminal output.