### PR TITLE
Reporting Solutions in Per Unit, by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ PowerModels.jl Change Log
 
 ### Staged
 - Made solution default units, per unit (breaking)
-- Removed deprecated bus-less constraint_theta_ref function
+- Removed deprecated bus-less constraint_theta_ref function (breaking)
 - Moved check_cost_models into the objective building function
 - Fixed out of range bug in calc_theta_delta_bounds
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@ PowerModels.jl Change Log
 =================
 
 ### Staged
+- Made solution default units, per unit (breaking)
+- Removed deprecated bus-less constraint_theta_ref function
 - Moved check_cost_models into the objective building function
 - Fixed out of range bug in calc_theta_delta_bounds
 

--- a/src/core/constraint_template.jl
+++ b/src/core/constraint_template.jl
@@ -29,13 +29,6 @@ function constraint_theta_ref(pm::GenericPowerModel, bus)
     return constraint_theta_ref(pm, bus["index"])
 end
 
-"deprecated in favor of explicit bus-based reference"
-function constraint_theta_ref(pm::GenericPowerModel)
-    (i,bus) = first(pm.ref[:ref_buses])
-    Base.depwarn("constraint_theta_ref(pm) without an explicit bus object is deprecated use constraint_theta_ref(pm, bus) instead; using bus $(i) of $(length(pm.ref[:ref_buses])) specified reference buses", :constraint_theta_ref)
-    return constraint_theta_ref(pm, bus["index"])
-end
-
 ""
 function constraint_voltage_magnitude_setpoint(pm::GenericPowerModel, bus; epsilon = 0.0)
     @assert epsilon >= 0.0

--- a/src/core/data.jl
+++ b/src/core/data.jl
@@ -89,13 +89,26 @@ function check_keys(data, keys)
     end
 end
 
-"Recursively applies new_data to data, overwritting information"
+
+"recursively applies new_data to data, overwriting information"
 function update_data(data::Dict{String,Any}, new_data::Dict{String,Any})
+    if haskey(data, "per_unit") && haskey(new_data, "per_unit")
+        if data["per_unit"] != new_data["per_unit"]
+            error("update_data requires datasets in the same units, try make_per_unit and make_mixed_units")
+        end
+    else
+        warn("running update_data with data that does not include per_unit field, units may be incorrect")
+    end
+    _update_data(data, new_data)
+end
+
+"recursive call of _update_data"
+function _update_data(data::Dict{String,Any}, new_data::Dict{String,Any})
     for (key, new_v) in new_data
         if haskey(data, key)
             v = data[key]
             if isa(v, Dict) && isa(new_v, Dict)
-                update_data(v, new_v)
+                _update_data(v, new_v)
             else
                 data[key] = new_v
             end
@@ -104,6 +117,7 @@ function update_data(data::Dict{String,Any}, new_data::Dict{String,Any})
         end
     end
 end
+
 
 ""
 function apply_func(data::Dict{String,Any}, key::String, func)

--- a/src/core/solution.jl
+++ b/src/core/solution.jl
@@ -8,7 +8,6 @@ function build_solution(pm::GenericPowerModel, status, solve_time; objective = N
     end
 
     sol = solution_builder(pm)
-    make_mixed_units(sol)
 
     solution = Dict{String,Any}(
         "solver" => string(typeof(pm.model.solver)),

--- a/test/data.jl
+++ b/test/data.jl
@@ -1,0 +1,52 @@
+# Tests of data checking and transformation code
+
+function compare_dict(d1, d2)
+    for (k1,v1) in d1
+        if !haskey(d2, k1)
+            #@test false
+            return false
+        end
+        v2 = d2[k1]
+
+        if isa(v1, Number)
+            #@test isapprox(v1, v2)
+            if !isapprox(v1, v2)
+                return false
+            end
+        elseif isa(v1, Dict)
+            if !compare_dict(v1, v2)
+                return false
+            end
+        else
+            #@test v1 == v2
+            if v1 != v2
+                return false
+            end
+        end
+    end
+    return true
+end
+
+@testset "test idempotent units transformations" begin
+    @testset "3-bus case" begin
+        data = PowerModels.parse_file("../test/data/case3.m")
+        PowerModels.make_mixed_units(data)
+        PowerModels.make_per_unit(data)
+
+        @test compare_dict(data, PowerModels.parse_file("../test/data/case3.m"))
+    end
+    @testset "5-bus case" begin
+        data = PowerModels.parse_file("../test/data/case5_asym.m")
+        PowerModels.make_mixed_units(data)
+        PowerModels.make_per_unit(data)
+
+        @test compare_dict(data, PowerModels.parse_file("../test/data/case5_asym.m"))
+    end
+    @testset "24-bus case" begin
+        data = PowerModels.parse_file("../test/data/case24.m")
+        PowerModels.make_mixed_units(data)
+        PowerModels.make_per_unit(data)
+
+        @test compare_dict(data, PowerModels.parse_file("../test/data/case24.m"))
+    end
+end

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -6,21 +6,21 @@
 
         @test result["status"] == :LocalOptimal
         @test isapprox(result["objective"], 1.3371; atol = 1e-3)
-        @test isapprox(result["solution"]["bus"]["1"]["pd"], 147.1; atol = 1e0)
+        @test isapprox(result["solution"]["bus"]["1"]["pd"], 1.471; atol = 1e-2)
     end
     @testset "5-bus pjm case" begin
         result = run_api_opf("../test/data/case5.m", APIACPPowerModel, ipopt_solver)
 
         @test result["status"] == :LocalOptimal
         @test isapprox(result["objective"], 2.6872; atol = 1e-3)
-        @test isapprox(result["solution"]["bus"]["4"]["pd"], 1075.4; atol = 1e0)
+        @test isapprox(result["solution"]["bus"]["4"]["pd"], 10.754; atol = 1e-2)
     end
     @testset "30-bus ieee case" begin
         result = run_api_opf("../test/data/case30.m", APIACPPowerModel, ipopt_solver)
 
         @test result["status"] == :LocalOptimal
         @test isapprox(result["objective"], 1.6628; atol = 1e-3)
-        @test isapprox(result["solution"]["bus"]["2"]["pd"], 36.1; atol = 1e0)
+        @test isapprox(result["solution"]["bus"]["2"]["pd"], 0.361; atol = 1e-2)
     end
 end
 

--- a/test/output.jl
+++ b/test/output.jl
@@ -40,10 +40,10 @@ end
 
         branches = result["solution"]["branch"]
 
-        @test isapprox(branches["2"]["pf"],  20.01; atol = 1e-1)
-        @test isapprox(branches["2"]["pt"],   -19.80; atol = 1e-1)
-        @test isapprox(branches["2"]["qf"],   0.55; atol = 1e-1)
-        @test isapprox(branches["2"]["qt"],    -5.71; atol = 1e-1)
+        @test isapprox(branches["2"]["pf"],  0.2001; atol = 1e-3)
+        @test isapprox(branches["2"]["pt"], -0.1980; atol = 1e-3)
+        @test isapprox(branches["2"]["qf"],  0.0055; atol = 1e-3)
+        @test isapprox(branches["2"]["qt"], -0.0571; atol = 1e-3)
     end
 
     # A DCPPowerModel test is important because it does have variables for the reverse side of the lines
@@ -60,8 +60,8 @@ end
 
         branches = result["solution"]["branch"]
 
-        @test isapprox(branches["3"]["pf"], -10.3497; atol = 1e-1)
-        @test isapprox(branches["3"]["pt"],  10.3497; atol = 1e-1)
+        @test isapprox(branches["3"]["pf"], -0.103497; atol = 1e-3)
+        @test isapprox(branches["3"]["pt"],  0.103497; atol = 1e-3)
         @test isnan(branches["3"]["qf"])
         @test isnan(branches["3"]["qt"])
     end
@@ -75,14 +75,12 @@ end
         opf_result = run_ac_opf(data, ipopt_solver)
         @test opf_result["status"] == :LocalOptimal
         @test isapprox(opf_result["objective"], 5907; atol = 1e0)
-        PowerModels.make_per_unit(opf_result["solution"])
 
         PowerModels.update_data(data, opf_result["solution"])
 
         pf_result = run_ac_pf(data, ipopt_solver)
         @test pf_result["status"] == :LocalOptimal
         @test isapprox(pf_result["objective"], 0.0; atol = 1e-3)
-        PowerModels.make_per_unit(pf_result["solution"])
 
         for (i,bus) in data["bus"]
             @test isapprox(opf_result["solution"]["bus"][i]["va"], pf_result["solution"]["bus"][i]["va"]; atol = 1e-3)

--- a/test/pf.jl
+++ b/test/pf.jl
@@ -5,18 +5,18 @@
         @test result["status"] == :LocalOptimal
         @test isapprox(result["objective"], 0; atol = 1e-2)
 
-        @test isapprox(result["solution"]["gen"]["2"]["pg"], 160.0063; atol = 1e-1)
-        @test isapprox(result["solution"]["gen"]["3"]["pg"], 0; atol = 1e-1)
+        @test isapprox(result["solution"]["gen"]["2"]["pg"], 1.600063; atol = 1e-3)
+        @test isapprox(result["solution"]["gen"]["3"]["pg"], 0.0; atol = 1e-3)
 
         @test isapprox(result["solution"]["bus"]["1"]["vm"], 1.10000; atol = 1e-3)
         @test isapprox(result["solution"]["bus"]["1"]["va"], 0.00000; atol = 1e-3)
         @test isapprox(result["solution"]["bus"]["2"]["vm"], 0.92617; atol = 1e-3)
         @test isapprox(result["solution"]["bus"]["3"]["vm"], 0.90000; atol = 1e-3)
 
-        @test isapprox(result["solution"]["dcline"]["1"]["pf"],  10; atol = 1e-3)
-        @test isapprox(result["solution"]["dcline"]["1"]["pt"], -10; atol = 1e-3)
-        @test isapprox(result["solution"]["dcline"]["1"]["qf"], -40.3045; atol = 1e-3)
-        @test isapprox(result["solution"]["dcline"]["1"]["qt"],   6.47562; atol = 1e-3)
+        @test isapprox(result["solution"]["dcline"]["1"]["pf"],  0.10; atol = 1e-5)
+        @test isapprox(result["solution"]["dcline"]["1"]["pt"], -0.10; atol = 1e-5)
+        @test isapprox(result["solution"]["dcline"]["1"]["qf"], -0.403045; atol = 1e-5)
+        @test isapprox(result["solution"]["dcline"]["1"]["qt"],  0.0647562; atol = 1e-5)
     end
     @testset "5-bus asymmetric case" begin
         result = run_pf("../test/data/case5_asym.m", ACPPowerModel, ipopt_solver)
@@ -30,7 +30,7 @@
         @test result["status"] == :LocalOptimal
         @test isapprox(result["objective"], 0; atol = 1e-2)
 
-        @test isapprox(result["solution"]["gen"]["3"]["pg"], 333.6866; atol = 1e-1)
+        @test isapprox(result["solution"]["gen"]["3"]["pg"], 3.336866; atol = 1e-3)
 
         @test isapprox(result["solution"]["bus"]["1"]["vm"], 1.0635; atol = 1e-3)
         @test isapprox(result["solution"]["bus"]["2"]["vm"], 1.0808; atol = 1e-3)
@@ -40,8 +40,8 @@
         @test isapprox(result["solution"]["bus"]["5"]["vm"], 1.0530; atol = 1e-3)
 
 
-        @test isapprox(result["solution"]["dcline"]["1"]["pf"], 10; atol = 1e-3)
-        @test isapprox(result["solution"]["dcline"]["1"]["pt"], -8.9; atol = 1e-3)
+        @test isapprox(result["solution"]["dcline"]["1"]["pf"],  0.10; atol = 1e-5)
+        @test isapprox(result["solution"]["dcline"]["1"]["pt"], -0.089; atol = 1e-5)
 
     end
     @testset "6-bus case" begin
@@ -70,11 +70,11 @@ end
         @test result["status"] == :LocalOptimal
         @test isapprox(result["objective"], 0; atol = 1e-2)
 
-        @test isapprox(result["solution"]["gen"]["1"]["pg"], 154.994; atol = 1e-1)
+        @test isapprox(result["solution"]["gen"]["1"]["pg"], 1.54994; atol = 1e-3)
 
-        @test isapprox(result["solution"]["bus"]["1"]["va"], 0.00000; atol = 1e-3)
-        @test isapprox(result["solution"]["bus"]["2"]["va"], 5.24122; atol = 1e-3)
-        @test isapprox(result["solution"]["bus"]["3"]["va"], -16.21006; atol = 1e-3)
+        @test isapprox(result["solution"]["bus"]["1"]["va"],  0.00000; atol = 1e-5)
+        @test isapprox(result["solution"]["bus"]["2"]["va"],  0.09147654582; atol = 1e-5)
+        @test isapprox(result["solution"]["bus"]["3"]["va"], -0.28291891895; atol = 1e-5)
     end
     @testset "5-bus asymmetric case" begin
         result = run_dc_pf("../test/data/case5_asym.m", ipopt_solver)
@@ -87,8 +87,8 @@ end
 
         @test result["status"] == :LocalOptimal
         @test isapprox(result["objective"], 0; atol = 1e-2)
-        @test isapprox(result["solution"]["bus"]["1"]["va"], 0.00000; atol = 1e-3)
-        @test isapprox(result["solution"]["bus"]["4"]["va"], 0.00000; atol = 1e-3)
+        @test isapprox(result["solution"]["bus"]["1"]["va"], 0.00000; atol = 1e-5)
+        @test isapprox(result["solution"]["bus"]["4"]["va"], 0.00000; atol = 1e-5)
     end
     @testset "24-bus rts case" begin
         result = run_pf("../test/data/case24.m", DCPPowerModel, ipopt_solver)
@@ -106,17 +106,17 @@ end
         @test result["status"] == :LocalOptimal
         @test isapprox(result["objective"], 0; atol = 1e-2)
 
-        @test result["solution"]["gen"]["1"]["pg"] >= 148.0
+        @test result["solution"]["gen"]["1"]["pg"] >= 1.480
 
-        @test isapprox(result["solution"]["gen"]["2"]["pg"], 160.0063; atol = 1e-1)
-        @test isapprox(result["solution"]["gen"]["3"]["pg"], 0; atol = 1e-1)
+        @test isapprox(result["solution"]["gen"]["2"]["pg"], 1.600063; atol = 1e-3)
+        @test isapprox(result["solution"]["gen"]["3"]["pg"], 0.0; atol = 1e-3)
 
         @test isapprox(result["solution"]["bus"]["1"]["vm"], 1.09999; atol = 1e-3)
         @test isapprox(result["solution"]["bus"]["2"]["vm"], 0.92616; atol = 1e-3)
         @test isapprox(result["solution"]["bus"]["3"]["vm"], 0.89999; atol = 1e-3)
 
-        @test isapprox(result["solution"]["dcline"]["1"]["pf"], 10; atol = 1e-3)
-        @test isapprox(result["solution"]["dcline"]["1"]["pt"], -10; atol = 1e-3)
+        @test isapprox(result["solution"]["dcline"]["1"]["pf"],  0.10; atol = 1e-5)
+        @test isapprox(result["solution"]["dcline"]["1"]["pt"], -0.10; atol = 1e-5)
     end
     @testset "5-bus asymmetric case" begin
         result = run_pf("../test/data/case5_asym.m", SOCWRPowerModel, ipopt_solver)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -27,6 +27,8 @@ include("output.jl")
 
 include("modify.jl")
 
+include("data.jl")
+
 include("pf.jl")
 
 include("opf.jl")


### PR DESCRIPTION
Currently this kind of operation is sloppy,
```
data = PowerModels.parse_file("../test/data/case3.m")
opf_result = run_ac_opf(data, ipopt_solver)
PowerModels.make_per_unit(data, opf_result["solution"])
PowerModels.update_data(data, opf_result["solution"])
pf_result = run_ac_pf(data, ipopt_solver)
```
because internally data is all in per-unit, but solutions are in mixed units by default.

This PR makes solutions in per-unit by default, so the workflow can be done like this,
```
data = PowerModels.parse_file("../test/data/case3.m")
opf_result = run_ac_opf(data, ipopt_solver)
PowerModels.update_data(data, opf_result["solution"])
pf_result = run_ac_pf(data, ipopt_solver)
```

To get a solution in the old units one simply needs to call,
```
PowerModels.make_mixed_units(data, opf_result["solution"])
```

This change will likely break any code that us using PowerModels, so my plan is to tag the current master as the next v0.3 version, and merge this change in on v0.4.0

Any concerns about this change?  @rb004f @frederikgeth @hakanergun @lroald