### PR TITLE
Idea for Supporting Multiple Networks

### DIFF
--- a/src/PowerModels.jl
+++ b/src/PowerModels.jl
@@ -30,6 +30,7 @@ include("form/shared.jl")
 
 include("prob/pf.jl")
 include("prob/opf.jl")
+include("prob/mpopf.jl")
 include("prob/ots.jl")
 include("prob/misc.jl")
 include("prob/tnep.jl")

--- a/src/core/base.jl
+++ b/src/core/base.jl
@@ -82,14 +82,25 @@ end
 
 ### Helper functions for ignoring the basecase
 
-getref(pm::GenericPowerModel, key::Symbol) = getref(pm, 0, key)
-getref(pm::GenericPowerModel, n::Int, key::Symbol) = pm.ref[:nw][n][key]
+#nw_data(pm::GenericPowerModel, key::String) = nw_ref(pm, 0, key)
+#nw_data(pm::GenericPowerModel, key::String, idx::String) = nw_ref(pm, 0, key, idx)
+#nw_data(pm::GenericPowerModel, n::String, key::String) = pm.data["nw"][n][key]
+#nw_data(pm::GenericPowerModel, n::String, key::String, idx::String) = pm.data[:nw][n][key][idx]
 
-getvar(pm::GenericPowerModel, key::Symbol) = getref(pm, 0, key)
-getvar(pm::GenericPowerModel, n::Int, key::Symbol) = pm.var[:nw][n][key]
+nw_ref(pm::GenericPowerModel, key::Symbol) = nw_ref(pm, 0, key)
+nw_ref(pm::GenericPowerModel, key::Symbol, idx) = nw_ref(pm, 0, key, idx)
+nw_ref(pm::GenericPowerModel, n::Int, key::Symbol) = pm.ref[:nw][n][key]
+nw_ref(pm::GenericPowerModel, n::Int, key::Symbol, idx) = pm.ref[:nw][n][key][idx]
 
-getext(pm::GenericPowerModel, key::Symbol) = getref(pm, 0, key)
-getext(pm::GenericPowerModel, n::Int, key::Symbol) = pm.ext[:nw][n][key]
+nw_var(pm::GenericPowerModel, key::Symbol) = nw_var(pm, 0, key)
+nw_var(pm::GenericPowerModel, key::Symbol, idx) = nw_var(pm, 0, key, idx)
+nw_var(pm::GenericPowerModel, n::Int, key::Symbol) = pm.var[:nw][n][key]
+nw_var(pm::GenericPowerModel, n::Int, key::Symbol, idx) = pm.var[:nw][n][key][idx]
+
+nw_ext(pm::GenericPowerModel, key::Symbol) = nw_ext(pm, 0, key)
+nw_ext(pm::GenericPowerModel, key::Symbol, idx) = nw_ext(pm, 0, key, idx)
+nw_ext(pm::GenericPowerModel, n::Int, key::Symbol) = pm.ext[:nw][n][key]
+nw_ext(pm::GenericPowerModel, n::Int, key::Symbol, idx) = pm.ext[:nw][n][key][idx]
 
 
 # TODO Ask Miles, why do we need to put JuMP. here?  using at top level should bring it in

--- a/src/core/base.jl
+++ b/src/core/base.jl
@@ -19,7 +19,7 @@ type GenericPowerModel{T<:AbstractPowerFormulation}
     setting::Dict{String,Any}
     solution::Dict{String,Any}
     var::Dict{Symbol,Any} # model variable lookup
-    ref::Dict{Symbol,Any} # reference data
+    ref::Dict{Int,Any} # reference data
     ext::Dict{Symbol,Any} # user extentions
 end
 ```
@@ -59,15 +59,18 @@ function GenericPowerModel(data::Dict{String,Any}, T::DataType; setting = Dict{S
 
     # TODO is may be a good place to check component connectivity validity
     # i.e. https://github.com/lanl-ansi/PowerModels.jl/issues/131
+    ref = build_ref(data)
+    vars = Dict{Symbol,Any}(r => Dict{Symbol,Any}() for r in keys(ref))
+    ext = Dict{Symbol,Any}(r => Dict{Symbol,Any}() for r in keys(ref))
 
     pm = GenericPowerModel{T}(
         Model(solver = solver), # model
         data, # data
         setting, # setting
         Dict{String,Any}(), # solution
-        build_ref(data), # refrence data
-        Dict{Symbol,Any}(), # vars
-        Dict{Symbol,Any}() # ext
+        ref,
+        vars,
+        ext
     )
 
     return pm
@@ -158,99 +161,107 @@ If `:ne_branch` exists, then the following keys are also available with similar 
 
 * `:ne_branch`, `:ne_arcs_from`, `:ne_arcs_to`, `:ne_arcs`, `:ne_bus_arcs`, `:ne_buspairs`.
 """
-function build_ref(data::Dict{String,Any})
-    ref = Dict{Symbol,Any}()
-    for (key, item) in data
-        if isa(item, Dict)
-            item_lookup = Dict([(parse(Int, k), v) for (k,v) in item])
-            ref[Symbol(key)] = item_lookup
-        else
-            ref[Symbol(key)] = item
+function build_ref(networks::Dict{String,Any})
+    refs = Dict{Symbol,Any}()
+
+    for (i,data) in networks
+        network_id = Symbol(i)
+
+        ref = refs[network_id] = Dict{Symbol,Any}()
+
+        for (key, item) in data
+            if isa(item, Dict)
+                item_lookup = Dict([(parse(Int, k), v) for (k,v) in item])
+                ref[Symbol(key)] = item_lookup
+            else
+                ref[Symbol(key)] = item
+            end
         end
-    end
 
-    off_angmin, off_angmax = calc_theta_delta_bounds(data)
-    ref[:off_angmin] = off_angmin
-    ref[:off_angmax] = off_angmax
+        off_angmin, off_angmax = calc_theta_delta_bounds(data)
+        ref[:off_angmin] = off_angmin
+        ref[:off_angmax] = off_angmax
 
-    # filter turned off stuff
-    ref[:bus] = filter((i, bus) -> bus["bus_type"] != 4, ref[:bus])
-    ref[:gen] = filter((i, gen) -> gen["gen_status"] == 1 && gen["gen_bus"] in keys(ref[:bus]), ref[:gen])
-    ref[:branch] = filter((i, branch) -> branch["br_status"] == 1 && branch["f_bus"] in keys(ref[:bus]) && branch["t_bus"] in keys(ref[:bus]), ref[:branch])
-    ref[:dcline] = filter((i, dcline) -> dcline["br_status"] == 1 && dcline["f_bus"] in keys(ref[:bus]) && dcline["t_bus"] in keys(ref[:bus]), ref[:dcline])
+        # filter turned off stuff
+        ref[:bus] = filter((i, bus) -> bus["bus_type"] != 4, ref[:bus])
+        ref[:gen] = filter((i, gen) -> gen["gen_status"] == 1 && gen["gen_bus"] in keys(ref[:bus]), ref[:gen])
+        ref[:branch] = filter((i, branch) -> branch["br_status"] == 1 && branch["f_bus"] in keys(ref[:bus]) && branch["t_bus"] in keys(ref[:bus]), ref[:branch])
+        ref[:dcline] = filter((i, dcline) -> dcline["br_status"] == 1 && dcline["f_bus"] in keys(ref[:bus]) && dcline["t_bus"] in keys(ref[:bus]), ref[:dcline])
 
-    ref[:arcs_from] = [(i,branch["f_bus"],branch["t_bus"]) for (i,branch) in ref[:branch]]
-    ref[:arcs_to]   = [(i,branch["t_bus"],branch["f_bus"]) for (i,branch) in ref[:branch]]
-    ref[:arcs] = [ref[:arcs_from]; ref[:arcs_to]]
+        ref[:arcs_from] = [(i,branch["f_bus"],branch["t_bus"]) for (i,branch) in ref[:branch]]
+        ref[:arcs_to]   = [(i,branch["t_bus"],branch["f_bus"]) for (i,branch) in ref[:branch]]
+        ref[:arcs] = [ref[:arcs_from]; ref[:arcs_to]]
 
-    ref[:arcs_from_dc] = [(i,dcline["f_bus"],dcline["t_bus"]) for (i,dcline) in ref[:dcline]]
-    ref[:arcs_to_dc]   = [(i,dcline["t_bus"],dcline["f_bus"]) for (i,dcline) in ref[:dcline]]
-    ref[:arcs_dc] = [ref[:arcs_from_dc]; ref[:arcs_to_dc]]
+        ref[:arcs_from_dc] = [(i,dcline["f_bus"],dcline["t_bus"]) for (i,dcline) in ref[:dcline]]
+        ref[:arcs_to_dc]   = [(i,dcline["t_bus"],dcline["f_bus"]) for (i,dcline) in ref[:dcline]]
+        ref[:arcs_dc] = [ref[:arcs_from_dc]; ref[:arcs_to_dc]]
 
-    bus_gens = Dict([(i, []) for (i,bus) in ref[:bus]])
-    for (i,gen) in ref[:gen]
-        push!(bus_gens[gen["gen_bus"]], i)
-    end
-    ref[:bus_gens] = bus_gens
-
-    bus_arcs = Dict([(i, []) for (i,bus) in ref[:bus]])
-    for (l,i,j) in ref[:arcs]
-        push!(bus_arcs[i], (l,i,j))
-    end
-    ref[:bus_arcs] = bus_arcs
-
-    bus_arcs_dc = Dict([(i, []) for (i,bus) in ref[:bus]])
-    for (l,i,j) in ref[:arcs_dc]
-        push!(bus_arcs_dc[i], (l,i,j))
-    end
-    ref[:bus_arcs_dc] = bus_arcs_dc
-
-    # a set of buses to support multiple connected components
-    ref_buses = Dict()
-    for (k,v) in ref[:bus]
-        if v["bus_type"] == 3
-            ref_buses[k] = v
+        bus_gens = Dict([(i, []) for (i,bus) in ref[:bus]])
+        for (i,gen) in ref[:gen]
+            push!(bus_gens[gen["gen_bus"]], i)
         end
-    end
+        ref[:bus_gens] = bus_gens
 
-    if length(ref_buses) == 0
-        big_gen = biggest_generator(ref[:gen])
-        gen_bus = big_gen["gen_bus"]
-        ref_buses[gen_bus] = ref[:bus][gen_bus]
-        warn("no reference bus found, setting bus $(gen_bus) as reference based on generator $(big_gen["index"])")
-    end
-
-    if length(ref_buses) > 1
-        warn("multiple reference buses found, $(keys(ref_buses)), this can cause infeasibility if they are in the same connected component")
-    end
-
-    ref[:ref_buses] = ref_buses
-
-
-    ref[:buspairs] = buspair_parameters(ref[:arcs_from], ref[:branch], ref[:bus])
-    ############################ DC LINES##########################################
-    if haskey(ref, :dcline)
-        ref[:buspairs_dc] = buspair_parameters_dc(ref[:arcs_from_dc], ref[:dcline], ref[:bus])
-    end
-    ###############################################################################
-
-    if haskey(ref, :ne_branch)
-        ref[:ne_branch] = filter((i, branch) -> branch["br_status"] == 1 && branch["f_bus"] in keys(ref[:bus]) && branch["t_bus"] in keys(ref[:bus]), ref[:ne_branch])
-
-        ref[:ne_arcs_from] = [(i,branch["f_bus"],branch["t_bus"]) for (i,branch) in ref[:ne_branch]]
-        ref[:ne_arcs_to]   = [(i,branch["t_bus"],branch["f_bus"]) for (i,branch) in ref[:ne_branch]]
-        ref[:ne_arcs] = [ref[:ne_arcs_from]; ref[:ne_arcs_to]]
-
-        ne_bus_arcs = Dict([(i, []) for (i,bus) in ref[:bus]])
-        for (l,i,j) in ref[:ne_arcs]
-            push!(ne_bus_arcs[i], (l,i,j))
+        bus_arcs = Dict([(i, []) for (i,bus) in ref[:bus]])
+        for (l,i,j) in ref[:arcs]
+            push!(bus_arcs[i], (l,i,j))
         end
-        ref[:ne_bus_arcs] = ne_bus_arcs
+        ref[:bus_arcs] = bus_arcs
 
-        ref[:ne_buspairs] = buspair_parameters(ref[:ne_arcs_from], ref[:ne_branch], ref[:bus])
+        bus_arcs_dc = Dict([(i, []) for (i,bus) in ref[:bus]])
+        for (l,i,j) in ref[:arcs_dc]
+            push!(bus_arcs_dc[i], (l,i,j))
+        end
+        ref[:bus_arcs_dc] = bus_arcs_dc
+
+        # a set of buses to support multiple connected components
+        ref_buses = Dict()
+        for (k,v) in ref[:bus]
+            if v["bus_type"] == 3
+                ref_buses[k] = v
+            end
+        end
+
+        if length(ref_buses) == 0
+            big_gen = biggest_generator(ref[:gen])
+            gen_bus = big_gen["gen_bus"]
+            ref_buses[gen_bus] = ref[:bus][gen_bus]
+            warn("no reference bus found, setting bus $(gen_bus) as reference based on generator $(big_gen["index"])")
+        end
+
+        if length(ref_buses) > 1
+            warn("multiple reference buses found, $(keys(ref_buses)), this can cause infeasibility if they are in the same connected component")
+        end
+
+        ref[:ref_buses] = ref_buses
+
+
+        ref[:buspairs] = buspair_parameters(ref[:arcs_from], ref[:branch], ref[:bus])
+        ############################ DC LINES##########################################
+        if haskey(ref, :dcline)
+            ref[:buspairs_dc] = buspair_parameters_dc(ref[:arcs_from_dc], ref[:dcline], ref[:bus])
+        end
+        ###############################################################################
+
+        if haskey(ref, :ne_branch)
+            ref[:ne_branch] = filter((i, branch) -> branch["br_status"] == 1 && branch["f_bus"] in keys(ref[:bus]) && branch["t_bus"] in keys(ref[:bus]), ref[:ne_branch])
+
+            ref[:ne_arcs_from] = [(i,branch["f_bus"],branch["t_bus"]) for (i,branch) in ref[:ne_branch]]
+            ref[:ne_arcs_to]   = [(i,branch["t_bus"],branch["f_bus"]) for (i,branch) in ref[:ne_branch]]
+            ref[:ne_arcs] = [ref[:ne_arcs_from]; ref[:ne_arcs_to]]
+
+            ne_bus_arcs = Dict([(i, []) for (i,bus) in ref[:bus]])
+            for (l,i,j) in ref[:ne_arcs]
+                push!(ne_bus_arcs[i], (l,i,j))
+            end
+            ref[:ne_bus_arcs] = ne_bus_arcs
+
+            ref[:ne_buspairs] = buspair_parameters(ref[:ne_arcs_from], ref[:ne_branch], ref[:bus])
+        end
+
     end
 
-    return ref
+    return refs
 end
 
 

--- a/src/core/base.jl
+++ b/src/core/base.jl
@@ -75,6 +75,18 @@ function GenericPowerModel(data::Dict{String,Any}, T::DataType; setting = Dict{S
 end
 
 
+### Helper functions for ignoring the basecase
+
+getref(pm::GenericPowerModel, key::Symbol) = getref(pm, :base, key)
+getref(pm::GenericPowerModel, n::Symbol, key::Symbol) = pm.ref[n][key]
+
+getvar(pm::GenericPowerModel, key::Symbol) = getref(pm, :base, key)
+getvar(pm::GenericPowerModel, n::Symbol, key::Symbol) = pm.vars[n][key]
+
+getext(pm::GenericPowerModel, key::Symbol) = getref(pm, :base, key)
+getext(pm::GenericPowerModel, n::Symbol, key::Symbol) = pm.ext[n][key]
+
+
 # TODO Ask Miles, why do we need to put JuMP. here?  using at top level should bring it in
 function JuMP.setsolver(pm::GenericPowerModel, solver::MathProgBase.AbstractMathProgSolver)
     setsolver(pm.model, solver)

--- a/src/core/base.jl
+++ b/src/core/base.jl
@@ -81,7 +81,7 @@ getref(pm::GenericPowerModel, key::Symbol) = getref(pm, :base, key)
 getref(pm::GenericPowerModel, n::Symbol, key::Symbol) = pm.ref[n][key]
 
 getvar(pm::GenericPowerModel, key::Symbol) = getref(pm, :base, key)
-getvar(pm::GenericPowerModel, n::Symbol, key::Symbol) = pm.vars[n][key]
+getvar(pm::GenericPowerModel, n::Symbol, key::Symbol) = pm.var[n][key]
 
 getext(pm::GenericPowerModel, key::Symbol) = getref(pm, :base, key)
 getext(pm::GenericPowerModel, n::Symbol, key::Symbol) = pm.ext[n][key]

--- a/src/core/constraint.jl
+++ b/src/core/constraint.jl
@@ -6,17 +6,17 @@
 
 # Generic thermal limit constraint
 "`p[f_idx]^2 + q[f_idx]^2 <= rate_a^2`"
-function constraint_thermal_limit_from(pm::GenericPowerModel, n::Symbol, f_idx, rate_a)
-    p_fr = pm.var[n][:p][f_idx]
-    q_fr = pm.var[n][:q][f_idx]
+function constraint_thermal_limit_from(pm::GenericPowerModel, n::Int, f_idx, rate_a)
+    p_fr = pm.var[:nw][n][:p][f_idx]
+    q_fr = pm.var[:nw][n][:q][f_idx]
     c = @constraint(pm.model, p_fr^2 + q_fr^2 <= rate_a^2)
     return Set([c])
 end
 
 "`p[t_idx]^2 + q[t_idx]^2 <= rate_a^2`"
-function constraint_thermal_limit_to(pm::GenericPowerModel, n::Symbol, t_idx, rate_a)
-    p_to = pm.var[n][:p][t_idx]
-    q_to = pm.var[n][:q][t_idx]
+function constraint_thermal_limit_to(pm::GenericPowerModel, n::Int, t_idx, rate_a)
+    p_to = pm.var[:nw][n][:p][t_idx]
+    q_to = pm.var[:nw][n][:q][t_idx]
     c = @constraint(pm.model, p_to^2 + q_to^2 <= rate_a^2)
     return Set([c])
 end

--- a/src/core/constraint.jl
+++ b/src/core/constraint.jl
@@ -6,17 +6,17 @@
 
 # Generic thermal limit constraint
 "`p[f_idx]^2 + q[f_idx]^2 <= rate_a^2`"
-function constraint_thermal_limit_from(pm::GenericPowerModel, r::Symbol, f_idx, rate_a)
-    p_fr = pm.var[r][:p][f_idx]
-    q_fr = pm.var[r][:q][f_idx]
+function constraint_thermal_limit_from(pm::GenericPowerModel, n::Symbol, f_idx, rate_a)
+    p_fr = pm.var[n][:p][f_idx]
+    q_fr = pm.var[n][:q][f_idx]
     c = @constraint(pm.model, p_fr^2 + q_fr^2 <= rate_a^2)
     return Set([c])
 end
 
 "`p[t_idx]^2 + q[t_idx]^2 <= rate_a^2`"
-function constraint_thermal_limit_to(pm::GenericPowerModel, r::Symbol, t_idx, rate_a)
-    p_to = pm.var[r][:p][t_idx]
-    q_to = pm.var[r][:q][t_idx]
+function constraint_thermal_limit_to(pm::GenericPowerModel, n::Symbol, t_idx, rate_a)
+    p_to = pm.var[n][:p][t_idx]
+    q_to = pm.var[n][:q][t_idx]
     c = @constraint(pm.model, p_to^2 + q_to^2 <= rate_a^2)
     return Set([c])
 end

--- a/src/core/constraint.jl
+++ b/src/core/constraint.jl
@@ -22,17 +22,17 @@ function constraint_thermal_limit_to(pm::GenericPowerModel, n::Int, t_idx, rate_
 end
 
 "`norm([p[f_idx]; q[f_idx]]) <= rate_a`"
-function constraint_thermal_limit_from{T <: AbstractConicPowerFormulation}(pm::GenericPowerModel{T}, f_idx, rate_a)
-    p_fr = pm.var[:p][f_idx]
-    q_fr = pm.var[:q][f_idx]
+function constraint_thermal_limit_from{T <: AbstractConicPowerFormulation}(pm::GenericPowerModel{T}, n::Int, f_idx, rate_a)
+    p_fr = pm.var[:nw][n][:p][f_idx]
+    q_fr = pm.var[:nw][n][:q][f_idx]
     c = @constraint(pm.model, norm([p_fr; q_fr]) <= rate_a)
     return Set([c])
 end
 
 "`norm([p[t_idx]; q[t_idx]]) <= rate_a`"
-function constraint_thermal_limit_to{T <: AbstractConicPowerFormulation}(pm::GenericPowerModel{T}, t_idx, rate_a)
-    p_to = pm.var[:p][t_idx]
-    q_to = pm.var[:q][t_idx]
+function constraint_thermal_limit_to{T <: AbstractConicPowerFormulation}(pm::GenericPowerModel{T}, n::Int, t_idx, rate_a)
+    p_to = pm.var[:nw][n][:p][t_idx]
+    q_to = pm.var[:nw][n][:q][t_idx]
     c = @constraint(pm.model, norm([p_to; q_to]) <= rate_a)
     return Set([c])
 end
@@ -76,15 +76,15 @@ function constraint_thermal_limit_to_ne(pm::GenericPowerModel, i, t_idx, rate_a)
 end
 
 "`pg[i] == pg`"
-function constraint_active_gen_setpoint(pm::GenericPowerModel, i, pg)
-    pg_var = pm.var[:pg][i]
+function constraint_active_gen_setpoint(pm::GenericPowerModel, n::Int, i, pg)
+    pg_var = pm.var[:nw][n][:pg][i]
     c = @constraint(pm.model, pg_var == pg)
     return Set([c])
 end
 
 "`qq[i] == qq`"
-function constraint_reactive_gen_setpoint(pm::GenericPowerModel, i, qg)
-    qg_var = pm.var[:qg][i]
+function constraint_reactive_gen_setpoint(pm::GenericPowerModel, n::Int, i, qg)
+    qg_var = pm.var[:nw][n][:qg][i]
     c = @constraint(pm.model, qg_var == qg)
     return Set([c])
 end
@@ -96,18 +96,18 @@ Creates Line Flow constraint for DC Lines (Matpower Formulation)
 p_fr + p_to == loss0 + p_fr * loss1
 ```
 """
-function constraint_dcline{T}(pm::GenericPowerModel{T}, f_bus, t_bus, f_idx, t_idx, loss0, loss1)
-    p_fr = pm.var[:p_dc][f_idx]
-    p_to = pm.var[:p_dc][t_idx]
+function constraint_dcline{T}(pm::GenericPowerModel{T}, n::Int, f_bus, t_bus, f_idx, t_idx, loss0, loss1)
+    p_fr = pm.var[:nw][n][:p_dc][f_idx]
+    p_to = pm.var[:nw][n][:p_dc][t_idx]
 
     c1 = @constraint(pm.model, (1-loss1) * p_fr + (p_to - loss0) == 0)
     return Set([c1])
 end
 
 "`pf[i] == pf, pt[i] == pt`"
-function constraint_active_dcline_setpoint(pm::GenericPowerModel, i, f_idx, t_idx, pf, pt, epsilon)
-    p_fr = pm.var[:p_dc][f_idx]
-    p_to = pm.var[:p_dc][t_idx]
+function constraint_active_dcline_setpoint(pm::GenericPowerModel, n::Int, i, f_idx, t_idx, pf, pt, epsilon)
+    p_fr = pm.var[:nw][n][:p_dc][f_idx]
+    p_to = pm.var[:nw][n][:p_dc][t_idx]
 
     if epsilon == 0.0
         c1 = @constraint(pm.model, p_fr == pf)

--- a/src/core/constraint.jl
+++ b/src/core/constraint.jl
@@ -6,17 +6,17 @@
 
 # Generic thermal limit constraint
 "`p[f_idx]^2 + q[f_idx]^2 <= rate_a^2`"
-function constraint_thermal_limit_from(pm::GenericPowerModel, f_idx, rate_a)
-    p_fr = pm.var[:p][f_idx]
-    q_fr = pm.var[:q][f_idx]
+function constraint_thermal_limit_from(pm::GenericPowerModel, r::Symbol, f_idx, rate_a)
+    p_fr = pm.var[r][:p][f_idx]
+    q_fr = pm.var[r][:q][f_idx]
     c = @constraint(pm.model, p_fr^2 + q_fr^2 <= rate_a^2)
     return Set([c])
 end
 
 "`p[t_idx]^2 + q[t_idx]^2 <= rate_a^2`"
-function constraint_thermal_limit_to(pm::GenericPowerModel, t_idx, rate_a)
-    p_to = pm.var[:p][t_idx]
-    q_to = pm.var[:q][t_idx]
+function constraint_thermal_limit_to(pm::GenericPowerModel, r::Symbol, t_idx, rate_a)
+    p_to = pm.var[r][:p][t_idx]
+    q_to = pm.var[r][:q][t_idx]
     c = @constraint(pm.model, p_to^2 + q_to^2 <= rate_a^2)
     return Set([c])
 end

--- a/src/core/constraint_template.jl
+++ b/src/core/constraint_template.jl
@@ -26,8 +26,8 @@ end
 
 ""
 constraint_theta_ref(pm::GenericPowerModel, bus) = constraint_theta_ref(pm, :base, bus)
-function constraint_theta_ref(pm::GenericPowerModel, r::Symbol, bus)
-    return constraint_theta_ref(pm, r, bus["index"])
+function constraint_theta_ref(pm::GenericPowerModel, n::Symbol, bus)
+    return constraint_theta_ref(pm, n, bus["index"])
 end
 
 
@@ -41,13 +41,13 @@ end
 
 ""
 constraint_kcl_shunt(pm::GenericPowerModel, bus) = constraint_kcl_shunt(pm, :base, bus)
-function constraint_kcl_shunt(pm::GenericPowerModel, r::Symbol, bus)
+function constraint_kcl_shunt(pm::GenericPowerModel, n::Symbol, bus)
     i = bus["index"]
-    bus_arcs = pm.ref[r][:bus_arcs][i]
-    bus_arcs_dc = pm.ref[r][:bus_arcs_dc][i]
-    bus_gens = pm.ref[r][:bus_gens][i]
+    bus_arcs = pm.ref[n][:bus_arcs][i]
+    bus_arcs_dc = pm.ref[n][:bus_arcs_dc][i]
+    bus_gens = pm.ref[n][:bus_gens][i]
 
-    return constraint_kcl_shunt(pm, r, i, bus_arcs, bus_arcs_dc, bus_gens, bus["pd"], bus["qd"], bus["gs"], bus["bs"])
+    return constraint_kcl_shunt(pm, n, i, bus_arcs, bus_arcs_dc, bus_gens, bus["pd"], bus["qd"], bus["gs"], bus["bs"])
 end
 
 ""
@@ -66,7 +66,7 @@ end
 
 ""
 constraint_ohms_yt_from(pm::GenericPowerModel, branch) = constraint_ohms_yt_from(pm, :base, branch)
-function constraint_ohms_yt_from(pm::GenericPowerModel, r::Symbol, branch)
+function constraint_ohms_yt_from(pm::GenericPowerModel, n::Symbol, branch)
     i = branch["index"]
     f_bus = branch["f_bus"]
     t_bus = branch["t_bus"]
@@ -78,13 +78,13 @@ function constraint_ohms_yt_from(pm::GenericPowerModel, r::Symbol, branch)
     c = branch["br_b"]
     tm = branch["tap"]^2
 
-    return constraint_ohms_yt_from(pm, r, f_bus, t_bus, f_idx, t_idx, g, b, c, tr, ti, tm)
+    return constraint_ohms_yt_from(pm, n, f_bus, t_bus, f_idx, t_idx, g, b, c, tr, ti, tm)
 end
 
 
 ""
 constraint_ohms_yt_to(pm::GenericPowerModel, branch) = constraint_ohms_yt_to(pm, :base, branch)
-function constraint_ohms_yt_to(pm::GenericPowerModel, r::Symbol, branch)
+function constraint_ohms_yt_to(pm::GenericPowerModel, n::Symbol, branch)
     i = branch["index"]
     f_bus = branch["f_bus"]
     t_bus = branch["t_bus"]
@@ -96,7 +96,7 @@ function constraint_ohms_yt_to(pm::GenericPowerModel, r::Symbol, branch)
     c = branch["br_b"]
     tm = branch["tap"]^2
 
-    return constraint_ohms_yt_to(pm, r, f_bus, t_bus, f_idx, t_idx, g, b, c, tr, ti, tm)
+    return constraint_ohms_yt_to(pm, n, f_bus, t_bus, f_idx, t_idx, g, b, c, tr, ti, tm)
 end
 
 
@@ -312,24 +312,24 @@ end
 
 ""
 constraint_thermal_limit_from(pm::GenericPowerModel, branch; kwargs...) = constraint_thermal_limit_from(pm, :base, branch; kwargs...)
-function constraint_thermal_limit_from(pm::GenericPowerModel, r::Symbol, branch; scale = 1.0)
+function constraint_thermal_limit_from(pm::GenericPowerModel, n::Symbol, branch; scale = 1.0)
     i = branch["index"]
     f_bus = branch["f_bus"]
     t_bus = branch["t_bus"]
     f_idx = (i, f_bus, t_bus)
 
-    return constraint_thermal_limit_from(pm, r, f_idx, branch["rate_a"]*scale)
+    return constraint_thermal_limit_from(pm, n, f_idx, branch["rate_a"]*scale)
 end
 
 ""
 constraint_thermal_limit_to(pm::GenericPowerModel, branch; kwargs...) = constraint_thermal_limit_to(pm, :base, branch; kwargs...)
-function constraint_thermal_limit_to(pm::GenericPowerModel, r::Symbol, branch; scale = 1.0)
+function constraint_thermal_limit_to(pm::GenericPowerModel, n::Symbol, branch; scale = 1.0)
     i = branch["index"]
     f_bus = branch["f_bus"]
     t_bus = branch["t_bus"]
     t_idx = (i, t_bus, f_bus)
 
-    return constraint_thermal_limit_to(pm, r, t_idx, branch["rate_a"]*scale)
+    return constraint_thermal_limit_to(pm, n, t_idx, branch["rate_a"]*scale)
 end
 
 ""
@@ -376,15 +376,15 @@ end
 
 ""
 constraint_phase_angle_difference(pm::GenericPowerModel, branch) = constraint_phase_angle_difference(pm, :base, branch)
-function constraint_phase_angle_difference(pm::GenericPowerModel, r::Symbol, branch)
+function constraint_phase_angle_difference(pm::GenericPowerModel, n::Symbol, branch)
     i = branch["index"]
     f_bus = branch["f_bus"]
     t_bus = branch["t_bus"]
     pair = (f_bus, t_bus)
-    buspair = pm.ref[r][:buspairs][pair]
+    buspair = pm.ref[n][:buspairs][pair]
 
     if buspair["line"] == i
-        return constraint_phase_angle_difference(pm, r, f_bus, t_bus, buspair["angmin"], buspair["angmax"])
+        return constraint_phase_angle_difference(pm, n, f_bus, t_bus, buspair["angmin"], buspair["angmax"])
     end
     return Set()
 end

--- a/src/core/constraint_template.jl
+++ b/src/core/constraint_template.jl
@@ -25,8 +25,8 @@ end
 ### Bus - Setpoint Constraints ###
 
 ""
-constraint_theta_ref(pm::GenericPowerModel, bus) = constraint_theta_ref(pm, :base, bus)
-function constraint_theta_ref(pm::GenericPowerModel, n::Symbol, bus)
+constraint_theta_ref(pm::GenericPowerModel, bus) = constraint_theta_ref(pm, 0, bus)
+function constraint_theta_ref(pm::GenericPowerModel, n::Int, bus)
     return constraint_theta_ref(pm, n, bus["index"])
 end
 
@@ -40,12 +40,12 @@ end
 ### Bus - KCL Constraints ###
 
 ""
-constraint_kcl_shunt(pm::GenericPowerModel, bus) = constraint_kcl_shunt(pm, :base, bus)
-function constraint_kcl_shunt(pm::GenericPowerModel, n::Symbol, bus)
+constraint_kcl_shunt(pm::GenericPowerModel, bus) = constraint_kcl_shunt(pm, 0, bus)
+function constraint_kcl_shunt(pm::GenericPowerModel, n::Int, bus)
     i = bus["index"]
-    bus_arcs = pm.ref[n][:bus_arcs][i]
-    bus_arcs_dc = pm.ref[n][:bus_arcs_dc][i]
-    bus_gens = pm.ref[n][:bus_gens][i]
+    bus_arcs = pm.ref[:nw][n][:bus_arcs][i]
+    bus_arcs_dc = pm.ref[:nw][n][:bus_arcs_dc][i]
+    bus_gens = pm.ref[:nw][n][:bus_gens][i]
 
     return constraint_kcl_shunt(pm, n, i, bus_arcs, bus_arcs_dc, bus_gens, bus["pd"], bus["qd"], bus["gs"], bus["bs"])
 end
@@ -65,8 +65,8 @@ end
 
 
 ""
-constraint_ohms_yt_from(pm::GenericPowerModel, branch) = constraint_ohms_yt_from(pm, :base, branch)
-function constraint_ohms_yt_from(pm::GenericPowerModel, n::Symbol, branch)
+constraint_ohms_yt_from(pm::GenericPowerModel, branch) = constraint_ohms_yt_from(pm, 0, branch)
+function constraint_ohms_yt_from(pm::GenericPowerModel, n::Int, branch)
     i = branch["index"]
     f_bus = branch["f_bus"]
     t_bus = branch["t_bus"]
@@ -83,8 +83,8 @@ end
 
 
 ""
-constraint_ohms_yt_to(pm::GenericPowerModel, branch) = constraint_ohms_yt_to(pm, :base, branch)
-function constraint_ohms_yt_to(pm::GenericPowerModel, n::Symbol, branch)
+constraint_ohms_yt_to(pm::GenericPowerModel, branch) = constraint_ohms_yt_to(pm, 0, branch)
+function constraint_ohms_yt_to(pm::GenericPowerModel, n::Int, branch)
     i = branch["index"]
     f_bus = branch["f_bus"]
     t_bus = branch["t_bus"]
@@ -311,8 +311,8 @@ end
 ### Branch - Thermal Limit Constraints ###
 
 ""
-constraint_thermal_limit_from(pm::GenericPowerModel, branch; kwargs...) = constraint_thermal_limit_from(pm, :base, branch; kwargs...)
-function constraint_thermal_limit_from(pm::GenericPowerModel, n::Symbol, branch; scale = 1.0)
+constraint_thermal_limit_from(pm::GenericPowerModel, branch; kwargs...) = constraint_thermal_limit_from(pm, 0, branch; kwargs...)
+function constraint_thermal_limit_from(pm::GenericPowerModel, n::Int, branch; scale = 1.0)
     i = branch["index"]
     f_bus = branch["f_bus"]
     t_bus = branch["t_bus"]
@@ -322,8 +322,8 @@ function constraint_thermal_limit_from(pm::GenericPowerModel, n::Symbol, branch;
 end
 
 ""
-constraint_thermal_limit_to(pm::GenericPowerModel, branch; kwargs...) = constraint_thermal_limit_to(pm, :base, branch; kwargs...)
-function constraint_thermal_limit_to(pm::GenericPowerModel, n::Symbol, branch; scale = 1.0)
+constraint_thermal_limit_to(pm::GenericPowerModel, branch; kwargs...) = constraint_thermal_limit_to(pm, 0, branch; kwargs...)
+function constraint_thermal_limit_to(pm::GenericPowerModel, n::Int, branch; scale = 1.0)
     i = branch["index"]
     f_bus = branch["f_bus"]
     t_bus = branch["t_bus"]
@@ -375,13 +375,13 @@ end
 ### Branch - Phase Angle Difference Constraints ###
 
 ""
-constraint_phase_angle_difference(pm::GenericPowerModel, branch) = constraint_phase_angle_difference(pm, :base, branch)
-function constraint_phase_angle_difference(pm::GenericPowerModel, n::Symbol, branch)
+constraint_phase_angle_difference(pm::GenericPowerModel, branch) = constraint_phase_angle_difference(pm, 0, branch)
+function constraint_phase_angle_difference(pm::GenericPowerModel, n::Int, branch)
     i = branch["index"]
     f_bus = branch["f_bus"]
     t_bus = branch["t_bus"]
     pair = (f_bus, t_bus)
-    buspair = pm.ref[n][:buspairs][pair]
+    buspair = pm.ref[:nw][n][:buspairs][pair]
 
     if buspair["line"] == i
         return constraint_phase_angle_difference(pm, n, f_bus, t_bus, buspair["angmin"], buspair["angmax"])

--- a/src/core/constraint_template.jl
+++ b/src/core/constraint_template.jl
@@ -13,13 +13,15 @@
 
 ### Generator Constraints ###
 ""
-function constraint_active_gen_setpoint(pm::GenericPowerModel, gen)
-    return constraint_active_gen_setpoint(pm, gen["index"], gen["pg"])
+constraint_active_gen_setpoint(pm::GenericPowerModel, gen) = constraint_active_gen_setpoint(pm, 0, gen)
+function constraint_active_gen_setpoint(pm::GenericPowerModel, n::Int, gen)
+    return constraint_active_gen_setpoint(pm, n, gen["index"], gen["pg"])
 end
 
 ""
-function constraint_reactive_gen_setpoint(pm::GenericPowerModel, gen)
-    return constraint_reactive_gen_setpoint(pm, gen["index"], gen["qg"])
+constraint_reactive_gen_setpoint(pm::GenericPowerModel, gen) = constraint_reactive_gen_setpoint(pm, 0, gen)
+function constraint_reactive_gen_setpoint(pm::GenericPowerModel, n::Int, gen)
+    return constraint_reactive_gen_setpoint(pm, n, gen["index"], gen["qg"])
 end
 
 ### Bus - Setpoint Constraints ###
@@ -32,9 +34,10 @@ end
 
 
 ""
-function constraint_voltage_magnitude_setpoint(pm::GenericPowerModel, bus; epsilon = 0.0)
+constraint_voltage_magnitude_setpoint(pm::GenericPowerModel, bus; kwargs...) = constraint_voltage_magnitude_setpoint(pm, 0, bus; kwargs...)
+function constraint_voltage_magnitude_setpoint(pm::GenericPowerModel, n::Int, bus; epsilon = 0.0)
     @assert epsilon >= 0.0
-    return constraint_voltage_magnitude_setpoint(pm, bus["index"], bus["vm"], epsilon)
+    return constraint_voltage_magnitude_setpoint(pm, n, bus["index"], bus["vm"], epsilon)
 end
 
 ### Bus - KCL Constraints ###
@@ -103,7 +106,8 @@ end
 ### Branch - Loss Constraints DC LINES###
 
 ""
-function constraint_dcline(pm::GenericPowerModel, dcline)
+constraint_dcline(pm::GenericPowerModel, dcline) = constraint_dcline(pm, 0, dcline)
+function constraint_dcline(pm::GenericPowerModel, n::Int, dcline)
     i = dcline["index"]
     f_bus = dcline["f_bus"]
     t_bus = dcline["t_bus"]
@@ -112,12 +116,13 @@ function constraint_dcline(pm::GenericPowerModel, dcline)
     loss0 = dcline["loss0"]
     loss1 = dcline["loss1"]
 
-    return constraint_dcline(pm, f_bus, t_bus, f_idx, t_idx, loss0, loss1)
+    return constraint_dcline(pm, n, f_bus, t_bus, f_idx, t_idx, loss0, loss1)
 end
 
 
 ""
-function constraint_voltage_dcline_setpoint(pm::GenericPowerModel, dcline; epsilon = 0.0)
+constraint_voltage_dcline_setpoint(pm::GenericPowerModel, dcline; kwargs...) = constraint_voltage_dcline_setpoint(pm, 0, dcline; kwargs...)
+function constraint_voltage_dcline_setpoint(pm::GenericPowerModel, n::Int, dcline; epsilon = 0.0)
     @assert epsilon >= 0.0
     i = dcline["index"]
     f_bus = dcline["f_bus"]
@@ -125,10 +130,11 @@ function constraint_voltage_dcline_setpoint(pm::GenericPowerModel, dcline; epsil
     vf = dcline["vf"]
     vt = dcline["vt"]
 
-    return constraint_voltage_dcline_setpoint(pm, f_bus, t_bus, vf, vt, epsilon)
+    return constraint_voltage_dcline_setpoint(pm, n, f_bus, t_bus, vf, vt, epsilon)
 end
 
-function constraint_active_dcline_setpoint(pm::GenericPowerModel, dcline; epsilon = 0.0)
+constraint_active_dcline_setpoint(pm::GenericPowerModel, dcline; kwargs...) = constraint_active_dcline_setpoint(pm, 0, dcline; kwargs...)
+function constraint_active_dcline_setpoint(pm::GenericPowerModel, n::Int, dcline; epsilon = 0.0)
     i = dcline["index"]
     f_bus = dcline["f_bus"]
     t_bus = dcline["t_bus"]
@@ -137,7 +143,7 @@ function constraint_active_dcline_setpoint(pm::GenericPowerModel, dcline; epsilo
     pf = dcline["pf"]
     pt = dcline["pt"]
 
-    return constraint_active_dcline_setpoint(pm, i, f_idx, t_idx, pf, pt, epsilon)
+    return constraint_active_dcline_setpoint(pm, n, i, f_idx, t_idx, pf, pt, epsilon)
 end
 
 
@@ -255,7 +261,8 @@ end
 ### Branch - Current ###
 
 ""
-function constraint_power_magnitude_sqr(pm::GenericPowerModel, branch)
+constraint_power_magnitude_sqr(pm::GenericPowerModel, branch) = constraint_power_magnitude_sqr(pm, 0, branch)
+function constraint_power_magnitude_sqr(pm::GenericPowerModel, n::Int, branch)
     i = branch["index"]
     f_bus = branch["f_bus"]
     t_bus = branch["t_bus"]
@@ -263,7 +270,7 @@ function constraint_power_magnitude_sqr(pm::GenericPowerModel, branch)
 
     tm = branch["tap"]^2
 
-    return constraint_power_magnitude_sqr(pm, f_bus, t_bus, arc_from, tm)
+    return constraint_power_magnitude_sqr(pm, n, f_bus, t_bus, arc_from, tm)
 end
 
 ""
@@ -279,7 +286,8 @@ function constraint_power_magnitude_sqr_on_off(pm::GenericPowerModel, branch)
 end
 
 ""
-function constraint_power_magnitude_link(pm::GenericPowerModel, branch)
+constraint_power_magnitude_link(pm::GenericPowerModel, branch) = constraint_power_magnitude_link(pm, 0, branch)
+function constraint_power_magnitude_link(pm::GenericPowerModel, n::Int, branch)
     i = branch["index"]
     f_bus = branch["f_bus"]
     t_bus = branch["t_bus"]
@@ -290,7 +298,7 @@ function constraint_power_magnitude_link(pm::GenericPowerModel, branch)
     c = branch["br_b"]
     tm = branch["tap"]^2
 
-    return constraint_power_magnitude_link(pm, f_bus, t_bus, arc_from, g, b, c, tr, ti, tm)
+    return constraint_power_magnitude_link(pm, n, f_bus, t_bus, arc_from, g, b, c, tr, ti, tm)
 end
 
 ""

--- a/src/core/data.jl
+++ b/src/core/data.jl
@@ -131,7 +131,7 @@ end
 
 
 function make_per_unit(data::Dict{String,Any})
-    for (n,network_data) in data
+    for (n,network_data) in data["nw"]
         make_network_per_unit(network_data)
     end
 end
@@ -224,7 +224,7 @@ end
 
 
 function make_mixed_units(data::Dict{String,Any})
-    for (n,network_data) in data
+    for (n,network_data) in data["nw"]
         make_network_mixed_units(network_data)
     end
 end

--- a/src/core/data.jl
+++ b/src/core/data.jl
@@ -129,8 +129,15 @@ function apply_func(data::Dict{String,Any}, key::String, func)
     end
 end
 
-"Transforms network data into per-unit"
+
 function make_per_unit(data::Dict{String,Any})
+    for (n,network_data) in data
+        make_network_per_unit(network_data)
+    end
+end
+
+"Transforms network data into per-unit"
+function make_network_per_unit(data::Dict{String,Any})
     if !haskey(data, "per_unit") || data["per_unit"] == false
         data["per_unit"] = true
         mva_base = data["baseMVA"]
@@ -215,8 +222,15 @@ function make_per_unit(data::Dict{String,Any})
     end
 end
 
-"Transforms network data into mixed-units (inverse of per-unit)"
+
 function make_mixed_units(data::Dict{String,Any})
+    for (n,network_data) in data
+        make_network_mixed_units(network_data)
+    end
+end
+
+"Transforms network data into mixed-units (inverse of per-unit)"
+function make_network_mixed_units(data::Dict{String,Any})
     if haskey(data, "per_unit") && data["per_unit"] == true
         data["per_unit"] = false
         mva_base = data["baseMVA"]

--- a/src/core/objective.jl
+++ b/src/core/objective.jl
@@ -48,37 +48,50 @@ function objective_min_fuel_cost(pm::GenericPowerModel)
     )
 end
 
+
 ""
 function objective_min_fuel_cost{T <: AbstractConicPowerFormulation}(pm::GenericPowerModel{T})
     check_cost_models(pm)
 
-    pg = pm.var[:pg]
-    dc_p = pm.var[:p_dc]
-    from_idx = Dict(arc[1] => arc for arc in pm.ref[:arcs_from_dc])
+    pg = Dict(n => pm.var[:nw][n][:pg] for (n,ref) in pm.ref[:nw])
+    dc_p = Dict(n => pm.var[:nw][n][:p_dc] for (n,ref) in pm.ref[:nw])
 
-    pg_sqr = pm.var[:pg_sqr] = @variable(pm.model, 
-        [i in keys(pm.ref[:gen])], basename="pg_sqr",
-        lowerbound = pm.ref[:gen][i]["pmin"]^2,
-        upperbound = pm.ref[:gen][i]["pmax"]^2
-    )
-    for (i, gen) in pm.ref[:gen]
-        @constraint(pm.model, norm([2*pg[i], pg_sqr[i]-1]) <= pg_sqr[i]+1)
+    from_idx = Dict()
+    for (n,ref) in pm.ref[:nw]
+        from_idx[n] = Dict(arc[1] => arc for arc in ref[:arcs_from_dc])
     end
 
-    dc_p_sqr = pm.var[:dc_p_sqr] = @variable(pm.model, 
-        dc_p_sqr[i in keys(pm.ref[:dcline])], basename="dc_p_sqr",
-        lowerbound = pm.ref[:dcline][i]["pminf"]^2,
-        upperbound = pm.ref[:dcline][i]["pmaxf"]^2
-    )
-    for (i, dcline) in pm.ref[:dcline]
-        @constraint(pm.model, norm([2*dc_p[from_idx[i]], dc_p_sqr[i]-1]) <= dc_p_sqr[i]+1)
+    pg_sqr = Dict()
+    dc_p_sqr = Dict()
+    for (n,ref) in pm.ref[:nw]
+        pg_sqr[n] = pm.var[:nw][n][:pg_sqr] = @variable(pm.model, 
+            [i in keys(pm.ref[:nw][n][:gen])], basename="$(n)_pg_sqr",
+            lowerbound = pm.ref[:nw][n][:gen][i]["pmin"]^2,
+            upperbound = pm.ref[:nw][n][:gen][i]["pmax"]^2
+        )
+        for (i, gen) in pm.ref[:nw][n][:gen]
+            @constraint(pm.model, norm([2*pg[n][i], pg_sqr[n][i]-1]) <= pg_sqr[n][i]+1)
+        end
+
+        dc_p_sqr[n] = pm.var[:nw][n][:dc_p_sqr] = @variable(pm.model, 
+            [i in keys(pm.ref[:nw][n][:dcline])], basename="$(n)_dc_p_sqr",
+            lowerbound = pm.ref[:nw][n][:dcline][i]["pminf"]^2,
+            upperbound = pm.ref[:nw][n][:dcline][i]["pmaxf"]^2
+        )
+
+        for (i, dcline) in pm.ref[:nw][n][:dcline]
+            @constraint(pm.model, norm([2*dc_p[n][from_idx[n][i]], dc_p_sqr[n][i]-1]) <= dc_p_sqr[n][i]+1)
+        end
     end
 
     return @objective(pm.model, Min,
-        sum( gen["cost"][1]*pg_sqr[i] + gen["cost"][2]*pg[i] + gen["cost"][3] for (i,gen) in pm.ref[:gen]) +
-        sum(dcline["cost"][1]*dc_p_sqr[i]^2 + dcline["cost"][2]*dc_p[from_idx[i]] + dcline["cost"][3] for (i,dcline) in pm.ref[:dcline])
+        sum(
+            sum( gen["cost"][1]*pg_sqr[n][i] + gen["cost"][2]*pg[n][i] + gen["cost"][3] for (i,gen) in ref[:gen]) +
+            sum(dcline["cost"][1]*dc_p_sqr[n][i]^2 + dcline["cost"][2]*dc_p[n][from_idx[n][i]] + dcline["cost"][3] for (i,dcline) in ref[:dcline])
+        for (n,ref) in pm.ref[:nw])
     )
 end
+
 
 "Cost of building lines"
 function objective_tnep_cost(pm::GenericPowerModel)

--- a/src/core/solution.jl
+++ b/src/core/solution.jl
@@ -7,7 +7,17 @@ function build_solution(pm::GenericPowerModel, status, solve_time; objective = N
         status = solver_status_dict(Symbol(typeof(pm.model.solver).name.module), status)
     end
 
-    sol = solution_builder(pm)
+    sol = Dict{String,Any}()
+    data = Dict{String,Any}()
+
+    for (r,data) in pm.data
+        sol[r] = solution_builder(pm, r)
+        data[r] = Dict(
+            "name" => data["name"],
+            "bus_count" => length(data["bus"]),
+            "branch_count" => length(data["branch"])
+        )
+    end
 
     solution = Dict{String,Any}(
         "solver" => string(typeof(pm.model.solver)),
@@ -16,16 +26,12 @@ function build_solution(pm::GenericPowerModel, status, solve_time; objective = N
         "objective_lb" => guard_getobjbound(pm.model),
         "solve_time" => solve_time,
         "solution" => sol,
+        "data" => data,
         "machine" => Dict(
             "cpu" => Sys.cpu_info()[1].model,
             "memory" => string(Sys.total_memory()/2^30, " Gb")
-            ),
-        "data" => Dict(
-            "name" => pm.data["name"],
-            "bus_count" => length(pm.data["bus"]),
-            "branch_count" => length(pm.data["branch"])
-            )
         )
+    )
 
     pm.solution = solution
 
@@ -33,96 +39,95 @@ function build_solution(pm::GenericPowerModel, status, solve_time; objective = N
 end
 
 ""
-function init_solution(pm::GenericPowerModel)
-    return Dict{String,Any}(key => pm.data[key] for key in ["per_unit", "baseMVA"])
+function init_solution(data::Dict{String,Any})
+    return Dict{String,Any}(key => data[key] for key in ["per_unit", "baseMVA"])
 end
 
 ""
-function get_solution(pm::GenericPowerModel)
-    sol = init_solution(pm)
-    add_bus_voltage_setpoint(sol, pm)
-    add_generator_power_setpoint(sol, pm)
-    add_branch_flow_setpoint(sol, pm)
-    add_dcline_flow_setpoint(sol, pm)
+function get_solution(pm::GenericPowerModel, r::String)
+    sol = init_solution(pm.data[r])
+    add_bus_voltage_setpoint(sol, pm, r)
+    add_generator_power_setpoint(sol, pm, r)
+    add_branch_flow_setpoint(sol, pm, r)
+    add_dcline_flow_setpoint(sol, pm, r)
     return sol
 end
 
 ""
-function add_bus_voltage_setpoint(sol, pm::GenericPowerModel)
-    add_setpoint(sol, pm, "bus", "bus_i", "vm", :v)
-    add_setpoint(sol, pm, "bus", "bus_i", "va", :t)
+function add_bus_voltage_setpoint(sol, pm::GenericPowerModel, r::String)
+    add_setpoint(sol, pm, r, "bus", "bus_i", "vm", :v)
+    add_setpoint(sol, pm, r, "bus", "bus_i", "va", :t)
 end
 
 ""
-function add_generator_power_setpoint(sol, pm::GenericPowerModel)
-    mva_base = pm.data["baseMVA"]
-    add_setpoint(sol, pm, "gen", "index", "pg", :pg)
-    add_setpoint(sol, pm, "gen", "index", "qg", :qg)
+function add_generator_power_setpoint(sol, pm::GenericPowerModel, r::String)
+    add_setpoint(sol, pm, r, "gen", "index", "pg", :pg)
+    add_setpoint(sol, pm, r, "gen", "index", "qg", :qg)
 end
 
 ""
-function add_bus_demand_setpoint(sol, pm::GenericPowerModel)
-    mva_base = pm.data["baseMVA"]
-    add_setpoint(sol, pm, "bus", "bus_i", "pd", :pd; default_value = (item) -> item["pd"]*mva_base)
-    add_setpoint(sol, pm, "bus", "bus_i", "qd", :qd; default_value = (item) -> item["qd"]*mva_base)
+function add_bus_demand_setpoint(sol, pm::GenericPowerModel, r::String)
+    add_setpoint(sol, pm, r, "bus", "bus_i", "pd", :pd; default_value = (item) -> item["pd"])
+    add_setpoint(sol, pm, r, "bus", "bus_i", "qd", :qd; default_value = (item) -> item["qd"])
 end
 
 ""
-function add_branch_flow_setpoint(sol, pm::GenericPowerModel)
+function add_branch_flow_setpoint(sol, pm::GenericPowerModel, r::String)
     # check the line flows were requested
     if haskey(pm.setting, "output") && haskey(pm.setting["output"], "line_flows") && pm.setting["output"]["line_flows"] == true
-        add_setpoint(sol, pm, "branch", "index", "pf", :p; extract_var = (var,idx,item) -> var[(idx, item["f_bus"], item["t_bus"])])
-        add_setpoint(sol, pm, "branch", "index", "qf", :q; extract_var = (var,idx,item) -> var[(idx, item["f_bus"], item["t_bus"])])
-        add_setpoint(sol, pm, "branch", "index", "pt", :p; extract_var = (var,idx,item) -> var[(idx, item["t_bus"], item["f_bus"])])
-        add_setpoint(sol, pm, "branch", "index", "qt", :q; extract_var = (var,idx,item) -> var[(idx, item["t_bus"], item["f_bus"])])
+        add_setpoint(sol, pm, r, "branch", "index", "pf", :p; extract_var = (var,idx,item) -> var[(idx, item["f_bus"], item["t_bus"])])
+        add_setpoint(sol, pm, r, "branch", "index", "qf", :q; extract_var = (var,idx,item) -> var[(idx, item["f_bus"], item["t_bus"])])
+        add_setpoint(sol, pm, r, "branch", "index", "pt", :p; extract_var = (var,idx,item) -> var[(idx, item["t_bus"], item["f_bus"])])
+        add_setpoint(sol, pm, r, "branch", "index", "qt", :q; extract_var = (var,idx,item) -> var[(idx, item["t_bus"], item["f_bus"])])
     end
 end
 
 ""
-function add_dcline_flow_setpoint(sol, pm::GenericPowerModel)
-    add_setpoint(sol, pm, "dcline", "index", "pf", :p_dc; extract_var = (var,idx,item) -> var[(idx, item["f_bus"], item["t_bus"])])
-    add_setpoint(sol, pm, "dcline", "index", "qf", :q_dc; extract_var = (var,idx,item) -> var[(idx, item["f_bus"], item["t_bus"])])
-    add_setpoint(sol, pm, "dcline", "index", "pt", :p_dc; extract_var = (var,idx,item) -> var[(idx, item["t_bus"], item["f_bus"])])
-    add_setpoint(sol, pm, "dcline", "index", "qt", :q_dc; extract_var = (var,idx,item) -> var[(idx, item["t_bus"], item["f_bus"])])
+function add_dcline_flow_setpoint(sol, pm::GenericPowerModel, r::String)
+    add_setpoint(sol, pm, r, "dcline", "index", "pf", :p_dc; extract_var = (var,idx,item) -> var[(idx, item["f_bus"], item["t_bus"])])
+    add_setpoint(sol, pm, r, "dcline", "index", "qf", :q_dc; extract_var = (var,idx,item) -> var[(idx, item["f_bus"], item["t_bus"])])
+    add_setpoint(sol, pm, r, "dcline", "index", "pt", :p_dc; extract_var = (var,idx,item) -> var[(idx, item["t_bus"], item["f_bus"])])
+    add_setpoint(sol, pm, r, "dcline", "index", "qt", :q_dc; extract_var = (var,idx,item) -> var[(idx, item["t_bus"], item["f_bus"])])
 end
 
 ""
-function add_branch_flow_setpoint_ne(sol, pm::GenericPowerModel)
+function add_branch_flow_setpoint_ne(sol, pm::GenericPowerModel, r::String)
     # check the line flows were requested
     if haskey(pm.setting, "output") && haskey(pm.setting["output"], "line_flows") && pm.setting["output"]["line_flows"] == true
-        add_setpoint(sol, pm, "ne_branch", "index", "pf", :p_ne; scale = (x,item) -> x*mva_base, extract_var = (var,idx,item) -> var[(idx, item["f_bus"], item["t_bus"])])
-        add_setpoint(sol, pm, "ne_branch", "index", "qf", :q_ne; scale = (x,item) -> x*mva_base, extract_var = (var,idx,item) -> var[(idx, item["f_bus"], item["t_bus"])])
-        add_setpoint(sol, pm, "ne_branch", "index", "pt", :p_ne; scale = (x,item) -> x*mva_base, extract_var = (var,idx,item) -> var[(idx, item["t_bus"], item["f_bus"])])
-        add_setpoint(sol, pm, "ne_branch", "index", "qt", :q_ne; scale = (x,item) -> x*mva_base, extract_var = (var,idx,item) -> var[(idx, item["t_bus"], item["f_bus"])])
+        add_setpoint(sol, pm, r, "ne_branch", "index", "pf", :p_ne; scale = (x,item) -> x*mva_base, extract_var = (var,idx,item) -> var[(idx, item["f_bus"], item["t_bus"])])
+        add_setpoint(sol, pm, r, "ne_branch", "index", "qf", :q_ne; scale = (x,item) -> x*mva_base, extract_var = (var,idx,item) -> var[(idx, item["f_bus"], item["t_bus"])])
+        add_setpoint(sol, pm, r, "ne_branch", "index", "pt", :p_ne; scale = (x,item) -> x*mva_base, extract_var = (var,idx,item) -> var[(idx, item["t_bus"], item["f_bus"])])
+        add_setpoint(sol, pm, r, "ne_branch", "index", "qt", :q_ne; scale = (x,item) -> x*mva_base, extract_var = (var,idx,item) -> var[(idx, item["t_bus"], item["f_bus"])])
     end
 end
 
 ""
-function add_branch_status_setpoint(sol, pm::GenericPowerModel)
-  add_setpoint(sol, pm, "branch", "index", "br_status", :line_z; default_value = (item) -> 1)
+function add_branch_status_setpoint(sol, pm::GenericPowerModel, r::String)
+  add_setpoint(sol, pm, r, "branch", "index", "br_status", :line_z; default_value = (item) -> 1)
 end
 
-function add_branch_status_setpoint_dc(sol, pm::GenericPowerModel)
-  add_setpoint(sol, pm, "dcline", "index", "br_status", :line_z; default_value = (item) -> 1)
-end
-
-""
-function add_branch_ne_setpoint(sol, pm::GenericPowerModel)
-  add_setpoint(sol, pm, "ne_branch", "index", "built", :line_ne; default_value = (item) -> 1)
+function add_branch_status_setpoint_dc(sol, pm::GenericPowerModel, r::String)
+  add_setpoint(sol, pm, r, "dcline", "index", "br_status", :line_z; default_value = (item) -> 1)
 end
 
 ""
-function add_setpoint(sol, pm::GenericPowerModel, dict_name, index_name, param_name, variable_symbol; default_value = (item) -> NaN, scale = (x,item) -> x, extract_var = (var,idx,item) -> var[idx])
+function add_branch_ne_setpoint(sol, pm::GenericPowerModel, r::String)
+  add_setpoint(sol, pm, r, "ne_branch", "index", "built", :line_ne; default_value = (item) -> 1)
+end
+
+""
+function add_setpoint(sol, pm::GenericPowerModel, r::String, dict_name, index_name, param_name, variable_symbol; default_value = (item) -> NaN, scale = (x,item) -> x, extract_var = (var,idx,item) -> var[idx])
     sol_dict = get(sol, dict_name, Dict{String,Any}())
-    if length(pm.data[dict_name]) > 0
+    if length(pm.data[r][dict_name]) > 0
         sol[dict_name] = sol_dict
     end
-    for (i,item) in pm.data[dict_name]
+    for (i,item) in pm.data[r][dict_name]
         idx = Int(item[index_name])
         sol_item = sol_dict[i] = get(sol_dict, i, Dict{String,Any}())
         sol_item[param_name] = default_value(item)
         try
-            var = extract_var(pm.var[variable_symbol], idx, item)
+            rs = Symbol(r)
+            var = extract_var(pm.var[rs][variable_symbol], idx, item)
             sol_item[param_name] = scale(getvalue(var), item)
         catch
         end

--- a/src/core/variable.jl
+++ b/src/core/variable.jl
@@ -10,30 +10,30 @@ end
 
 
 "variable: `t[i]` for `i` in `bus`es"
-function variable_phase_angle(pm::GenericPowerModel; bounded::Bool = true)
-    pm.var[:t] = @variable(pm.model,
-        [i in keys(pm.ref[:bus])], basename="t",
-        start = getstart(pm.ref[:bus], i, "t_start")
+function variable_phase_angle(pm::GenericPowerModel, r::Symbol=:base; bounded::Bool = true)
+    pm.var[r][:t] = @variable(pm.model,
+        [i in keys(pm.ref[r][:bus])], basename="$(r)_t",
+        start = getstart(pm.ref[r][:bus], i, "t_start")
     )
-    return pm.var[:t]
+    return pm.var[r][:t]
 end
 
 "variable: `v[i]` for `i` in `bus`es"
-function variable_voltage_magnitude(pm::GenericPowerModel; bounded = true)
+function variable_voltage_magnitude(pm::GenericPowerModel, r::Symbol=:base; bounded = true)
     if bounded
-        pm.var[:v] = @variable(pm.model,
-            [i in keys(pm.ref[:bus])], basename="v",
-            lowerbound = pm.ref[:bus][i]["vmin"],
-            upperbound = pm.ref[:bus][i]["vmax"],
-            start = getstart(pm.ref[:bus], i, "v_start", 1.0)
+        pm.var[r][:v] = @variable(pm.model,
+            [i in keys(pm.ref[r][:bus])], basename="$(r)_v",
+            lowerbound = pm.ref[r][:bus][i]["vmin"],
+            upperbound = pm.ref[r][:bus][i]["vmax"],
+            start = getstart(pm.ref[r][:bus], i, "v_start", 1.0)
         )
     else
-        pm.var[:v] = @variable(pm.model,
-            [i in keys(pm.ref[:bus])], basename="v",
+        pm.var[r][:v] = @variable(pm.model,
+            [i in keys(pm.ref[r][:bus])], basename="$(r)_v",
             lowerbound = 0,
-            start = getstart(pm.ref[:bus], i, "v_start", 1.0))
+            start = getstart(pm.ref[r][:bus], i, "v_start", 1.0))
     end
-    return pm.var[:v]
+    return pm.var[r][:v]
 end
 
 
@@ -202,39 +202,39 @@ end
 
 
 "variable: `pg[j]` for `j` in `gen`"
-function variable_active_generation(pm::GenericPowerModel; bounded = true)
+function variable_active_generation(pm::GenericPowerModel, r::Symbol=:base; bounded = true)
     if bounded
-        pm.var[:pg] = @variable(pm.model,
-            [i in keys(pm.ref[:gen])], basename="pg",
-            lowerbound = pm.ref[:gen][i]["pmin"],
-            upperbound = pm.ref[:gen][i]["pmax"],
-            start = getstart(pm.ref[:gen], i, "pg_start")
+        pm.var[r][:pg] = @variable(pm.model,
+            [i in keys(pm.ref[r][:gen])], basename="$(r)_pg",
+            lowerbound = pm.ref[r][:gen][i]["pmin"],
+            upperbound = pm.ref[r][:gen][i]["pmax"],
+            start = getstart(pm.ref[r][:gen], i, "pg_start")
         )
     else
-        pm.var[:pg] = @variable(pm.model,
-            [i in keys(pm.ref[:gen])], basename="pg",
-            start = getstart(pm.ref[:gen], i, "pg_start")
+        pm.var[r][:pg] = @variable(pm.model,
+            [i in keys(pm.ref[r][:gen])], basename="$(r)_pg",
+            start = getstart(pm.ref[r][:gen], i, "pg_start")
         )
     end
-    return pm.var[:pg]
+    return pm.var[r][:pg]
 end
 
 "variable: `qq[j]` for `j` in `gen`"
-function variable_reactive_generation(pm::GenericPowerModel; bounded = true)
+function variable_reactive_generation(pm::GenericPowerModel, r::Symbol=:base; bounded = true)
     if bounded
-        pm.var[:qg] = @variable(pm.model,
-            [i in keys(pm.ref[:gen])], basename="qg",
-            lowerbound = pm.ref[:gen][i]["qmin"],
-            upperbound = pm.ref[:gen][i]["qmax"],
-            start = getstart(pm.ref[:gen], i, "qg_start")
+        pm.var[r][:qg] = @variable(pm.model,
+            [i in keys(pm.ref[r][:gen])], basename="$(r)_qg",
+            lowerbound = pm.ref[r][:gen][i]["qmin"],
+            upperbound = pm.ref[r][:gen][i]["qmax"],
+            start = getstart(pm.ref[r][:gen], i, "qg_start")
         )
     else
         pm.var[:qg] = @variable(pm.model,
-            [i in keys(pm.ref[:gen])], basename="qg",
-            start = getstart(pm.ref[:gen], i, "qg_start")
+            [i in keys(pm.ref[r][:gen])], basename="$(r)_qg",
+            start = getstart(pm.ref[r][:gen], i, "qg_start")
         )
     end
-    return pm.var[:qg]
+    return pm.var[r][:qg]
 end
 
 ""
@@ -245,39 +245,39 @@ end
 
 
 "variable: `p[l,i,j]` for `(l,i,j)` in `arcs`"
-function variable_active_line_flow(pm::GenericPowerModel; bounded = true)
+function variable_active_line_flow(pm::GenericPowerModel, r::Symbol=:base; bounded = true)
     if bounded
-        pm.var[:p] = @variable(pm.model,
-            [(l,i,j) in pm.ref[:arcs]], basename="p",
-            lowerbound = -pm.ref[:branch][l]["rate_a"],
-            upperbound =  pm.ref[:branch][l]["rate_a"],
-            start = getstart(pm.ref[:branch], l, "p_start")
+        pm.var[r][:p] = @variable(pm.model,
+            [(l,i,j) in pm.ref[r][:arcs]], basename="$(r)_p",
+            lowerbound = -pm.ref[r][:branch][l]["rate_a"],
+            upperbound =  pm.ref[r][:branch][l]["rate_a"],
+            start = getstart(pm.ref[r][:branch], l, "p_start")
         )
     else
         pm.var[:p] = @variable(pm.model,
-            [(l,i,j) in pm.ref[:arcs]], basename="p",
-            start = getstart(pm.ref[:branch], l, "p_start")
+            [(l,i,j) in pm.ref[r][:arcs]], basename="$(r)_p",
+            start = getstart(pm.ref[r][:branch], l, "p_start")
         )
     end
-    return pm.var[:p]
+    return pm.var[r][:p]
 end
 
 "variable: `q[l,i,j]` for `(l,i,j)` in `arcs`"
-function variable_reactive_line_flow(pm::GenericPowerModel; bounded = true)
+function variable_reactive_line_flow(pm::GenericPowerModel, r::Symbol=:base; bounded = true)
     if bounded
-        pm.var[:q] = @variable(pm.model,
-            [(l,i,j) in pm.ref[:arcs]], basename="q",
-            lowerbound = -pm.ref[:branch][l]["rate_a"],
-            upperbound =  pm.ref[:branch][l]["rate_a"],
-            start = getstart(pm.ref[:branch], l, "q_start")
+        pm.var[r][:q] = @variable(pm.model,
+            [(l,i,j) in pm.ref[r][:arcs]], basename="$(r)_q",
+            lowerbound = -pm.ref[r][:branch][l]["rate_a"],
+            upperbound =  pm.ref[r][:branch][l]["rate_a"],
+            start = getstart(pm.ref[r][:branch], l, "q_start")
         )
     else
         pm.var[:q] = @variable(pm.model, 
-            [(l,i,j) in pm.ref[:arcs]], basename="q",
-            start = getstart(pm.ref[:branch], l, "q_start")
+            [(l,i,j) in pm.ref[r][:arcs]], basename="$(r)_q",
+            start = getstart(pm.ref[r][:branch], l, "q_start")
         )
     end
-    return pm.var[:q]
+    return pm.var[r][:q]
 end
 
 function variable_dcline_flow(pm::GenericPowerModel; kwargs...)
@@ -286,69 +286,69 @@ function variable_dcline_flow(pm::GenericPowerModel; kwargs...)
 end
 
 "variable: `p_dc[l,i,j]` for `(l,i,j)` in `arcs_dc`"
-function variable_active_dcline_flow(pm::GenericPowerModel; bounded = true)
+function variable_active_dcline_flow(pm::GenericPowerModel, r::Symbol=:base; bounded = true)
     # build bounds lookups based over arcs set
     pmin = Dict()
     pref = Dict()
     pmax = Dict()
-    for (l,i,j) in pm.ref[:arcs_from_dc]
-        pmin[(l,i,j)] = pm.ref[:dcline][l]["pminf"]
-        pmax[(l,i,j)] = pm.ref[:dcline][l]["pmaxf"]
-        pref[(l,i,j)] = pm.ref[:dcline][l]["pf"]
+    for (l,i,j) in pm.ref[r][:arcs_from_dc]
+        pmin[(l,i,j)] = pm.ref[r][:dcline][l]["pminf"]
+        pmax[(l,i,j)] = pm.ref[r][:dcline][l]["pmaxf"]
+        pref[(l,i,j)] = pm.ref[r][:dcline][l]["pf"]
     end
-    for (l,i,j) in pm.ref[:arcs_to_dc]
-        pmin[(l,i,j)] = pm.ref[:dcline][l]["pmint"]
-        pmax[(l,i,j)] = pm.ref[:dcline][l]["pmaxt"]
-        pref[(l,i,j)] = pm.ref[:dcline][l]["pt"]
+    for (l,i,j) in pm.ref[r][:arcs_to_dc]
+        pmin[(l,i,j)] = pm.ref[r][:dcline][l]["pmint"]
+        pmax[(l,i,j)] = pm.ref[r][:dcline][l]["pmaxt"]
+        pref[(l,i,j)] = pm.ref[r][:dcline][l]["pt"]
     end
 
     if bounded
-        pm.var[:p_dc] = @variable(pm.model,
-            [(l,i,j) in pm.ref[:arcs_dc]], basename="p_dc",
+        pm.var[r][:p_dc] = @variable(pm.model,
+            [(l,i,j) in pm.ref[r][:arcs_dc]], basename="$(r)_p_dc",
             lowerbound = pmin[(l,i,j)],
             upperbound = pmax[(l,i,j)], 
             start = pref[(l,i,j)]
         )
     else
-        pm.var[:p_dc] = @variable(pm.model,
-            [(l,i,j) in pm.ref[:arcs_dc]], basename="p_dc",
+        pm.var[r][:p_dc] = @variable(pm.model,
+            [(l,i,j) in pm.ref[r][:arcs_dc]], basename="$(r)_p_dc",
             start = pref[(l,i,j)]
         )
     end
-    return pm.var[:p_dc]
+    return pm.var[r][:p_dc]
 end
 
 "variable: `q_dc[l,i,j]` for `(l,i,j)` in `arcs_dc`"
-function variable_reactive_dcline_flow(pm::GenericPowerModel; bounded = true)
+function variable_reactive_dcline_flow(pm::GenericPowerModel, r::Symbol=:base; bounded = true)
     # build bounds lookups based over arcs set
     qmin = Dict()
     qref = Dict()
     qmax = Dict()
-    for (l,i,j) in pm.ref[:arcs_from_dc]
-        qmin[(l,i,j)] = pm.ref[:dcline][l]["qminf"]
-        qmax[(l,i,j)] = pm.ref[:dcline][l]["qmaxf"]
-        qref[(l,i,j)] = pm.ref[:dcline][l]["qf"]
+    for (l,i,j) in pm.ref[r][:arcs_from_dc]
+        qmin[(l,i,j)] = pm.ref[r][:dcline][l]["qminf"]
+        qmax[(l,i,j)] = pm.ref[r][:dcline][l]["qmaxf"]
+        qref[(l,i,j)] = pm.ref[r][:dcline][l]["qf"]
     end
-    for (l,i,j) in pm.ref[:arcs_to_dc]
-        qmin[(l,i,j)] = pm.ref[:dcline][l]["qmint"]
-        qmax[(l,i,j)] = pm.ref[:dcline][l]["qmaxt"]
-        qref[(l,i,j)] = pm.ref[:dcline][l]["qt"]
+    for (l,i,j) in pm.ref[r][:arcs_to_dc]
+        qmin[(l,i,j)] = pm.ref[r][:dcline][l]["qmint"]
+        qmax[(l,i,j)] = pm.ref[r][:dcline][l]["qmaxt"]
+        qref[(l,i,j)] = pm.ref[r][:dcline][l]["qt"]
     end
 
     if bounded
-        pm.var[:q_dc] = @variable(pm.model, 
-            q_dc[(l,i,j) in pm.ref[:arcs_dc]], basename="q_dc",
+        pm.var[r][:q_dc] = @variable(pm.model, 
+            q_dc[(l,i,j) in pm.ref[r][:arcs_dc]], basename="$(r)_q_dc",
             lowerbound = qmin[(l,i,j)],
             upperbound = qmax[(l,i,j)],
             start = qref[(l,i,j)]
         )
     else
-        pm.var[:q_dc] = @variable(pm.model,
-            [(l,i,j) in pm.ref[:arcs_dc]], basename="q_dc",
+        pm.var[r][:q_dc] = @variable(pm.model,
+            [(l,i,j) in pm.ref[r][:arcs_dc]], basename="$(r)_q_dc",
             start = qref[(l,i,j)]
         )
     end
-    return pm.var[:q_dc]
+    return pm.var[r][:q_dc]
 end
 
 ##################################################################

--- a/src/core/variable.jl
+++ b/src/core/variable.jl
@@ -10,30 +10,30 @@ end
 
 
 "variable: `t[i]` for `i` in `bus`es"
-function variable_phase_angle(pm::GenericPowerModel, r::Symbol=:base; bounded::Bool = true)
-    pm.var[r][:t] = @variable(pm.model,
-        [i in keys(pm.ref[r][:bus])], basename="$(r)_t",
-        start = getstart(pm.ref[r][:bus], i, "t_start")
+function variable_phase_angle(pm::GenericPowerModel, n::Symbol=:base; bounded::Bool = true)
+    pm.var[n][:t] = @variable(pm.model,
+        [i in keys(pm.ref[n][:bus])], basename="$(n)_t",
+        start = getstart(pm.ref[n][:bus], i, "t_start")
     )
-    return pm.var[r][:t]
+    return pm.var[n][:t]
 end
 
 "variable: `v[i]` for `i` in `bus`es"
-function variable_voltage_magnitude(pm::GenericPowerModel, r::Symbol=:base; bounded = true)
+function variable_voltage_magnitude(pm::GenericPowerModel, n::Symbol=:base; bounded = true)
     if bounded
-        pm.var[r][:v] = @variable(pm.model,
-            [i in keys(pm.ref[r][:bus])], basename="$(r)_v",
-            lowerbound = pm.ref[r][:bus][i]["vmin"],
-            upperbound = pm.ref[r][:bus][i]["vmax"],
-            start = getstart(pm.ref[r][:bus], i, "v_start", 1.0)
+        pm.var[n][:v] = @variable(pm.model,
+            [i in keys(pm.ref[n][:bus])], basename="$(n)_v",
+            lowerbound = pm.ref[n][:bus][i]["vmin"],
+            upperbound = pm.ref[n][:bus][i]["vmax"],
+            start = getstart(pm.ref[n][:bus], i, "v_start", 1.0)
         )
     else
-        pm.var[r][:v] = @variable(pm.model,
-            [i in keys(pm.ref[r][:bus])], basename="$(r)_v",
+        pm.var[n][:v] = @variable(pm.model,
+            [i in keys(pm.ref[n][:bus])], basename="$(n)_v",
             lowerbound = 0,
-            start = getstart(pm.ref[r][:bus], i, "v_start", 1.0))
+            start = getstart(pm.ref[n][:bus], i, "v_start", 1.0))
     end
-    return pm.var[r][:v]
+    return pm.var[n][:v]
 end
 
 
@@ -202,39 +202,39 @@ end
 
 
 "variable: `pg[j]` for `j` in `gen`"
-function variable_active_generation(pm::GenericPowerModel, r::Symbol=:base; bounded = true)
+function variable_active_generation(pm::GenericPowerModel, n::Symbol=:base; bounded = true)
     if bounded
-        pm.var[r][:pg] = @variable(pm.model,
-            [i in keys(pm.ref[r][:gen])], basename="$(r)_pg",
-            lowerbound = pm.ref[r][:gen][i]["pmin"],
-            upperbound = pm.ref[r][:gen][i]["pmax"],
-            start = getstart(pm.ref[r][:gen], i, "pg_start")
+        pm.var[n][:pg] = @variable(pm.model,
+            [i in keys(pm.ref[n][:gen])], basename="$(n)_pg",
+            lowerbound = pm.ref[n][:gen][i]["pmin"],
+            upperbound = pm.ref[n][:gen][i]["pmax"],
+            start = getstart(pm.ref[n][:gen], i, "pg_start")
         )
     else
-        pm.var[r][:pg] = @variable(pm.model,
-            [i in keys(pm.ref[r][:gen])], basename="$(r)_pg",
-            start = getstart(pm.ref[r][:gen], i, "pg_start")
+        pm.var[n][:pg] = @variable(pm.model,
+            [i in keys(pm.ref[n][:gen])], basename="$(n)_pg",
+            start = getstart(pm.ref[n][:gen], i, "pg_start")
         )
     end
-    return pm.var[r][:pg]
+    return pm.var[n][:pg]
 end
 
 "variable: `qq[j]` for `j` in `gen`"
-function variable_reactive_generation(pm::GenericPowerModel, r::Symbol=:base; bounded = true)
+function variable_reactive_generation(pm::GenericPowerModel, n::Symbol=:base; bounded = true)
     if bounded
-        pm.var[r][:qg] = @variable(pm.model,
-            [i in keys(pm.ref[r][:gen])], basename="$(r)_qg",
-            lowerbound = pm.ref[r][:gen][i]["qmin"],
-            upperbound = pm.ref[r][:gen][i]["qmax"],
-            start = getstart(pm.ref[r][:gen], i, "qg_start")
+        pm.var[n][:qg] = @variable(pm.model,
+            [i in keys(pm.ref[n][:gen])], basename="$(n)_qg",
+            lowerbound = pm.ref[n][:gen][i]["qmin"],
+            upperbound = pm.ref[n][:gen][i]["qmax"],
+            start = getstart(pm.ref[n][:gen], i, "qg_start")
         )
     else
         pm.var[:qg] = @variable(pm.model,
-            [i in keys(pm.ref[r][:gen])], basename="$(r)_qg",
-            start = getstart(pm.ref[r][:gen], i, "qg_start")
+            [i in keys(pm.ref[n][:gen])], basename="$(n)_qg",
+            start = getstart(pm.ref[n][:gen], i, "qg_start")
         )
     end
-    return pm.var[r][:qg]
+    return pm.var[n][:qg]
 end
 
 ""
@@ -245,39 +245,39 @@ end
 
 
 "variable: `p[l,i,j]` for `(l,i,j)` in `arcs`"
-function variable_active_line_flow(pm::GenericPowerModel, r::Symbol=:base; bounded = true)
+function variable_active_line_flow(pm::GenericPowerModel, n::Symbol=:base; bounded = true)
     if bounded
-        pm.var[r][:p] = @variable(pm.model,
-            [(l,i,j) in pm.ref[r][:arcs]], basename="$(r)_p",
-            lowerbound = -pm.ref[r][:branch][l]["rate_a"],
-            upperbound =  pm.ref[r][:branch][l]["rate_a"],
-            start = getstart(pm.ref[r][:branch], l, "p_start")
+        pm.var[n][:p] = @variable(pm.model,
+            [(l,i,j) in pm.ref[n][:arcs]], basename="$(n)_p",
+            lowerbound = -pm.ref[n][:branch][l]["rate_a"],
+            upperbound =  pm.ref[n][:branch][l]["rate_a"],
+            start = getstart(pm.ref[n][:branch], l, "p_start")
         )
     else
         pm.var[:p] = @variable(pm.model,
-            [(l,i,j) in pm.ref[r][:arcs]], basename="$(r)_p",
-            start = getstart(pm.ref[r][:branch], l, "p_start")
+            [(l,i,j) in pm.ref[n][:arcs]], basename="$(n)_p",
+            start = getstart(pm.ref[n][:branch], l, "p_start")
         )
     end
-    return pm.var[r][:p]
+    return pm.var[n][:p]
 end
 
 "variable: `q[l,i,j]` for `(l,i,j)` in `arcs`"
-function variable_reactive_line_flow(pm::GenericPowerModel, r::Symbol=:base; bounded = true)
+function variable_reactive_line_flow(pm::GenericPowerModel, n::Symbol=:base; bounded = true)
     if bounded
-        pm.var[r][:q] = @variable(pm.model,
-            [(l,i,j) in pm.ref[r][:arcs]], basename="$(r)_q",
-            lowerbound = -pm.ref[r][:branch][l]["rate_a"],
-            upperbound =  pm.ref[r][:branch][l]["rate_a"],
-            start = getstart(pm.ref[r][:branch], l, "q_start")
+        pm.var[n][:q] = @variable(pm.model,
+            [(l,i,j) in pm.ref[n][:arcs]], basename="$(n)_q",
+            lowerbound = -pm.ref[n][:branch][l]["rate_a"],
+            upperbound =  pm.ref[n][:branch][l]["rate_a"],
+            start = getstart(pm.ref[n][:branch], l, "q_start")
         )
     else
         pm.var[:q] = @variable(pm.model, 
-            [(l,i,j) in pm.ref[r][:arcs]], basename="$(r)_q",
-            start = getstart(pm.ref[r][:branch], l, "q_start")
+            [(l,i,j) in pm.ref[n][:arcs]], basename="$(n)_q",
+            start = getstart(pm.ref[n][:branch], l, "q_start")
         )
     end
-    return pm.var[r][:q]
+    return pm.var[n][:q]
 end
 
 function variable_dcline_flow(pm::GenericPowerModel; kwargs...)
@@ -286,69 +286,69 @@ function variable_dcline_flow(pm::GenericPowerModel; kwargs...)
 end
 
 "variable: `p_dc[l,i,j]` for `(l,i,j)` in `arcs_dc`"
-function variable_active_dcline_flow(pm::GenericPowerModel, r::Symbol=:base; bounded = true)
+function variable_active_dcline_flow(pm::GenericPowerModel, n::Symbol=:base; bounded = true)
     # build bounds lookups based over arcs set
     pmin = Dict()
     pref = Dict()
     pmax = Dict()
-    for (l,i,j) in pm.ref[r][:arcs_from_dc]
-        pmin[(l,i,j)] = pm.ref[r][:dcline][l]["pminf"]
-        pmax[(l,i,j)] = pm.ref[r][:dcline][l]["pmaxf"]
-        pref[(l,i,j)] = pm.ref[r][:dcline][l]["pf"]
+    for (l,i,j) in pm.ref[n][:arcs_from_dc]
+        pmin[(l,i,j)] = pm.ref[n][:dcline][l]["pminf"]
+        pmax[(l,i,j)] = pm.ref[n][:dcline][l]["pmaxf"]
+        pref[(l,i,j)] = pm.ref[n][:dcline][l]["pf"]
     end
-    for (l,i,j) in pm.ref[r][:arcs_to_dc]
-        pmin[(l,i,j)] = pm.ref[r][:dcline][l]["pmint"]
-        pmax[(l,i,j)] = pm.ref[r][:dcline][l]["pmaxt"]
-        pref[(l,i,j)] = pm.ref[r][:dcline][l]["pt"]
+    for (l,i,j) in pm.ref[n][:arcs_to_dc]
+        pmin[(l,i,j)] = pm.ref[n][:dcline][l]["pmint"]
+        pmax[(l,i,j)] = pm.ref[n][:dcline][l]["pmaxt"]
+        pref[(l,i,j)] = pm.ref[n][:dcline][l]["pt"]
     end
 
     if bounded
-        pm.var[r][:p_dc] = @variable(pm.model,
-            [(l,i,j) in pm.ref[r][:arcs_dc]], basename="$(r)_p_dc",
+        pm.var[n][:p_dc] = @variable(pm.model,
+            [(l,i,j) in pm.ref[n][:arcs_dc]], basename="$(n)_p_dc",
             lowerbound = pmin[(l,i,j)],
             upperbound = pmax[(l,i,j)], 
             start = pref[(l,i,j)]
         )
     else
-        pm.var[r][:p_dc] = @variable(pm.model,
-            [(l,i,j) in pm.ref[r][:arcs_dc]], basename="$(r)_p_dc",
+        pm.var[n][:p_dc] = @variable(pm.model,
+            [(l,i,j) in pm.ref[n][:arcs_dc]], basename="$(n)_p_dc",
             start = pref[(l,i,j)]
         )
     end
-    return pm.var[r][:p_dc]
+    return pm.var[n][:p_dc]
 end
 
 "variable: `q_dc[l,i,j]` for `(l,i,j)` in `arcs_dc`"
-function variable_reactive_dcline_flow(pm::GenericPowerModel, r::Symbol=:base; bounded = true)
+function variable_reactive_dcline_flow(pm::GenericPowerModel, n::Symbol=:base; bounded = true)
     # build bounds lookups based over arcs set
     qmin = Dict()
     qref = Dict()
     qmax = Dict()
-    for (l,i,j) in pm.ref[r][:arcs_from_dc]
-        qmin[(l,i,j)] = pm.ref[r][:dcline][l]["qminf"]
-        qmax[(l,i,j)] = pm.ref[r][:dcline][l]["qmaxf"]
-        qref[(l,i,j)] = pm.ref[r][:dcline][l]["qf"]
+    for (l,i,j) in pm.ref[n][:arcs_from_dc]
+        qmin[(l,i,j)] = pm.ref[n][:dcline][l]["qminf"]
+        qmax[(l,i,j)] = pm.ref[n][:dcline][l]["qmaxf"]
+        qref[(l,i,j)] = pm.ref[n][:dcline][l]["qf"]
     end
-    for (l,i,j) in pm.ref[r][:arcs_to_dc]
-        qmin[(l,i,j)] = pm.ref[r][:dcline][l]["qmint"]
-        qmax[(l,i,j)] = pm.ref[r][:dcline][l]["qmaxt"]
-        qref[(l,i,j)] = pm.ref[r][:dcline][l]["qt"]
+    for (l,i,j) in pm.ref[n][:arcs_to_dc]
+        qmin[(l,i,j)] = pm.ref[n][:dcline][l]["qmint"]
+        qmax[(l,i,j)] = pm.ref[n][:dcline][l]["qmaxt"]
+        qref[(l,i,j)] = pm.ref[n][:dcline][l]["qt"]
     end
 
     if bounded
-        pm.var[r][:q_dc] = @variable(pm.model, 
-            q_dc[(l,i,j) in pm.ref[r][:arcs_dc]], basename="$(r)_q_dc",
+        pm.var[n][:q_dc] = @variable(pm.model, 
+            q_dc[(l,i,j) in pm.ref[n][:arcs_dc]], basename="$(n)_q_dc",
             lowerbound = qmin[(l,i,j)],
             upperbound = qmax[(l,i,j)],
             start = qref[(l,i,j)]
         )
     else
-        pm.var[r][:q_dc] = @variable(pm.model,
-            [(l,i,j) in pm.ref[r][:arcs_dc]], basename="$(r)_q_dc",
+        pm.var[n][:q_dc] = @variable(pm.model,
+            [(l,i,j) in pm.ref[n][:arcs_dc]], basename="$(n)_q_dc",
             start = qref[(l,i,j)]
         )
     end
-    return pm.var[r][:q_dc]
+    return pm.var[n][:q_dc]
 end
 
 ##################################################################

--- a/src/core/variable.jl
+++ b/src/core/variable.jl
@@ -195,9 +195,9 @@ end
 
 
 "generates variables for both `active` and `reactive` generation"
-function variable_generation(pm::GenericPowerModel; kwargs...)
-    variable_active_generation(pm; kwargs...)
-    variable_reactive_generation(pm; kwargs...)
+function variable_generation(pm::GenericPowerModel, n::Symbol=:base; kwargs...)
+    variable_active_generation(pm, n; kwargs...)
+    variable_reactive_generation(pm, n; kwargs...)
 end
 
 
@@ -238,9 +238,9 @@ function variable_reactive_generation(pm::GenericPowerModel, n::Symbol=:base; bo
 end
 
 ""
-function variable_line_flow(pm::GenericPowerModel; kwargs...)
-    variable_active_line_flow(pm; kwargs...)
-    variable_reactive_line_flow(pm; kwargs...)
+function variable_line_flow(pm::GenericPowerModel, n::Symbol=:base; kwargs...)
+    variable_active_line_flow(pm, n; kwargs...)
+    variable_reactive_line_flow(pm, n; kwargs...)
 end
 
 
@@ -280,9 +280,9 @@ function variable_reactive_line_flow(pm::GenericPowerModel, n::Symbol=:base; bou
     return pm.var[n][:q]
 end
 
-function variable_dcline_flow(pm::GenericPowerModel; kwargs...)
-    variable_active_dcline_flow(pm; kwargs...)
-    variable_reactive_dcline_flow(pm; kwargs...)
+function variable_dcline_flow(pm::GenericPowerModel, n::Symbol=:base; kwargs...)
+    variable_active_dcline_flow(pm, n; kwargs...)
+    variable_reactive_dcline_flow(pm, n; kwargs...)
 end
 
 "variable: `p_dc[l,i,j]` for `(l,i,j)` in `arcs_dc`"

--- a/src/core/variable.jl
+++ b/src/core/variable.jl
@@ -10,30 +10,30 @@ end
 
 
 "variable: `t[i]` for `i` in `bus`es"
-function variable_phase_angle(pm::GenericPowerModel, n::Symbol=:base; bounded::Bool = true)
-    pm.var[n][:t] = @variable(pm.model,
-        [i in keys(pm.ref[n][:bus])], basename="$(n)_t",
-        start = getstart(pm.ref[n][:bus], i, "t_start")
+function variable_phase_angle(pm::GenericPowerModel, n::Int=0; bounded::Bool = true)
+    pm.var[:nw][n][:t] = @variable(pm.model,
+        [i in keys(pm.ref[:nw][n][:bus])], basename="$(n)_t",
+        start = getstart(pm.ref[:nw][n][:bus], i, "t_start")
     )
-    return pm.var[n][:t]
+    #return pm.var[:nw][n][:t]
 end
 
 "variable: `v[i]` for `i` in `bus`es"
-function variable_voltage_magnitude(pm::GenericPowerModel, n::Symbol=:base; bounded = true)
+function variable_voltage_magnitude(pm::GenericPowerModel, n::Int=0; bounded = true)
     if bounded
-        pm.var[n][:v] = @variable(pm.model,
-            [i in keys(pm.ref[n][:bus])], basename="$(n)_v",
-            lowerbound = pm.ref[n][:bus][i]["vmin"],
-            upperbound = pm.ref[n][:bus][i]["vmax"],
-            start = getstart(pm.ref[n][:bus], i, "v_start", 1.0)
+        pm.var[:nw][n][:v] = @variable(pm.model,
+            [i in keys(pm.ref[:nw][n][:bus])], basename="$(n)_v",
+            lowerbound = pm.ref[:nw][n][:bus][i]["vmin"],
+            upperbound = pm.ref[:nw][n][:bus][i]["vmax"],
+            start = getstart(pm.ref[:nw][n][:bus], i, "v_start", 1.0)
         )
     else
-        pm.var[n][:v] = @variable(pm.model,
-            [i in keys(pm.ref[n][:bus])], basename="$(n)_v",
+        pm.var[:nw][n][:v] = @variable(pm.model,
+            [i in keys(pm.ref[:nw][n][:bus])], basename="$(n)_v",
             lowerbound = 0,
-            start = getstart(pm.ref[n][:bus], i, "v_start", 1.0))
+            start = getstart(pm.ref[:nw][n][:bus], i, "v_start", 1.0))
     end
-    return pm.var[n][:v]
+    return pm.var[:nw][n][:v]
 end
 
 
@@ -195,160 +195,160 @@ end
 
 
 "generates variables for both `active` and `reactive` generation"
-function variable_generation(pm::GenericPowerModel, n::Symbol=:base; kwargs...)
+function variable_generation(pm::GenericPowerModel, n::Int=0; kwargs...)
     variable_active_generation(pm, n; kwargs...)
     variable_reactive_generation(pm, n; kwargs...)
 end
 
 
 "variable: `pg[j]` for `j` in `gen`"
-function variable_active_generation(pm::GenericPowerModel, n::Symbol=:base; bounded = true)
+function variable_active_generation(pm::GenericPowerModel, n::Int=0; bounded = true)
     if bounded
-        pm.var[n][:pg] = @variable(pm.model,
-            [i in keys(pm.ref[n][:gen])], basename="$(n)_pg",
-            lowerbound = pm.ref[n][:gen][i]["pmin"],
-            upperbound = pm.ref[n][:gen][i]["pmax"],
-            start = getstart(pm.ref[n][:gen], i, "pg_start")
+        pm.var[:nw][n][:pg] = @variable(pm.model,
+            [i in keys(pm.ref[:nw][n][:gen])], basename="$(n)_pg",
+            lowerbound = pm.ref[:nw][n][:gen][i]["pmin"],
+            upperbound = pm.ref[:nw][n][:gen][i]["pmax"],
+            start = getstart(pm.ref[:nw][n][:gen], i, "pg_start")
         )
     else
-        pm.var[n][:pg] = @variable(pm.model,
-            [i in keys(pm.ref[n][:gen])], basename="$(n)_pg",
-            start = getstart(pm.ref[n][:gen], i, "pg_start")
+        pm.var[:nw][n][:pg] = @variable(pm.model,
+            [i in keys(pm.ref[:nw][n][:gen])], basename="$(n)_pg",
+            start = getstart(pm.ref[:nw][n][:gen], i, "pg_start")
         )
     end
-    return pm.var[n][:pg]
+    return pm.var[:nw][n][:pg]
 end
 
 "variable: `qq[j]` for `j` in `gen`"
-function variable_reactive_generation(pm::GenericPowerModel, n::Symbol=:base; bounded = true)
+function variable_reactive_generation(pm::GenericPowerModel, n::Int=0; bounded = true)
     if bounded
-        pm.var[n][:qg] = @variable(pm.model,
-            [i in keys(pm.ref[n][:gen])], basename="$(n)_qg",
-            lowerbound = pm.ref[n][:gen][i]["qmin"],
-            upperbound = pm.ref[n][:gen][i]["qmax"],
-            start = getstart(pm.ref[n][:gen], i, "qg_start")
+        pm.var[:nw][n][:qg] = @variable(pm.model,
+            [i in keys(pm.ref[:nw][n][:gen])], basename="$(n)_qg",
+            lowerbound = pm.ref[:nw][n][:gen][i]["qmin"],
+            upperbound = pm.ref[:nw][n][:gen][i]["qmax"],
+            start = getstart(pm.ref[:nw][n][:gen], i, "qg_start")
         )
     else
-        pm.var[:qg] = @variable(pm.model,
-            [i in keys(pm.ref[n][:gen])], basename="$(n)_qg",
-            start = getstart(pm.ref[n][:gen], i, "qg_start")
+        pm.var[:nw][n][:qg] = @variable(pm.model,
+            [i in keys(pm.ref[:nw][n][:gen])], basename="$(n)_qg",
+            start = getstart(pm.ref[:nw][n][:gen], i, "qg_start")
         )
     end
-    return pm.var[n][:qg]
+    return pm.var[:nw][n][:qg]
 end
 
 ""
-function variable_line_flow(pm::GenericPowerModel, n::Symbol=:base; kwargs...)
+function variable_line_flow(pm::GenericPowerModel, n::Int=0; kwargs...)
     variable_active_line_flow(pm, n; kwargs...)
     variable_reactive_line_flow(pm, n; kwargs...)
 end
 
 
 "variable: `p[l,i,j]` for `(l,i,j)` in `arcs`"
-function variable_active_line_flow(pm::GenericPowerModel, n::Symbol=:base; bounded = true)
+function variable_active_line_flow(pm::GenericPowerModel, n::Int=0; bounded = true)
     if bounded
-        pm.var[n][:p] = @variable(pm.model,
-            [(l,i,j) in pm.ref[n][:arcs]], basename="$(n)_p",
-            lowerbound = -pm.ref[n][:branch][l]["rate_a"],
-            upperbound =  pm.ref[n][:branch][l]["rate_a"],
-            start = getstart(pm.ref[n][:branch], l, "p_start")
+        pm.var[:nw][n][:p] = @variable(pm.model,
+            [(l,i,j) in pm.ref[:nw][n][:arcs]], basename="$(n)_p",
+            lowerbound = -pm.ref[:nw][n][:branch][l]["rate_a"],
+            upperbound =  pm.ref[:nw][n][:branch][l]["rate_a"],
+            start = getstart(pm.ref[:nw][n][:branch], l, "p_start")
         )
     else
-        pm.var[:p] = @variable(pm.model,
-            [(l,i,j) in pm.ref[n][:arcs]], basename="$(n)_p",
-            start = getstart(pm.ref[n][:branch], l, "p_start")
+        pm.var[:nw][n][:p] = @variable(pm.model,
+            [(l,i,j) in pm.ref[:nw][n][:arcs]], basename="$(n)_p",
+            start = getstart(pm.ref[:nw][n][:branch], l, "p_start")
         )
     end
-    return pm.var[n][:p]
+    return pm.var[:nw][n][:p]
 end
 
 "variable: `q[l,i,j]` for `(l,i,j)` in `arcs`"
-function variable_reactive_line_flow(pm::GenericPowerModel, n::Symbol=:base; bounded = true)
+function variable_reactive_line_flow(pm::GenericPowerModel, n::Int=:base; bounded = true)
     if bounded
-        pm.var[n][:q] = @variable(pm.model,
-            [(l,i,j) in pm.ref[n][:arcs]], basename="$(n)_q",
-            lowerbound = -pm.ref[n][:branch][l]["rate_a"],
-            upperbound =  pm.ref[n][:branch][l]["rate_a"],
-            start = getstart(pm.ref[n][:branch], l, "q_start")
+        pm.var[:nw][n][:q] = @variable(pm.model,
+            [(l,i,j) in pm.ref[:nw][n][:arcs]], basename="$(n)_q",
+            lowerbound = -pm.ref[:nw][n][:branch][l]["rate_a"],
+            upperbound =  pm.ref[:nw][n][:branch][l]["rate_a"],
+            start = getstart(pm.ref[:nw][n][:branch], l, "q_start")
         )
     else
-        pm.var[:q] = @variable(pm.model, 
-            [(l,i,j) in pm.ref[n][:arcs]], basename="$(n)_q",
-            start = getstart(pm.ref[n][:branch], l, "q_start")
+        pm.var[:nw][n][:q] = @variable(pm.model, 
+            [(l,i,j) in pm.ref[:nw][n][:arcs]], basename="$(n)_q",
+            start = getstart(pm.ref[:nw][n][:branch], l, "q_start")
         )
     end
-    return pm.var[n][:q]
+    return pm.var[:nw][n][:q]
 end
 
-function variable_dcline_flow(pm::GenericPowerModel, n::Symbol=:base; kwargs...)
+function variable_dcline_flow(pm::GenericPowerModel, n::Int=0; kwargs...)
     variable_active_dcline_flow(pm, n; kwargs...)
     variable_reactive_dcline_flow(pm, n; kwargs...)
 end
 
 "variable: `p_dc[l,i,j]` for `(l,i,j)` in `arcs_dc`"
-function variable_active_dcline_flow(pm::GenericPowerModel, n::Symbol=:base; bounded = true)
+function variable_active_dcline_flow(pm::GenericPowerModel, n::Int=0; bounded = true)
     # build bounds lookups based over arcs set
     pmin = Dict()
     pref = Dict()
     pmax = Dict()
-    for (l,i,j) in pm.ref[n][:arcs_from_dc]
-        pmin[(l,i,j)] = pm.ref[n][:dcline][l]["pminf"]
-        pmax[(l,i,j)] = pm.ref[n][:dcline][l]["pmaxf"]
-        pref[(l,i,j)] = pm.ref[n][:dcline][l]["pf"]
+    for (l,i,j) in pm.ref[:nw][n][:arcs_from_dc]
+        pmin[(l,i,j)] = pm.ref[:nw][n][:dcline][l]["pminf"]
+        pmax[(l,i,j)] = pm.ref[:nw][n][:dcline][l]["pmaxf"]
+        pref[(l,i,j)] = pm.ref[:nw][n][:dcline][l]["pf"]
     end
-    for (l,i,j) in pm.ref[n][:arcs_to_dc]
-        pmin[(l,i,j)] = pm.ref[n][:dcline][l]["pmint"]
-        pmax[(l,i,j)] = pm.ref[n][:dcline][l]["pmaxt"]
-        pref[(l,i,j)] = pm.ref[n][:dcline][l]["pt"]
+    for (l,i,j) in pm.ref[:nw][n][:arcs_to_dc]
+        pmin[(l,i,j)] = pm.ref[:nw][n][:dcline][l]["pmint"]
+        pmax[(l,i,j)] = pm.ref[:nw][n][:dcline][l]["pmaxt"]
+        pref[(l,i,j)] = pm.ref[:nw][n][:dcline][l]["pt"]
     end
 
     if bounded
-        pm.var[n][:p_dc] = @variable(pm.model,
-            [(l,i,j) in pm.ref[n][:arcs_dc]], basename="$(n)_p_dc",
+        pm.var[:nw][n][:p_dc] = @variable(pm.model,
+            [(l,i,j) in pm.ref[:nw][n][:arcs_dc]], basename="$(n)_p_dc",
             lowerbound = pmin[(l,i,j)],
             upperbound = pmax[(l,i,j)], 
             start = pref[(l,i,j)]
         )
     else
-        pm.var[n][:p_dc] = @variable(pm.model,
-            [(l,i,j) in pm.ref[n][:arcs_dc]], basename="$(n)_p_dc",
+        pm.var[:nw][n][:p_dc] = @variable(pm.model,
+            [(l,i,j) in pm.ref[:nw][n][:arcs_dc]], basename="$(n)_p_dc",
             start = pref[(l,i,j)]
         )
     end
-    return pm.var[n][:p_dc]
+    return pm.var[:nw][n][:p_dc]
 end
 
 "variable: `q_dc[l,i,j]` for `(l,i,j)` in `arcs_dc`"
-function variable_reactive_dcline_flow(pm::GenericPowerModel, n::Symbol=:base; bounded = true)
+function variable_reactive_dcline_flow(pm::GenericPowerModel, n::Int=0; bounded = true)
     # build bounds lookups based over arcs set
     qmin = Dict()
     qref = Dict()
     qmax = Dict()
-    for (l,i,j) in pm.ref[n][:arcs_from_dc]
-        qmin[(l,i,j)] = pm.ref[n][:dcline][l]["qminf"]
-        qmax[(l,i,j)] = pm.ref[n][:dcline][l]["qmaxf"]
-        qref[(l,i,j)] = pm.ref[n][:dcline][l]["qf"]
+    for (l,i,j) in pm.ref[:nw][n][:arcs_from_dc]
+        qmin[(l,i,j)] = pm.ref[:nw][n][:dcline][l]["qminf"]
+        qmax[(l,i,j)] = pm.ref[:nw][n][:dcline][l]["qmaxf"]
+        qref[(l,i,j)] = pm.ref[[:nw]n][:dcline][l]["qf"]
     end
-    for (l,i,j) in pm.ref[n][:arcs_to_dc]
-        qmin[(l,i,j)] = pm.ref[n][:dcline][l]["qmint"]
-        qmax[(l,i,j)] = pm.ref[n][:dcline][l]["qmaxt"]
-        qref[(l,i,j)] = pm.ref[n][:dcline][l]["qt"]
+    for (l,i,j) in pm.ref[:nw][n][:arcs_to_dc]
+        qmin[(l,i,j)] = pm.ref[:nw][n][:dcline][l]["qmint"]
+        qmax[(l,i,j)] = pm.ref[:nw][n][:dcline][l]["qmaxt"]
+        qref[(l,i,j)] = pm.ref[:nw][n][:dcline][l]["qt"]
     end
 
     if bounded
-        pm.var[n][:q_dc] = @variable(pm.model, 
-            q_dc[(l,i,j) in pm.ref[n][:arcs_dc]], basename="$(n)_q_dc",
+        pm.var[:nw][n][:q_dc] = @variable(pm.model, 
+            q_dc[(l,i,j) in pm.ref[:nw][n][:arcs_dc]], basename="$(n)_q_dc",
             lowerbound = qmin[(l,i,j)],
             upperbound = qmax[(l,i,j)],
             start = qref[(l,i,j)]
         )
     else
-        pm.var[n][:q_dc] = @variable(pm.model,
-            [(l,i,j) in pm.ref[n][:arcs_dc]], basename="$(n)_q_dc",
+        pm.var[:nw][n][:q_dc] = @variable(pm.model,
+            [(l,i,j) in pm.ref[:nw][n][:arcs_dc]], basename="$(n)_q_dc",
             start = qref[(l,i,j)]
         )
     end
-    return pm.var[n][:q_dc]
+    return pm.var[:nw][n][:q_dc]
 end
 
 ##################################################################

--- a/src/core/variable.jl
+++ b/src/core/variable.jl
@@ -38,25 +38,25 @@ end
 
 
 "real part of the voltage variable `i` in `bus`es"
-function variable_voltage_real(pm::GenericPowerModel; bounded::Bool = true)
-    pm.var[:vr] = @variable(pm.model, 
-        [i in keys(pm.ref[:bus])], basename="vr",
-        lowerbound = -pm.ref[:bus][i]["vmax"],
-        upperbound =  pm.ref[:bus][i]["vmax"], 
-        start = getstart(pm.ref[:bus], i, "vr_start", 1.0)
+function variable_voltage_real(pm::GenericPowerModel, n::Int=0; bounded::Bool = true)
+    pm.var[:nw][n][:vr] = @variable(pm.model, 
+        [i in keys(pm.ref[:nw][n][:bus])], basename="$(n)_vr",
+        lowerbound = -pm.ref[:nw][n][:bus][i]["vmax"],
+        upperbound =  pm.ref[:nw][n][:bus][i]["vmax"], 
+        start = getstart(pm.ref[:nw][n][:bus], i, "vr_start", 1.0)
     )
-    return pm.var[:vr]
+    return pm.var[:nw][n][:vr]
 end
 
 "real part of the voltage variable `i` in `bus`es"
-function variable_voltage_imaginary(pm::GenericPowerModel; bounded::Bool = true)
-    pm.var[:vi] = @variable(pm.model, 
-        [i in keys(pm.ref[:bus])], basename="vi",
-        lowerbound = -pm.ref[:bus][i]["vmax"],
-        upperbound =  pm.ref[:bus][i]["vmax"],
-        start = getstart(pm.ref[:bus], i, "vi_start")
+function variable_voltage_imaginary(pm::GenericPowerModel, n::Int=0; bounded::Bool = true)
+    pm.var[:nw][n][:vi] = @variable(pm.model, 
+        [i in keys(pm.ref[:nw][n][:bus])], basename="$(n)_vi",
+        lowerbound = -pm.ref[:nw][n][:bus][i]["vmax"],
+        upperbound =  pm.ref[:nw][n][:bus][i]["vmax"],
+        start = getstart(pm.ref[:nw][n][:bus], i, "vi_start")
     )
-    return pm.var[:vi]
+    return pm.var[:nw][n][:vi]
 end
 
 
@@ -67,7 +67,7 @@ function variable_voltage_magnitude_from_on_off(pm::GenericPowerModel)
     branches = pm.ref[:branch]
 
     pm.var[:v_from] = @variable(pm.model,
-        [i in keys(pm.ref[:branch])], basename="v_from",
+        [i in keys(pm.ref[:branch])], basename="$(n)_v_from",
         lowerbound = 0,
         upperbound = buses[branches[i]["f_bus"]]["vmax"],
         start = getstart(pm.ref[:bus], i, "v_from_start", 1.0)
@@ -82,7 +82,7 @@ function variable_voltage_magnitude_to_on_off(pm::GenericPowerModel)
     branches = pm.ref[:branch]
 
     pm.var[:v_to] = @variable(pm.model,
-        [i in keys(pm.ref[:branch])], basename="v_to",
+        [i in keys(pm.ref[:branch])], basename="$(n)_v_to",
         lowerbound = 0,
         upperbound = buses[branches[i]["t_bus"]]["vmax"],
         start = getstart(pm.ref[:bus], i, "v_to_start", 1.0)
@@ -93,22 +93,22 @@ end
 
 
 "variable: `w[i] >= 0` for `i` in `bus`es"
-function variable_voltage_magnitude_sqr(pm::GenericPowerModel; bounded = true)
+function variable_voltage_magnitude_sqr(pm::GenericPowerModel, n::Int=0; bounded = true)
     if bounded
-        pm.var[:w] = @variable(pm.model, 
-            [i in keys(pm.ref[:bus])], basename="w",
-            lowerbound = pm.ref[:bus][i]["vmin"]^2,
-            upperbound = pm.ref[:bus][i]["vmax"]^2,
-            start = getstart(pm.ref[:bus], i, "w_start", 1.001)
+        pm.var[:nw][n][:w] = @variable(pm.model, 
+            [i in keys(pm.ref[:nw][n][:bus])], basename="$(n)_w",
+            lowerbound = pm.ref[:nw][n][:bus][i]["vmin"]^2,
+            upperbound = pm.ref[:nw][n][:bus][i]["vmax"]^2,
+            start = getstart(pm.ref[:nw][n][:bus], i, "w_start", 1.001)
         )
     else
-        pm.var[:w] = @variable(pm.model, 
-            [i in keys(pm.ref[:bus])], basename="w",
+        pm.var[:nw][n][:w] = @variable(pm.model, 
+            [i in keys(pm.ref[:nw][n][:bus])], basename="$(n)_w",
             lowerbound = 0,
-            start = getstart(pm.ref[:bus], i, "w_start", 1.001)
+            start = getstart(pm.ref[:nw][n][:bus], i, "w_start", 1.001)
         )
     end
-    return pm.var[:w]
+    return pm.var[:nw][n][:w]
 end
 
 "variable: `0 <= w_from[l] <= buses[branches[l][\"f_bus\"]][\"vmax\"]^2` for `l` in `branch`es"
@@ -117,7 +117,7 @@ function variable_voltage_magnitude_sqr_from_on_off(pm::GenericPowerModel)
     branches = pm.ref[:branch]
 
     pm.var[:w_from] = @variable(pm.model,
-        [i in keys(pm.ref[:branch])], basename="w_from",
+        [i in keys(pm.ref[:branch])], basename="$(n)_w_from",
         lowerbound = 0,
         upperbound = buses[branches[i]["f_bus"]]["vmax"]^2,
         start = getstart(pm.ref[:bus], i, "w_from_start", 1.001)
@@ -132,7 +132,7 @@ function variable_voltage_magnitude_sqr_to_on_off(pm::GenericPowerModel)
     branches = pm.ref[:branch]
 
     pm.var[:w_to] = @variable(pm.model, 
-        [i in keys(pm.ref[:branch])], basename="w_to",
+        [i in keys(pm.ref[:branch])], basename="$(n)_w_to",
         lowerbound = 0,
         upperbound = buses[branches[i]["t_bus"]]["vmax"]^2,
         start = getstart(pm.ref[:bus], i, "w_to_start", 1.001)
@@ -143,33 +143,33 @@ end
 
 
 ""
-function variable_voltage_product(pm::GenericPowerModel; bounded = true)
+function variable_voltage_product(pm::GenericPowerModel, n::Int=0; bounded = true)
     if bounded
-        wr_min, wr_max, wi_min, wi_max = calc_voltage_product_bounds(pm.ref[:buspairs])
+        wr_min, wr_max, wi_min, wi_max = calc_voltage_product_bounds(pm.ref[:nw][n][:buspairs])
 
-        pm.var[:wr] = @variable(pm.model, 
-            [bp in keys(pm.ref[:buspairs])], basename="wr",
+        pm.var[:nw][n][:wr] = @variable(pm.model, 
+            [bp in keys(pm.ref[:nw][n][:buspairs])], basename="$(n)_wr",
             lowerbound = wr_min[bp],
             upperbound = wr_max[bp],
-            start = getstart(pm.ref[:buspairs], bp, "wr_start", 1.0)
+            start = getstart(pm.ref[:nw][n][:buspairs], bp, "wr_start", 1.0)
         )
-        pm.var[:wi] = @variable(pm.model,
-            wi[bp in keys(pm.ref[:buspairs])], basename="wi",
+        pm.var[:nw][n][:wi] = @variable(pm.model,
+            wi[bp in keys(pm.ref[:nw][n][:buspairs])], basename="$(n)_wi",
             lowerbound = wi_min[bp],
             upperbound = wi_max[bp],
-            start = getstart(pm.ref[:buspairs], bp, "wi_start")
+            start = getstart(pm.ref[:nw][n][:buspairs], bp, "wi_start")
         )
     else
         pm.var[:wr] = @variable(pm.model,
-            [bp in keys(pm.ref[:buspairs])], basename="wr",
-            start = getstart(pm.ref[:buspairs], bp, "wr_start", 1.0)
+            [bp in keys(pm.ref[:nw][n][:buspairs])], basename="$(n)_wr",
+            start = getstart(pm.ref[:nw][n][:buspairs], bp, "wr_start", 1.0)
         )
         pm.var[:wi] = @variable(pm.model, 
-            [bp in keys(pm.ref[:buspairs])], basename="wi",
-            start = getstart(pm.ref[:buspairs], bp, "wi_start")
+            [bp in keys(pm.ref[:nw][n][:buspairs])], basename="$(n)_wi",
+            start = getstart(pm.ref[:nw][n][:buspairs], bp, "wi_start")
         )
     end
-    return pm.var[:wr], pm.var[:wi]
+    return pm.var[:nw][n][:wr], pm.var[:nw][n][:wi]
 end
 
 ""
@@ -327,7 +327,7 @@ function variable_reactive_dcline_flow(pm::GenericPowerModel, n::Int=0; bounded 
     for (l,i,j) in pm.ref[:nw][n][:arcs_from_dc]
         qmin[(l,i,j)] = pm.ref[:nw][n][:dcline][l]["qminf"]
         qmax[(l,i,j)] = pm.ref[:nw][n][:dcline][l]["qmaxf"]
-        qref[(l,i,j)] = pm.ref[[:nw]n][:dcline][l]["qf"]
+        qref[(l,i,j)] = pm.ref[:nw][n][:dcline][l]["qf"]
     end
     for (l,i,j) in pm.ref[:nw][n][:arcs_to_dc]
         qmin[(l,i,j)] = pm.ref[:nw][n][:dcline][l]["qmint"]

--- a/src/form/acp.jl
+++ b/src/form/acp.jl
@@ -27,7 +27,7 @@ end
 variable_voltage_ne{T <: AbstractACPForm}(pm::GenericPowerModel{T}; kwargs...) = nothing
 
 "do nothing, this model does not have complex voltage constraints"
-constraint_voltage{T <: AbstractACPForm}(pm::GenericPowerModel{T}, n::Symbol=:base) = Set()
+constraint_voltage{T <: AbstractACPForm}(pm::GenericPowerModel{T}, n::Int=0) = Set()
 
 "do nothing, this model does not have complex voltage constraints"
 constraint_voltage_ne{T <: AbstractACPForm}(pm::GenericPowerModel{T}) = nothing

--- a/src/form/acp.jl
+++ b/src/form/acp.jl
@@ -18,16 +18,16 @@ ACPPowerModel(data::Dict{String,Any}; kwargs...) =
     GenericPowerModel(data, StandardACPForm; kwargs...)
 
 ""
-function variable_voltage{T <: AbstractACPForm}(pm::GenericPowerModel{T}; kwargs...)
-    variable_phase_angle(pm; kwargs...)
-    variable_voltage_magnitude(pm; kwargs...)
+function variable_voltage{T <: AbstractACPForm}(pm::GenericPowerModel{T}, n::Symbol=:base; kwargs...)
+    variable_phase_angle(pm, n; kwargs...)
+    variable_voltage_magnitude(pm, n; kwargs...)
 end
 
 ""
 variable_voltage_ne{T <: AbstractACPForm}(pm::GenericPowerModel{T}; kwargs...) = nothing
 
 "do nothing, this model does not have complex voltage constraints"
-constraint_voltage{T <: AbstractACPForm}(pm::GenericPowerModel{T}) = Set()
+constraint_voltage{T <: AbstractACPForm}(pm::GenericPowerModel{T}, n::Symbol=:base) = Set()
 
 "do nothing, this model does not have complex voltage constraints"
 constraint_voltage_ne{T <: AbstractACPForm}(pm::GenericPowerModel{T}) = nothing

--- a/src/form/acp.jl
+++ b/src/form/acp.jl
@@ -33,8 +33,8 @@ constraint_voltage{T <: AbstractACPForm}(pm::GenericPowerModel{T}, n::Int=0) = S
 constraint_voltage_ne{T <: AbstractACPForm}(pm::GenericPowerModel{T}) = nothing
 
 "`vm - epsilon <= v[i] <= vm + epsilon`"
-function constraint_voltage_magnitude_setpoint{T <: AbstractACPForm}(pm::GenericPowerModel{T}, i, vm, epsilon)
-    v = pm.var[:v][i]
+function constraint_voltage_magnitude_setpoint{T <: AbstractACPForm}(pm::GenericPowerModel{T}, n::Int, i, vm, epsilon)
+    v = pm.var[:nw][n][:v][i]
 
     if epsilon == 0.0
         c = @constraint(pm.model, v == vm)
@@ -52,9 +52,9 @@ v_from  - epsilon <= v[i] <= v_from + epsilon
 v_to  - epsilon <= v[i] <= v_to + epsilon
 '''
 """
-function constraint_voltage_dcline_setpoint{T <: AbstractACPForm}(pm::GenericPowerModel{T}, f_bus, t_bus, vf, vt, epsilon)
-    v_f = pm.var[:v][f_bus]
-    v_t = pm.var[:v][t_bus]
+function constraint_voltage_dcline_setpoint{T <: AbstractACPForm}(pm::GenericPowerModel{T}, n::Int, f_bus, t_bus, vf, vt, epsilon)
+    v_f = pm.var[:nw][n][:v][f_bus]
+    v_t = pm.var[:nw][n][:v][t_bus]
 
     if epsilon == 0.0
         c1 = @constraint(pm.model, v_f == vf)
@@ -339,19 +339,20 @@ APIACPPowerModel(data::Dict{String,Any}; kwargs...) =
     GenericPowerModel(data, APIACPForm; kwargs...)
 
 "variable: load_factor >= 1.0"
-function variable_load_factor(pm::GenericPowerModel)
-    pm.var[:load_factor] = @variable(pm.model,
+function variable_load_factor(pm::GenericPowerModel, n::Int=0)
+    pm.var[:nw][n][:load_factor] = @variable(pm.model,
         basename="load_factor",
         lowerbound=1.0,
         start = 1.0
     )
-    return pm.var[:load_factor]
+    return pm.var[:nw][n][:load_factor]
 end
 
 "objective: Max. load_factor"
-objective_max_loading(pm::GenericPowerModel) =
-    @objective(pm.model, Max, pm.var[:load_factor])
+objective_max_loading(pm::GenericPowerModel, n::Int=0) =
+    @objective(pm.model, Max, pm.var[:nw][n][:load_factor])
 
+#=
 ""
 function objective_max_loading_voltage_norm(pm::GenericPowerModel)
     # Seems to create too much reactive power and makes even small models hard to converge
@@ -374,38 +375,38 @@ function objective_max_loading_gen_output(pm::GenericPowerModel)
 
     return @NLobjective(pm.model, Max, 100*scale*load_factor - sum( (pg[i]^2 - (2*qg[i])^2)^2 for (i,gen) in pm.ref[:gen] ))
 end
+=#
 
 ""
-function bounds_tighten_voltage(pm::APIACPPowerModel; epsilon = 0.001)
-    for (i,bus) in pm.ref[:bus]
-        v = pm.var[:v][i]
-        setupperbound(v, bus["vmax"]*(1.0-epsilon))
-        setlowerbound(v, bus["vmin"]*(1.0+epsilon))
+bounds_tighten_voltage(pm::APIACPPowerModel, bus; kwargs...) = bounds_tighten_voltage(pm, 0, bus; kwargs...)
+function bounds_tighten_voltage(pm::APIACPPowerModel, n::Int, bus; epsilon = 0.001)
+    v = pm.var[:nw][n][:v][bus["index"]]
+    setupperbound(v, bus["vmax"]*(1.0-epsilon))
+    setlowerbound(v, bus["vmin"]*(1.0+epsilon))
+end
+
+""
+upperbound_negative_active_generation(pm::APIACPPowerModel, gen; kwargs...) = upperbound_negative_active_generation(pm, 0, gen; kwargs...)
+function upperbound_negative_active_generation(pm::APIACPPowerModel, n::Int, gen)
+    if gen["pmax"] <= 0
+        pg = pm.var[:nw][n][:pg][gen["index"]]
+        setupperbound(pg, gen["pmax"])
     end
 end
 
 ""
-function upperbound_negative_active_generation(pm::APIACPPowerModel)
-    for (i,gen) in pm.ref[:gen]
-        if gen["pmax"] <= 0
-            pg = pm.var[:pg][i]
-            setupperbound(pg, gen["pmax"])
-        end
-    end
-end
-
-""
-function constraint_kcl_shunt_scaled(pm::APIACPPowerModel, bus)
+constraint_kcl_shunt_scaled(pm::APIACPPowerModel, bus) = constraint_kcl_shunt_scaled(pm, 0, bus)
+function constraint_kcl_shunt_scaled(pm::APIACPPowerModel, n::Int, bus)
     i = bus["index"]
-    bus_arcs = pm.ref[:bus_arcs][i]
-    bus_gens = pm.ref[:bus_gens][i]
+    bus_arcs = pm.ref[:nw][n][:bus_arcs][i]
+    bus_gens = pm.ref[:nw][n][:bus_gens][i]
 
-    load_factor = pm.var[:load_factor]
-    v = pm.var[:v]
-    p = pm.var[:p]
-    q = pm.var[:q]
-    pg = pm.var[:pg]
-    qg = pm.var[:qg]
+    load_factor = pm.var[:nw][n][:load_factor]
+    v = pm.var[:nw][n][:v]
+    p = pm.var[:nw][n][:p]
+    q = pm.var[:nw][n][:q]
+    pg = pm.var[:nw][n][:pg]
+    qg = pm.var[:nw][n][:qg]
 
     if bus["pd"] > 0 && bus["qd"] > 0
         c1 = @constraint(pm.model, sum(p[a] for a in bus_arcs) == sum(pg[g] for g in bus_gens) - bus["pd"]*load_factor - bus["gs"]*v[i]^2)
@@ -420,22 +421,21 @@ function constraint_kcl_shunt_scaled(pm::APIACPPowerModel, bus)
 end
 
 ""
-function get_solution(pm::APIACPPowerModel)
+function get_solution(pm::APIACPPowerModel, n::String)
     # super fallback
-    sol = init_solution(pm)
-    add_bus_voltage_setpoint(sol, pm)
-    add_generator_power_setpoint(sol, pm)
-    add_branch_flow_setpoint(sol, pm)
+    sol = init_solution(pm, n)
+    add_bus_voltage_setpoint(sol, pm, n)
+    add_generator_power_setpoint(sol, pm, n)
+    add_branch_flow_setpoint(sol, pm, n)
 
     # extension
-    add_bus_demand_setpoint(sol, pm)
+    add_bus_demand_setpoint(sol, pm, n)
 
     return sol
 end
 
 ""
-function add_bus_demand_setpoint(sol, pm::APIACPPowerModel)
-    mva_base = pm.data["baseMVA"]
-    add_setpoint(sol, pm, "bus", "bus_i", "pd", :load_factor; default_value = (item) -> item["pd"], scale = (x,item) -> item["pd"] > 0 && item["qd"] > 0 ? x*item["pd"] : item["pd"], extract_var = (var,idx,item) -> var)
-    add_setpoint(sol, pm, "bus", "bus_i", "qd", :load_factor; default_value = (item) -> item["qd"], scale = (x,item) -> item["qd"], extract_var = (var,idx,item) -> var)
+function add_bus_demand_setpoint(sol, pm::APIACPPowerModel, n::String)
+    add_setpoint(sol, pm, n, "bus", "bus_i", "pd", :load_factor; default_value = (item) -> item["pd"], scale = (x,item) -> item["pd"] > 0 && item["qd"] > 0 ? x*item["pd"] : item["pd"], extract_var = (var,idx,item) -> var)
+    add_setpoint(sol, pm, n, "bus", "bus_i", "qd", :load_factor; default_value = (item) -> item["qd"], scale = (x,item) -> item["qd"], extract_var = (var,idx,item) -> var)
 end

--- a/src/form/acp.jl
+++ b/src/form/acp.jl
@@ -75,14 +75,14 @@ sum(p[a] for a in bus_arcs) + sum(p_dc[a_dc] for a_dc in bus_arcs_dc) == sum(pg[
 sum(q[a] for a in bus_arcs) + sum(q_dc[a_dc] for a_dc in bus_arcs_dc) == sum(qg[g] for g in bus_gens) - qd + bs*v^2
 ```
 """
-function constraint_kcl_shunt{T <: AbstractACPForm}(pm::GenericPowerModel{T}, i, bus_arcs, bus_arcs_dc, bus_gens, pd, qd, gs, bs)
-    v = pm.var[:v][i]
-    p = pm.var[:p]
-    q = pm.var[:q]
-    pg = pm.var[:pg]
-    qg = pm.var[:qg]
-    p_dc = pm.var[:p_dc]
-    q_dc = pm.var[:q_dc]
+function constraint_kcl_shunt{T <: AbstractACPForm}(pm::GenericPowerModel{T}, r::Symbol, i, bus_arcs, bus_arcs_dc, bus_gens, pd, qd, gs, bs)
+    v = pm.var[r][:v][i]
+    p = pm.var[r][:p]
+    q = pm.var[r][:q]
+    pg = pm.var[r][:pg]
+    qg = pm.var[r][:qg]
+    p_dc = pm.var[r][:p_dc]
+    q_dc = pm.var[r][:q_dc]
 
     c1 = @constraint(pm.model, sum(p[a] for a in bus_arcs) + sum(p_dc[a_dc] for a_dc in bus_arcs_dc) == sum(pg[g] for g in bus_gens) - pd - gs*v^2)
     c2 = @constraint(pm.model, sum(q[a] for a in bus_arcs) + sum(q_dc[a_dc] for a_dc in bus_arcs_dc) == sum(qg[g] for g in bus_gens) - qd + bs*v^2)
@@ -119,13 +119,13 @@ p[f_idx] == g/tm*v[f_bus]^2 + (-g*tr+b*ti)/tm*(v[f_bus]*v[t_bus]*cos(t[f_bus]-t[
 q[f_idx] == -(b+c/2)/tm*v[f_bus]^2 - (-b*tr-g*ti)/tm*(v[f_bus]*v[t_bus]*cos(t[f_bus]-t[t_bus])) + (-g*tr+b*ti)/tm*(v[f_bus]*v[t_bus]*sin(t[f_bus]-t[t_bus]))
 ```
 """
-function constraint_ohms_yt_from{T <: AbstractACPForm}(pm::GenericPowerModel{T}, f_bus, t_bus, f_idx, t_idx, g, b, c, tr, ti, tm)
-    p_fr = pm.var[:p][f_idx]
-    q_fr = pm.var[:q][f_idx]
-    v_fr = pm.var[:v][f_bus]
-    v_to = pm.var[:v][t_bus]
-    t_fr = pm.var[:t][f_bus]
-    t_to = pm.var[:t][t_bus]
+function constraint_ohms_yt_from{T <: AbstractACPForm}(pm::GenericPowerModel{T}, r::Symbol, f_bus, t_bus, f_idx, t_idx, g, b, c, tr, ti, tm)
+    p_fr = pm.var[r][:p][f_idx]
+    q_fr = pm.var[r][:q][f_idx]
+    v_fr = pm.var[r][:v][f_bus]
+    v_to = pm.var[r][:v][t_bus]
+    t_fr = pm.var[r][:t][f_bus]
+    t_to = pm.var[r][:t][t_bus]
 
     c1 = @NLconstraint(pm.model, p_fr == g/tm*v_fr^2 + (-g*tr+b*ti)/tm*(v_fr*v_to*cos(t_fr-t_to)) + (-b*tr-g*ti)/tm*(v_fr*v_to*sin(t_fr-t_to)) )
     c2 = @NLconstraint(pm.model, q_fr == -(b+c/2)/tm*v_fr^2 - (-b*tr-g*ti)/tm*(v_fr*v_to*cos(t_fr-t_to)) + (-g*tr+b*ti)/tm*(v_fr*v_to*sin(t_fr-t_to)) )
@@ -140,13 +140,13 @@ p[t_idx] == g*v[t_bus]^2 + (-g*tr-b*ti)/tm*(v[t_bus]*v[f_bus]*cos(t[t_bus]-t[f_b
 q[t_idx] == -(b+c/2)*v[t_bus]^2 - (-b*tr+g*ti)/tm*(v[t_bus]*v[f_bus]*cos(t[f_bus]-t[t_bus])) + (-g*tr-b*ti)/tm*(v[t_bus]*v[f_bus]*sin(t[t_bus]-t[f_bus]))
 ```
 """
-function constraint_ohms_yt_to{T <: AbstractACPForm}(pm::GenericPowerModel{T}, f_bus, t_bus, f_idx, t_idx, g, b, c, tr, ti, tm)
-    p_to = pm.var[:p][t_idx]
-    q_to = pm.var[:q][t_idx]
-    v_fr = pm.var[:v][f_bus]
-    v_to = pm.var[:v][t_bus]
-    t_fr = pm.var[:t][f_bus]
-    t_to = pm.var[:t][t_bus]
+function constraint_ohms_yt_to{T <: AbstractACPForm}(pm::GenericPowerModel{T}, r::Symbol, f_bus, t_bus, f_idx, t_idx, g, b, c, tr, ti, tm)
+    p_to = pm.var[r][:p][t_idx]
+    q_to = pm.var[r][:q][t_idx]
+    v_fr = pm.var[r][:v][f_bus]
+    v_to = pm.var[r][:v][t_bus]
+    t_fr = pm.var[r][:t][f_bus]
+    t_to = pm.var[r][:t][t_bus]
 
     c1 = @NLconstraint(pm.model, p_to == g*v_to^2 + (-g*tr-b*ti)/tm*(v_to*v_fr*cos(t_to-t_fr)) + (-b*tr+g*ti)/tm*(v_to*v_fr*sin(t_to-t_fr)) )
     c2 = @NLconstraint(pm.model, q_to == -(b+c/2)*v_to^2 - (-b*tr+g*ti)/tm*(v_to*v_fr*cos(t_fr-t_to)) + (-g*tr-b*ti)/tm*(v_to*v_fr*sin(t_to-t_fr)) )

--- a/src/form/acp.jl
+++ b/src/form/acp.jl
@@ -18,7 +18,7 @@ ACPPowerModel(data::Dict{String,Any}; kwargs...) =
     GenericPowerModel(data, StandardACPForm; kwargs...)
 
 ""
-function variable_voltage{T <: AbstractACPForm}(pm::GenericPowerModel{T}, n::Symbol=:base; kwargs...)
+function variable_voltage{T <: AbstractACPForm}(pm::GenericPowerModel{T}, n::Int=0; kwargs...)
     variable_phase_angle(pm, n; kwargs...)
     variable_voltage_magnitude(pm, n; kwargs...)
 end
@@ -75,14 +75,14 @@ sum(p[a] for a in bus_arcs) + sum(p_dc[a_dc] for a_dc in bus_arcs_dc) == sum(pg[
 sum(q[a] for a in bus_arcs) + sum(q_dc[a_dc] for a_dc in bus_arcs_dc) == sum(qg[g] for g in bus_gens) - qd + bs*v^2
 ```
 """
-function constraint_kcl_shunt{T <: AbstractACPForm}(pm::GenericPowerModel{T}, n::Symbol, i, bus_arcs, bus_arcs_dc, bus_gens, pd, qd, gs, bs)
-    v = pm.var[n][:v][i]
-    p = pm.var[n][:p]
-    q = pm.var[n][:q]
-    pg = pm.var[n][:pg]
-    qg = pm.var[n][:qg]
-    p_dc = pm.var[n][:p_dc]
-    q_dc = pm.var[n][:q_dc]
+function constraint_kcl_shunt{T <: AbstractACPForm}(pm::GenericPowerModel{T}, n::Int, i, bus_arcs, bus_arcs_dc, bus_gens, pd, qd, gs, bs)
+    v = pm.var[:nw][n][:v][i]
+    p = pm.var[:nw][n][:p]
+    q = pm.var[:nw][n][:q]
+    pg = pm.var[:nw][n][:pg]
+    qg = pm.var[:nw][n][:qg]
+    p_dc = pm.var[:nw][n][:p_dc]
+    q_dc = pm.var[:nw][n][:q_dc]
 
     c1 = @constraint(pm.model, sum(p[a] for a in bus_arcs) + sum(p_dc[a_dc] for a_dc in bus_arcs_dc) == sum(pg[g] for g in bus_gens) - pd - gs*v^2)
     c2 = @constraint(pm.model, sum(q[a] for a in bus_arcs) + sum(q_dc[a_dc] for a_dc in bus_arcs_dc) == sum(qg[g] for g in bus_gens) - qd + bs*v^2)
@@ -119,13 +119,13 @@ p[f_idx] == g/tm*v[f_bus]^2 + (-g*tr+b*ti)/tm*(v[f_bus]*v[t_bus]*cos(t[f_bus]-t[
 q[f_idx] == -(b+c/2)/tm*v[f_bus]^2 - (-b*tr-g*ti)/tm*(v[f_bus]*v[t_bus]*cos(t[f_bus]-t[t_bus])) + (-g*tr+b*ti)/tm*(v[f_bus]*v[t_bus]*sin(t[f_bus]-t[t_bus]))
 ```
 """
-function constraint_ohms_yt_from{T <: AbstractACPForm}(pm::GenericPowerModel{T}, n::Symbol, f_bus, t_bus, f_idx, t_idx, g, b, c, tr, ti, tm)
-    p_fr = pm.var[n][:p][f_idx]
-    q_fr = pm.var[n][:q][f_idx]
-    v_fr = pm.var[n][:v][f_bus]
-    v_to = pm.var[n][:v][t_bus]
-    t_fr = pm.var[n][:t][f_bus]
-    t_to = pm.var[n][:t][t_bus]
+function constraint_ohms_yt_from{T <: AbstractACPForm}(pm::GenericPowerModel{T}, n::Int, f_bus, t_bus, f_idx, t_idx, g, b, c, tr, ti, tm)
+    p_fr = pm.var[:nw][n][:p][f_idx]
+    q_fr = pm.var[:nw][n][:q][f_idx]
+    v_fr = pm.var[:nw][n][:v][f_bus]
+    v_to = pm.var[:nw][n][:v][t_bus]
+    t_fr = pm.var[:nw][n][:t][f_bus]
+    t_to = pm.var[:nw][n][:t][t_bus]
 
     c1 = @NLconstraint(pm.model, p_fr == g/tm*v_fr^2 + (-g*tr+b*ti)/tm*(v_fr*v_to*cos(t_fr-t_to)) + (-b*tr-g*ti)/tm*(v_fr*v_to*sin(t_fr-t_to)) )
     c2 = @NLconstraint(pm.model, q_fr == -(b+c/2)/tm*v_fr^2 - (-b*tr-g*ti)/tm*(v_fr*v_to*cos(t_fr-t_to)) + (-g*tr+b*ti)/tm*(v_fr*v_to*sin(t_fr-t_to)) )
@@ -140,13 +140,13 @@ p[t_idx] == g*v[t_bus]^2 + (-g*tr-b*ti)/tm*(v[t_bus]*v[f_bus]*cos(t[t_bus]-t[f_b
 q[t_idx] == -(b+c/2)*v[t_bus]^2 - (-b*tr+g*ti)/tm*(v[t_bus]*v[f_bus]*cos(t[f_bus]-t[t_bus])) + (-g*tr-b*ti)/tm*(v[t_bus]*v[f_bus]*sin(t[t_bus]-t[f_bus]))
 ```
 """
-function constraint_ohms_yt_to{T <: AbstractACPForm}(pm::GenericPowerModel{T}, n::Symbol, f_bus, t_bus, f_idx, t_idx, g, b, c, tr, ti, tm)
-    p_to = pm.var[n][:p][t_idx]
-    q_to = pm.var[n][:q][t_idx]
-    v_fr = pm.var[n][:v][f_bus]
-    v_to = pm.var[n][:v][t_bus]
-    t_fr = pm.var[n][:t][f_bus]
-    t_to = pm.var[n][:t][t_bus]
+function constraint_ohms_yt_to{T <: AbstractACPForm}(pm::GenericPowerModel{T}, n::Int, f_bus, t_bus, f_idx, t_idx, g, b, c, tr, ti, tm)
+    p_to = pm.var[:nw][n][:p][t_idx]
+    q_to = pm.var[:nw][n][:q][t_idx]
+    v_fr = pm.var[:nw][n][:v][f_bus]
+    v_to = pm.var[:nw][n][:v][t_bus]
+    t_fr = pm.var[:nw][n][:t][f_bus]
+    t_to = pm.var[:nw][n][:t][t_bus]
 
     c1 = @NLconstraint(pm.model, p_to == g*v_to^2 + (-g*tr-b*ti)/tm*(v_to*v_fr*cos(t_to-t_fr)) + (-b*tr+g*ti)/tm*(v_to*v_fr*sin(t_to-t_fr)) )
     c2 = @NLconstraint(pm.model, q_to == -(b+c/2)*v_to^2 - (-b*tr+g*ti)/tm*(v_to*v_fr*cos(t_fr-t_to)) + (-g*tr-b*ti)/tm*(v_to*v_fr*sin(t_to-t_fr)) )

--- a/src/form/acp.jl
+++ b/src/form/acp.jl
@@ -75,14 +75,14 @@ sum(p[a] for a in bus_arcs) + sum(p_dc[a_dc] for a_dc in bus_arcs_dc) == sum(pg[
 sum(q[a] for a in bus_arcs) + sum(q_dc[a_dc] for a_dc in bus_arcs_dc) == sum(qg[g] for g in bus_gens) - qd + bs*v^2
 ```
 """
-function constraint_kcl_shunt{T <: AbstractACPForm}(pm::GenericPowerModel{T}, r::Symbol, i, bus_arcs, bus_arcs_dc, bus_gens, pd, qd, gs, bs)
-    v = pm.var[r][:v][i]
-    p = pm.var[r][:p]
-    q = pm.var[r][:q]
-    pg = pm.var[r][:pg]
-    qg = pm.var[r][:qg]
-    p_dc = pm.var[r][:p_dc]
-    q_dc = pm.var[r][:q_dc]
+function constraint_kcl_shunt{T <: AbstractACPForm}(pm::GenericPowerModel{T}, n::Symbol, i, bus_arcs, bus_arcs_dc, bus_gens, pd, qd, gs, bs)
+    v = pm.var[n][:v][i]
+    p = pm.var[n][:p]
+    q = pm.var[n][:q]
+    pg = pm.var[n][:pg]
+    qg = pm.var[n][:qg]
+    p_dc = pm.var[n][:p_dc]
+    q_dc = pm.var[n][:q_dc]
 
     c1 = @constraint(pm.model, sum(p[a] for a in bus_arcs) + sum(p_dc[a_dc] for a_dc in bus_arcs_dc) == sum(pg[g] for g in bus_gens) - pd - gs*v^2)
     c2 = @constraint(pm.model, sum(q[a] for a in bus_arcs) + sum(q_dc[a_dc] for a_dc in bus_arcs_dc) == sum(qg[g] for g in bus_gens) - qd + bs*v^2)
@@ -119,13 +119,13 @@ p[f_idx] == g/tm*v[f_bus]^2 + (-g*tr+b*ti)/tm*(v[f_bus]*v[t_bus]*cos(t[f_bus]-t[
 q[f_idx] == -(b+c/2)/tm*v[f_bus]^2 - (-b*tr-g*ti)/tm*(v[f_bus]*v[t_bus]*cos(t[f_bus]-t[t_bus])) + (-g*tr+b*ti)/tm*(v[f_bus]*v[t_bus]*sin(t[f_bus]-t[t_bus]))
 ```
 """
-function constraint_ohms_yt_from{T <: AbstractACPForm}(pm::GenericPowerModel{T}, r::Symbol, f_bus, t_bus, f_idx, t_idx, g, b, c, tr, ti, tm)
-    p_fr = pm.var[r][:p][f_idx]
-    q_fr = pm.var[r][:q][f_idx]
-    v_fr = pm.var[r][:v][f_bus]
-    v_to = pm.var[r][:v][t_bus]
-    t_fr = pm.var[r][:t][f_bus]
-    t_to = pm.var[r][:t][t_bus]
+function constraint_ohms_yt_from{T <: AbstractACPForm}(pm::GenericPowerModel{T}, n::Symbol, f_bus, t_bus, f_idx, t_idx, g, b, c, tr, ti, tm)
+    p_fr = pm.var[n][:p][f_idx]
+    q_fr = pm.var[n][:q][f_idx]
+    v_fr = pm.var[n][:v][f_bus]
+    v_to = pm.var[n][:v][t_bus]
+    t_fr = pm.var[n][:t][f_bus]
+    t_to = pm.var[n][:t][t_bus]
 
     c1 = @NLconstraint(pm.model, p_fr == g/tm*v_fr^2 + (-g*tr+b*ti)/tm*(v_fr*v_to*cos(t_fr-t_to)) + (-b*tr-g*ti)/tm*(v_fr*v_to*sin(t_fr-t_to)) )
     c2 = @NLconstraint(pm.model, q_fr == -(b+c/2)/tm*v_fr^2 - (-b*tr-g*ti)/tm*(v_fr*v_to*cos(t_fr-t_to)) + (-g*tr+b*ti)/tm*(v_fr*v_to*sin(t_fr-t_to)) )
@@ -140,13 +140,13 @@ p[t_idx] == g*v[t_bus]^2 + (-g*tr-b*ti)/tm*(v[t_bus]*v[f_bus]*cos(t[t_bus]-t[f_b
 q[t_idx] == -(b+c/2)*v[t_bus]^2 - (-b*tr+g*ti)/tm*(v[t_bus]*v[f_bus]*cos(t[f_bus]-t[t_bus])) + (-g*tr-b*ti)/tm*(v[t_bus]*v[f_bus]*sin(t[t_bus]-t[f_bus]))
 ```
 """
-function constraint_ohms_yt_to{T <: AbstractACPForm}(pm::GenericPowerModel{T}, r::Symbol, f_bus, t_bus, f_idx, t_idx, g, b, c, tr, ti, tm)
-    p_to = pm.var[r][:p][t_idx]
-    q_to = pm.var[r][:q][t_idx]
-    v_fr = pm.var[r][:v][f_bus]
-    v_to = pm.var[r][:v][t_bus]
-    t_fr = pm.var[r][:t][f_bus]
-    t_to = pm.var[r][:t][t_bus]
+function constraint_ohms_yt_to{T <: AbstractACPForm}(pm::GenericPowerModel{T}, n::Symbol, f_bus, t_bus, f_idx, t_idx, g, b, c, tr, ti, tm)
+    p_to = pm.var[n][:p][t_idx]
+    q_to = pm.var[n][:q][t_idx]
+    v_fr = pm.var[n][:v][f_bus]
+    v_to = pm.var[n][:v][t_bus]
+    t_fr = pm.var[n][:t][f_bus]
+    t_to = pm.var[n][:t][t_bus]
 
     c1 = @NLconstraint(pm.model, p_to == g*v_to^2 + (-g*tr-b*ti)/tm*(v_to*v_fr*cos(t_to-t_fr)) + (-b*tr+g*ti)/tm*(v_to*v_fr*sin(t_to-t_fr)) )
     c2 = @NLconstraint(pm.model, q_to == -(b+c/2)*v_to^2 - (-b*tr+g*ti)/tm*(v_to*v_fr*cos(t_fr-t_to)) + (-g*tr-b*ti)/tm*(v_to*v_fr*sin(t_to-t_fr)) )

--- a/src/form/acr.jl
+++ b/src/form/acr.jl
@@ -18,19 +18,19 @@ ACRPowerModel(data::Dict{String,Any}; kwargs...) =
 
 
 ""
-function variable_voltage{T <: AbstractACRForm}(pm::GenericPowerModel{T}; kwargs...)
-    variable_voltage_real(pm; kwargs...)
-    variable_voltage_imaginary(pm; kwargs...)
+function variable_voltage{T <: AbstractACRForm}(pm::GenericPowerModel{T}, n::Int=0; kwargs...)
+    variable_voltage_real(pm, n; kwargs...)
+    variable_voltage_imaginary(pm, n; kwargs...)
 end
 
 
 "add constraints for voltage magnitude"
-function constraint_voltage{T <: AbstractACRForm}(pm::GenericPowerModel{T}; kwargs...)
-    vr = pm.var[:vr]
-    vi = pm.var[:vi]
+function constraint_voltage{T <: AbstractACRForm}(pm::GenericPowerModel{T}, n::Int=0; kwargs...)
+    vr = pm.var[:nw][n][:vr]
+    vi = pm.var[:nw][n][:vi]
 
     cs = Set([])
-    for (i,bus) in pm.ref[:bus]
+    for (i,bus) in pm.ref[:nw][n][:bus]
         c1 = @constraint(pm.model, bus["vmin"]^2 <= (vr[i]^2 + vi[i]^2))
         c2 = @constraint(pm.model, bus["vmax"]^2 >= (vr[i]^2 + vi[i]^2))
         push!(cs, Set([c1, c2]))
@@ -54,21 +54,21 @@ end
 
 
 "reference bus angle constraint"
-function constraint_theta_ref{T <: AbstractACRForm}(pm::GenericPowerModel{T}, ref_bus::Int)
-    c = @constraint(pm.model, pm.var[:vi][ref_bus] == 0)
+function constraint_theta_ref{T <: AbstractACRForm}(pm::GenericPowerModel{T}, n::Int, ref_bus::Int)
+    c = @constraint(pm.model, pm.var[:nw][n][:vi][ref_bus] == 0)
     return Set([c])
 end
 
 
-function constraint_kcl_shunt{T <: AbstractACRForm}(pm::GenericPowerModel{T}, i, bus_arcs, bus_arcs_dc, bus_gens, pd, qd, gs, bs)
-    vr = pm.var[:vr][i]
-    vi = pm.var[:vi][i]
-    p = pm.var[:p]
-    q = pm.var[:q]
-    pg = pm.var[:pg]
-    qg = pm.var[:qg]
-    p_dc = pm.var[:p_dc]
-    q_dc = pm.var[:q_dc]
+function constraint_kcl_shunt{T <: AbstractACRForm}(pm::GenericPowerModel{T}, n::Int, i, bus_arcs, bus_arcs_dc, bus_gens, pd, qd, gs, bs)
+    vr = pm.var[:nw][n][:vr][i]
+    vi = pm.var[:nw][n][:vi][i]
+    p = pm.var[:nw][n][:p]
+    q = pm.var[:nw][n][:q]
+    pg = pm.var[:nw][n][:pg]
+    qg = pm.var[:nw][n][:qg]
+    p_dc = pm.var[:nw][n][:p_dc]
+    q_dc = pm.var[:nw][n][:q_dc]
 
     c1 = @constraint(pm.model, sum(p[a] for a in bus_arcs) + sum(p_dc[a_dc] for a_dc in bus_arcs_dc) == sum(pg[g] for g in bus_gens) - pd - gs*(vr^2 + vi^2))
     c2 = @constraint(pm.model, sum(q[a] for a in bus_arcs) + sum(q_dc[a_dc] for a_dc in bus_arcs_dc) == sum(qg[g] for g in bus_gens) - qd + bs*(vr^2 + vi^2))
@@ -79,13 +79,13 @@ end
 """
 Creates Ohms constraints (yt post fix indicates that Y and T values are in rectangular form)
 """
-function constraint_ohms_yt_from{T <: AbstractACRForm}(pm::GenericPowerModel{T}, f_bus, t_bus, f_idx, t_idx, g, b, c, tr, ti, tm)
-    p_fr = pm.var[:p][f_idx]
-    q_fr = pm.var[:q][f_idx]
-    vr_fr = pm.var[:vr][f_bus]
-    vr_to = pm.var[:vr][t_bus]
-    vi_fr = pm.var[:vi][f_bus]
-    vi_to = pm.var[:vi][t_bus]
+function constraint_ohms_yt_from{T <: AbstractACRForm}(pm::GenericPowerModel{T}, n::Int, f_bus, t_bus, f_idx, t_idx, g, b, c, tr, ti, tm)
+    p_fr = pm.var[:nw][n][:p][f_idx]
+    q_fr = pm.var[:nw][n][:q][f_idx]
+    vr_fr = pm.var[:nw][n][:vr][f_bus]
+    vr_to = pm.var[:nw][n][:vr][t_bus]
+    vi_fr = pm.var[:nw][n][:vi][f_bus]
+    vi_to = pm.var[:nw][n][:vi][t_bus]
 
     c1 = @NLconstraint(pm.model, p_fr ==        g/tm*(vr_fr^2 + vi_fr^2) + (-g*tr+b*ti)/tm*(vr_fr*vr_to + vi_fr*vi_to) + (-b*tr-g*ti)/tm*(vi_fr*vr_to - vr_fr*vi_to) )
     c2 = @NLconstraint(pm.model, q_fr == -(b+c/2)/tm*(vr_fr^2 + vi_fr^2) - (-b*tr-g*ti)/tm*(vr_fr*vr_to + vi_fr*vi_to) + (-g*tr+b*ti)/tm*(vi_fr*vr_to - vr_fr*vi_to) )
@@ -95,13 +95,13 @@ end
 """
 Creates Ohms constraints (yt post fix indicates that Y and T values are in rectangular form)
 """
-function constraint_ohms_yt_to{T <: AbstractACRForm}(pm::GenericPowerModel{T}, f_bus, t_bus, f_idx, t_idx, g, b, c, tr, ti, tm)
-    p_to = pm.var[:p][t_idx]
-    q_to = pm.var[:q][t_idx]
-    vr_fr = pm.var[:vr][f_bus]
-    vr_to = pm.var[:vr][t_bus]
-    vi_fr = pm.var[:vi][f_bus]
-    vi_to = pm.var[:vi][t_bus]
+function constraint_ohms_yt_to{T <: AbstractACRForm}(pm::GenericPowerModel{T}, n::Int, f_bus, t_bus, f_idx, t_idx, g, b, c, tr, ti, tm)
+    p_to = pm.var[:nw][n][:p][t_idx]
+    q_to = pm.var[:nw][n][:q][t_idx]
+    vr_fr = pm.var[:nw][n][:vr][f_bus]
+    vr_to = pm.var[:nw][n][:vr][t_bus]
+    vi_fr = pm.var[:nw][n][:vi][f_bus]
+    vi_to = pm.var[:nw][n][:vi][t_bus]
 
     c1 = @NLconstraint(pm.model, p_to ==        g*(vr_to^2 + vi_to^2) + (-g*tr-b*ti)/tm*(vr_fr*vr_to + vi_fr*vi_to) + (-b*tr+g*ti)/tm*(-(vi_fr*vr_to - vr_fr*vi_to)) )
     c2 = @NLconstraint(pm.model, q_to == -(b+c/2)*(vr_to^2 + vi_to^2) - (-b*tr+g*ti)/tm*(vr_fr*vr_to + vi_fr*vi_to) + (-g*tr-b*ti)/tm*(-(vi_fr*vr_to - vr_fr*vi_to)) )
@@ -112,11 +112,11 @@ end
 """
 branch phase angle difference bounds
 """
-function constraint_phase_angle_difference{T <: AbstractACRForm}(pm::GenericPowerModel{T}, f_bus, t_bus, angmin, angmax)
-    vr_fr = pm.var[:vr][f_bus]
-    vr_to = pm.var[:vr][t_bus]
-    vi_fr = pm.var[:vi][f_bus]
-    vi_to = pm.var[:vi][t_bus]
+function constraint_phase_angle_difference{T <: AbstractACRForm}(pm::GenericPowerModel{T}, n::Int, f_bus, t_bus, angmin, angmax)
+    vr_fr = pm.var[:nw][n][:vr][f_bus]
+    vr_to = pm.var[:nw][n][:vr][t_bus]
+    vi_fr = pm.var[:nw][n][:vi][f_bus]
+    vi_to = pm.var[:nw][n][:vi][t_bus]
 
     # this form appears to be more numerically stable than the one below
     c1 = @NLconstraint(pm.model, (vi_fr*vr_to - vr_fr*vi_to)/(vr_fr*vr_to + vi_fr*vi_to) <= tan(angmax))
@@ -130,16 +130,17 @@ end
 
 
 "extracts voltage set points from rectangular voltage form and converts into polar voltage form"
-function add_bus_voltage_setpoint{T <: AbstractACRForm}(sol, pm::GenericPowerModel{T})
+function add_bus_voltage_setpoint{T <: AbstractACRForm}(sol, pm::GenericPowerModel{T}, n::String)
     sol_dict = sol["bus"] = get(sol, "bus", Dict{String,Any}())
-    for (i,item) in pm.data["bus"]
+    for (i,item) in pm.data["nw"][n]["bus"]
         idx = Int(item["bus_i"])
         sol_item = sol_dict[i] = get(sol_dict, i, Dict{String,Any}())
         sol_item["vm"] = NaN
         sol_item["va"] = NaN
         try
-            vr = getvalue(pm.var[:vr][idx])
-            vi = getvalue(pm.var[:vi][idx])
+            ns = parse(Int, n)
+            vr = getvalue(pm.var[:nw][ns][:vr][idx])
+            vi = getvalue(pm.var[:nw][ns][:vi][idx])
             
             vm = sqrt(vr^2 + vi^2)
             sol_item["vm"] = vm

--- a/src/form/act.jl
+++ b/src/form/act.jl
@@ -17,19 +17,19 @@ ACTPowerModel(data::Dict{String,Any}; kwargs...) =
     GenericPowerModel(data, StandardACTForm; kwargs...)
 
 ""
-function variable_voltage{T <: AbstractACTForm}(pm::GenericPowerModel{T}; kwargs...)
-    variable_phase_angle(pm; kwargs...)
-    variable_voltage_magnitude_sqr(pm; kwargs...)
-    variable_voltage_product(pm; kwargs...)
+function variable_voltage{T <: AbstractACTForm}(pm::GenericPowerModel{T}, n::Int=0; kwargs...)
+    variable_phase_angle(pm, n; kwargs...)
+    variable_voltage_magnitude_sqr(pm, n; kwargs...)
+    variable_voltage_product(pm, n; kwargs...)
 end
 
-function constraint_voltage{T <: StandardACTForm}(pm::GenericPowerModel{T})
-    t = pm.var[:t]
-    w = pm.var[:w]
-    wr = pm.var[:wr]
-    wi = pm.var[:wi]
+function constraint_voltage{T <: StandardACTForm}(pm::GenericPowerModel{T}, n::Int=0)
+    t = pm.var[:nw][n][:t]
+    w = pm.var[:nw][n][:w]
+    wr = pm.var[:nw][n][:wr]
+    wi = pm.var[:nw][n][:wi]
 
-    for (i,j) in keys(pm.ref[:buspairs])
+    for (i,j) in keys(pm.ref[:nw][n][:buspairs])
         @NLconstraint(pm.model, wr[(i,j)]^2 + wi[(i,j)]^2 == w[i]*w[j])
         @NLconstraint(pm.model, wi[(i,j)]/wr[(i,j)] == tan(t[i] - t[j]))
     end
@@ -37,7 +37,7 @@ end
 
 
 ""
-function add_bus_voltage_setpoint{T <: AbstractACTForm}(sol, pm::GenericPowerModel{T})
-    add_setpoint(sol, pm, "bus", "bus_i", "vm", :w; scale = (x,item) -> sqrt(x))
-    add_setpoint(sol, pm, "bus", "bus_i", "va", :t)
+function add_bus_voltage_setpoint{T <: AbstractACTForm}(sol, pm::GenericPowerModel{T}, n::String)
+    add_setpoint(sol, pm, n, "bus", "bus_i", "vm", :w; scale = (x,item) -> sqrt(x))
+    add_setpoint(sol, pm, n, "bus", "bus_i", "va", :t)
 end

--- a/src/form/dcp.jl
+++ b/src/form/dcp.jl
@@ -16,83 +16,83 @@ DCPPowerModel(data::Dict{String,Any}; kwargs...) =
     GenericPowerModel(data, StandardDCPForm; kwargs...)
 
 ""
-variable_voltage{T <: AbstractDCPForm}(pm::GenericPowerModel{T}; kwargs...) =
-    variable_phase_angle(pm; kwargs...)
+variable_voltage{T <: AbstractDCPForm}(pm::GenericPowerModel{T}, n::Int=0; kwargs...) =
+    variable_phase_angle(pm, n; kwargs...)
 
 "nothing to add, there are no voltage variables on branches"
-variable_voltage_ne{T <: AbstractDCPForm}(pm::GenericPowerModel{T}; kwargs...) = Set([])
+variable_voltage_ne{T <: AbstractDCPForm}(pm::GenericPowerModel{T}, n::Int=0; kwargs...) = Set([])
 
 "dc models ignore reactive power flows"
-variable_reactive_generation{T <: AbstractDCPForm}(pm::GenericPowerModel{T}; bounded = true) = Set()
+variable_reactive_generation{T <: AbstractDCPForm}(pm::GenericPowerModel{T}, n::Int=0; bounded = true) = Set()
 
 "dc models ignore reactive power flows"
-variable_reactive_line_flow{T <: AbstractDCPForm}(pm::GenericPowerModel{T}; bounded = true) = Set()
+variable_reactive_line_flow{T <: AbstractDCPForm}(pm::GenericPowerModel{T}, n::Int=0; bounded = true) = Set()
 
 "dc models ignore reactive power flows"
-variable_reactive_line_flow_ne{T <: AbstractDCPForm}(pm::GenericPowerModel{T}) = Set([])
+variable_reactive_line_flow_ne{T <: AbstractDCPForm}(pm::GenericPowerModel{T}, n::Int=0) = Set([])
 
 
 ""
-function variable_active_line_flow{T <: StandardDCPForm}(pm::GenericPowerModel{T}; bounded = true)
+function variable_active_line_flow{T <: StandardDCPForm}(pm::GenericPowerModel{T}, n::Int=0; bounded = true)
     if bounded
-        pm.var[:p] = @variable(pm.model, 
-            [(l,i,j) in pm.ref[:arcs_from]], basename="p",
-            lowerbound = -pm.ref[:branch][l]["rate_a"],
-            upperbound =  pm.ref[:branch][l]["rate_a"],
-            start = getstart(pm.ref[:branch], l, "p_start")
+        pm.var[:nw][n][:p] = @variable(pm.model, 
+            [(l,i,j) in pm.ref[:nw][n][:arcs_from]], basename="$(n)_p",
+            lowerbound = -pm.ref[:nw][n][:branch][l]["rate_a"],
+            upperbound =  pm.ref[:nw][n][:branch][l]["rate_a"],
+            start = getstart(pm.ref[:nw][n][:branch], l, "p_start")
         )
     else
-        pm.var[:p] = @variable(pm.model,
-            [(l,i,j) in pm.ref[:arcs_from]], basename="p",
-            start = getstart(pm.ref[:branch], l, "p_start")
+        pm.var[:nw][n][:p] = @variable(pm.model,
+            [(l,i,j) in pm.ref[:nw][n][:arcs_from]], basename="$(n)_p",
+            start = getstart(pm.ref[:nw][n][:branch], l, "p_start")
         )
     end
 
     # this explicit type erasure is necessary 
-    p_expr = Dict{Any,Any}([((l,i,j), pm.var[:p][(l,i,j)]) for (l,i,j) in pm.ref[:arcs_from]])
-    p_expr = merge(p_expr, Dict([((l,j,i), -1.0*pm.var[:p][(l,i,j)]) for (l,i,j) in pm.ref[:arcs_from]]))
-    pm.var[:p] = p_expr
+    p_expr = Dict{Any,Any}([((l,i,j), pm.var[:nw][n][:p][(l,i,j)]) for (l,i,j) in pm.ref[:nw][n][:arcs_from]])
+    p_expr = merge(p_expr, Dict([((l,j,i), -1.0*pm.var[:nw][n][:p][(l,i,j)]) for (l,i,j) in pm.ref[:nw][n][:arcs_from]]))
+    pm.var[:nw][n][:p] = p_expr
 
-    return pm.var[:p]
+    return pm.var[:nw][n][:p]
 end
 
 ""
 function variable_active_line_flow_ne{T <: StandardDCPForm}(pm::GenericPowerModel{T})
     pm.var[:p_ne] = @variable(pm.model, 
-        [(l,i,j) in pm.ref[:ne_arcs_from]], basename="p_ne",
+        [(l,i,j) in pm.ref[:ne_arcs_from]], basename="$(n)_p_ne",
         lowerbound = -pm.ref[:ne_branch][l]["rate_a"],
         upperbound =  pm.ref[:ne_branch][l]["rate_a"],
         start = getstart(pm.ref[:ne_branch], l, "p_start")
     )
 
     # this explicit type erasure is necessary 
-    p_ne_expr = Dict{Any,Any}([((l,i,j), 1.0*pm.var[:p_ne][(l,i,j)]) for (l,i,j) in pm.ref[:ne_arcs_from]])
-    p_ne_expr = merge(p_ne_expr, Dict([((l,j,i), -1.0*pm.var[:p_ne][(l,i,j)]) for (l,i,j) in pm.ref[:ne_arcs_from]]))
+    p_ne_expr = Dict{Any,Any}([((l,i,j), 1.0*pm.var[:p_ne][(l,i,j)]) for (l,i,j) in pm.ref[:nw][n][:ne_arcs_from]])
+    p_ne_expr = merge(p_ne_expr, Dict([((l,j,i), -1.0*pm.var[:p_ne][(l,i,j)]) for (l,i,j) in pm.ref[:nw][n][:ne_arcs_from]]))
     pm.var[:p_ne] = p_ne_expr
 
     return pm.var[:p_ne]
 end
 
 "do nothing, this model does not have complex voltage variables"
-constraint_voltage{T <: AbstractDCPForm}(pm::GenericPowerModel{T}) = nothing
+constraint_voltage{T <: AbstractDCPForm}(pm::GenericPowerModel{T}, n::Int=0) = nothing
 
 "do nothing, this model does not have complex voltage variables"
-constraint_voltage_ne{T <: AbstractDCPForm}(pm::GenericPowerModel{T}) = nothing
+constraint_voltage_ne{T <: AbstractDCPForm}(pm::GenericPowerModel{T}, n::Int=0) = nothing
 
 "do nothing, this model does not have voltage variables"
-constraint_voltage_magnitude_setpoint{T <: AbstractDCPForm}(pm::GenericPowerModel{T}, i, vm, epsilon) = Set()
+constraint_voltage_magnitude_setpoint{T <: AbstractDCPForm}(pm::GenericPowerModel{T}, n::Int, i, vm, epsilon) = Set()
 
 "do nothing, this model does not have reactive variables"
-constraint_reactive_gen_setpoint{T <: AbstractDCPForm}(pm::GenericPowerModel{T}, i, qg) = Set()
+constraint_reactive_gen_setpoint{T <: AbstractDCPForm}(pm::GenericPowerModel{T}, n::Int, i, qg) = Set()
 
 "do nothing, this model does not have voltage variables"
-constraint_voltage_dcline_setpoint{T <: AbstractDCPForm}(pm::GenericPowerModel{T}, f_bus, t_bus, vf, vt, epsilon) = Set()
+constraint_voltage_dcline_setpoint{T <: AbstractDCPForm}(pm::GenericPowerModel{T}, n::Int, f_bus, t_bus, vf, vt, epsilon) = Set()
 
 ""
-function constraint_kcl_shunt{T <: AbstractDCPForm}(pm::GenericPowerModel{T}, i, bus_arcs, bus_arcs_dc, bus_gens, pd, qd, gs, bs)
-    pg = pm.var[:pg]
-    p = pm.var[:p]
-    p_dc = pm.var[:p_dc]
+function constraint_kcl_shunt{T <: AbstractDCPForm}(pm::GenericPowerModel{T}, n::Int, i, bus_arcs, bus_arcs_dc, bus_gens, pd, qd, gs, bs)
+    pg = pm.var[:nw][n][:pg]
+    p = pm.var[:nw][n][:p]
+    p_dc = pm.var[:nw][n][:p_dc]
 
     c = @constraint(pm.model, sum(p[a] for a in bus_arcs) + sum(p_dc[a_dc] for a_dc in bus_arcs_dc) == sum(pg[g] for g in bus_gens) - pd - gs*1.0^2)
     # omit reactive constraint
@@ -100,11 +100,11 @@ function constraint_kcl_shunt{T <: AbstractDCPForm}(pm::GenericPowerModel{T}, i,
 end
 
 ""
-function constraint_kcl_shunt_ne{T <: AbstractDCPForm}(pm::GenericPowerModel{T}, i, bus_arcs, bus_arcs_dc, bus_arcs_ne, bus_gens, pd, qd, gs, bs)
-    pg = pm.var[:pg]
-    p = pm.var[:p]
-    p_ne = pm.var[:p_ne]
-    p_dc = pm.var[:p_dc]
+function constraint_kcl_shunt_ne{T <: AbstractDCPForm}(pm::GenericPowerModel{T}, n::Int, i, bus_arcs, bus_arcs_dc, bus_arcs_ne, bus_gens, pd, qd, gs, bs)
+    pg = pm.var[:nw][n][:pg]
+    p = pm.var[:nw][n][:p]
+    p_ne = pm.var[:nw][n][:p_ne]
+    p_dc = pm.var[:nw][n][:p_dc]
 
     c = @constraint(pm.model, sum(p[a] for a in bus_arcs) + sum(p_ne[a] for a in bus_arcs_ne) + sum(p_dc[a_dc] for a_dc in bus_arcs_dc) == sum(pg[g] for g in bus_gens) - pd - gs*1.0^2)
     return Set([c])
@@ -117,10 +117,10 @@ Creates Ohms constraints (yt post fix indicates that Y and T values are in recta
 p[f_idx] == -b*(t[f_bus] - t[t_bus])
 ```
 """
-function constraint_ohms_yt_from{T <: AbstractDCPForm}(pm::GenericPowerModel{T}, f_bus, t_bus, f_idx, t_idx, g, b, c, tr, ti, tm)
-    p_fr = pm.var[:p][f_idx]
-    t_fr = pm.var[:t][f_bus]
-    t_to = pm.var[:t][t_bus]
+function constraint_ohms_yt_from{T <: AbstractDCPForm}(pm::GenericPowerModel{T}, n::Int, f_bus, t_bus, f_idx, t_idx, g, b, c, tr, ti, tm)
+    p_fr = pm.var[:nw][n][:p][f_idx]
+    t_fr = pm.var[:nw][n][:t][f_bus]
+    t_to = pm.var[:nw][n][:t][t_bus]
 
     c = @constraint(pm.model, p_fr == -b*(t_fr - t_to))
     # omit reactive constraint
@@ -128,13 +128,13 @@ function constraint_ohms_yt_from{T <: AbstractDCPForm}(pm::GenericPowerModel{T},
 end
 
 "Do nothing, this model is symmetric"
-constraint_ohms_yt_to{T <: AbstractDCPForm}(pm::GenericPowerModel{T}, f_bus, t_bus, f_idx, t_idx, g, b, c, tr, ti, tm) = Set()
+constraint_ohms_yt_to{T <: AbstractDCPForm}(pm::GenericPowerModel{T}, n::Int, f_bus, t_bus, f_idx, t_idx, g, b, c, tr, ti, tm) = Set()
 
-function constraint_ohms_yt_from_ne{T <: AbstractDCPForm}(pm::GenericPowerModel{T}, i, f_bus, t_bus, f_idx, t_idx, g, b, c, tr, ti, tm, t_min, t_max)
-    p_fr = pm.var[:p_ne][f_idx]
-    t_fr = pm.var[:t][f_bus]
-    t_to = pm.var[:t][t_bus]
-    z = pm.var[:line_ne][i]
+function constraint_ohms_yt_from_ne{T <: AbstractDCPForm}(pm::GenericPowerModel{T}, n::Int, i, f_bus, t_bus, f_idx, t_idx, g, b, c, tr, ti, tm, t_min, t_max)
+    p_fr = pm.var[:nw][n][:p_ne][f_idx]
+    t_fr = pm.var[:nw][n][:t][f_bus]
+    t_to = pm.var[:nw][n][:t][t_bus]
+    z = pm.var[:nw][n][:line_ne][i]
 
     c1 = @constraint(pm.model, p_fr <= -b*(t_fr - t_to + t_max*(1-z)) )
     c2 = @constraint(pm.model, p_fr >= -b*(t_fr - t_to + t_min*(1-z)) )
@@ -142,12 +142,12 @@ function constraint_ohms_yt_from_ne{T <: AbstractDCPForm}(pm::GenericPowerModel{
 end
 
 "Do nothing, this model is symmetric"
-constraint_ohms_yt_to_ne{T <: AbstractDCPForm}(pm::GenericPowerModel{T}, i, f_bus, t_bus, f_idx, t_idx, g, b, c, tr, ti, tm, t_min, t_max) = Set()
+constraint_ohms_yt_to_ne{T <: AbstractDCPForm}(pm::GenericPowerModel{T}, n::Int, i, f_bus, t_bus, f_idx, t_idx, g, b, c, tr, ti, tm, t_min, t_max) = Set()
 
 
 "`-rate_a <= p[f_idx] <= rate_a`"
-function constraint_thermal_limit_from{T <: AbstractDCPForm}(pm::GenericPowerModel{T}, f_idx, rate_a)
-    p_fr = pm.var[:p][f_idx]
+function constraint_thermal_limit_from{T <: AbstractDCPForm}(pm::GenericPowerModel{T}, n::Int, f_idx, rate_a)
+    p_fr = pm.var[:nw][n][:p][f_idx]
 
     if getlowerbound(p_fr) < -rate_a
         setlowerbound(p_fr, -rate_a)
@@ -161,12 +161,12 @@ function constraint_thermal_limit_from{T <: AbstractDCPForm}(pm::GenericPowerMod
 end
 
 "Do nothing, this model is symmetric"
-constraint_thermal_limit_to{T <: AbstractDCPForm}(pm::GenericPowerModel{T}, t_idx, rate_a) = Set()
+constraint_thermal_limit_to{T <: AbstractDCPForm}(pm::GenericPowerModel{T}, n::Int, t_idx, rate_a) = Set()
 
 ""
-function add_bus_voltage_setpoint{T <: AbstractDCPForm}(sol, pm::GenericPowerModel{T})
-    add_setpoint(sol, pm, "bus", "bus_i", "vm", :v; default_value = (item) -> 1)
-    add_setpoint(sol, pm, "bus", "bus_i", "va", :t)
+function add_bus_voltage_setpoint{T <: AbstractDCPForm}(sol, pm::GenericPowerModel{T}, n::String)
+    add_setpoint(sol, pm, n, "bus", "bus_i", "vm", :v; default_value = (item) -> 1)
+    add_setpoint(sol, pm, n, "bus", "bus_i", "va", :t)
 end
 
 ""

--- a/src/form/shared.jl
+++ b/src/form/shared.jl
@@ -22,8 +22,8 @@ AbstractWRForms = Union{AbstractACTForm, AbstractWRForm}
 AbstractPForms = Union{AbstractACPForm, AbstractACTForm, AbstractDCPForm}
 
 "`t[ref_bus] == 0`"
-constraint_theta_ref{T <: AbstractPForms}(pm::GenericPowerModel{T}, n::Symbol, ref_bus::Int) =
-    Set([@constraint(pm.model, pm.var[n][:t][ref_bus] == 0)])
+constraint_theta_ref{T <: AbstractPForms}(pm::GenericPowerModel{T}, n::Int, ref_bus::Int) =
+    Set([@constraint(pm.model, pm.var[:nw][n][:t][ref_bus] == 0)])
 
 """
 ```
@@ -31,9 +31,9 @@ t[f_bus] - t[t_bus] <= angmax
 t[f_bus] - t[t_bus] >= angmin
 ```
 """
-function constraint_phase_angle_difference{T <: AbstractPForms}(pm::GenericPowerModel{T}, n::Symbol, f_bus, t_bus, angmin, angmax)
-    t_fr = pm.var[n][:t][f_bus]
-    t_to = pm.var[n][:t][t_bus]
+function constraint_phase_angle_difference{T <: AbstractPForms}(pm::GenericPowerModel{T}, n::Int, f_bus, t_bus, angmin, angmax)
+    t_fr = pm.var[:nw][n][:t][f_bus]
+    t_to = pm.var[:nw][n][:t][t_bus]
 
     c1 = @constraint(pm.model, t_fr - t_to <= angmax)
     c2 = @constraint(pm.model, t_fr - t_to >= angmin)

--- a/src/form/shared.jl
+++ b/src/form/shared.jl
@@ -22,8 +22,8 @@ AbstractWRForms = Union{AbstractACTForm, AbstractWRForm}
 AbstractPForms = Union{AbstractACPForm, AbstractACTForm, AbstractDCPForm}
 
 "`t[ref_bus] == 0`"
-constraint_theta_ref{T <: AbstractPForms}(pm::GenericPowerModel{T}, r::Symbol, ref_bus::Int) =
-    Set([@constraint(pm.model, pm.var[r][:t][ref_bus] == 0)])
+constraint_theta_ref{T <: AbstractPForms}(pm::GenericPowerModel{T}, n::Symbol, ref_bus::Int) =
+    Set([@constraint(pm.model, pm.var[n][:t][ref_bus] == 0)])
 
 """
 ```
@@ -31,9 +31,9 @@ t[f_bus] - t[t_bus] <= angmax
 t[f_bus] - t[t_bus] >= angmin
 ```
 """
-function constraint_phase_angle_difference{T <: AbstractPForms}(pm::GenericPowerModel{T}, r::Symbol, f_bus, t_bus, angmin, angmax)
-    t_fr = pm.var[r][:t][f_bus]
-    t_to = pm.var[r][:t][t_bus]
+function constraint_phase_angle_difference{T <: AbstractPForms}(pm::GenericPowerModel{T}, n::Symbol, f_bus, t_bus, angmin, angmax)
+    t_fr = pm.var[n][:t][f_bus]
+    t_to = pm.var[n][:t][t_bus]
 
     c1 = @constraint(pm.model, t_fr - t_to <= angmax)
     c2 = @constraint(pm.model, t_fr - t_to >= angmin)

--- a/src/form/shared.jl
+++ b/src/form/shared.jl
@@ -22,8 +22,8 @@ AbstractWRForms = Union{AbstractACTForm, AbstractWRForm}
 AbstractPForms = Union{AbstractACPForm, AbstractACTForm, AbstractDCPForm}
 
 "`t[ref_bus] == 0`"
-constraint_theta_ref{T <: AbstractPForms}(pm::GenericPowerModel{T}, ref_bus::Int) =
-    Set([@constraint(pm.model, pm.var[:t][ref_bus] == 0)])
+constraint_theta_ref{T <: AbstractPForms}(pm::GenericPowerModel{T}, r::Symbol, ref_bus::Int) =
+    Set([@constraint(pm.model, pm.var[r][:t][ref_bus] == 0)])
 
 """
 ```
@@ -31,9 +31,9 @@ t[f_bus] - t[t_bus] <= angmax
 t[f_bus] - t[t_bus] >= angmin
 ```
 """
-function constraint_phase_angle_difference{T <: AbstractPForms}(pm::GenericPowerModel{T}, f_bus, t_bus, angmin, angmax)
-    t_fr = pm.var[:t][f_bus]
-    t_to = pm.var[:t][t_bus]
+function constraint_phase_angle_difference{T <: AbstractPForms}(pm::GenericPowerModel{T}, r::Symbol, f_bus, t_bus, angmin, angmax)
+    t_fr = pm.var[r][:t][f_bus]
+    t_to = pm.var[r][:t][t_bus]
 
     c1 = @constraint(pm.model, t_fr - t_to <= angmax)
     c2 = @constraint(pm.model, t_fr - t_to >= angmin)

--- a/src/form/shared.jl
+++ b/src/form/shared.jl
@@ -59,9 +59,9 @@ end
 """
 enforces pv-like buses on both sides of a dcline
 """
-function constraint_voltage_dcline_setpoint{T <: AbstractWRForms}(pm::GenericPowerModel{T}, f_bus, t_bus, vf, vt, epsilon)
-    w_f = pm.var[:w][f_bus]
-    w_t = pm.var[:w][t_bus]
+function constraint_voltage_dcline_setpoint{T <: AbstractWRForms}(pm::GenericPowerModel{T}, n::Int, f_bus, t_bus, vf, vt, epsilon)
+    w_f = pm.var[:nw][n][:w][f_bus]
+    w_t = pm.var[:nw][n][:w][t_bus]
     if epsilon == 0.0
         c1 = @constraint(pm.model, w_f == vf^2)
         c2 = @constraint(pm.model, w_t == vt^2)
@@ -82,14 +82,14 @@ sum(p[a] for a in bus_arcs) + sum(p_dc[a_dc] for a_dc in bus_arcs_dc) == sum(pg[
 sum(q[a] for a in bus_arcs) + sum(q_dc[a_dc] for a_dc in bus_arcs_dc) == sum(qg[g] for g in bus_gens) - qd + bs*w[i]
 ```
 """
-function constraint_kcl_shunt{T <: AbstractWRForms}(pm::GenericPowerModel{T}, i, bus_arcs, bus_arcs_dc, bus_gens, pd, qd, gs, bs)
-    w = pm.var[:w][i]
-    p = pm.var[:p]
-    q = pm.var[:q]
-    pg = pm.var[:pg]
-    qg = pm.var[:qg]
-    p_dc = pm.var[:p_dc]
-    q_dc = pm.var[:q_dc]
+function constraint_kcl_shunt{T <: AbstractWRForms}(pm::GenericPowerModel{T}, n::Int, i, bus_arcs, bus_arcs_dc, bus_gens, pd, qd, gs, bs)
+    w = pm.var[:nw][n][:w][i]
+    p = pm.var[:nw][n][:p]
+    q = pm.var[:nw][n][:q]
+    pg = pm.var[:nw][n][:pg]
+    qg = pm.var[:nw][n][:qg]
+    p_dc = pm.var[:nw][n][:p_dc]
+    q_dc = pm.var[:nw][n][:q_dc]
 
     c1 = @constraint(pm.model, sum(p[a] for a in bus_arcs) + sum(p_dc[a_dc] for a_dc in bus_arcs_dc) == sum(pg[g] for g in bus_gens) - pd - gs*w)
     c2 = @constraint(pm.model, sum(q[a] for a in bus_arcs) + sum(q_dc[a_dc] for a_dc in bus_arcs_dc) == sum(qg[g] for g in bus_gens) - qd + bs*w)
@@ -100,12 +100,12 @@ end
 """
 Creates Ohms constraints (yt post fix indicates that Y and T values are in rectangular form)
 """
-function constraint_ohms_yt_from{T <: AbstractWRForms}(pm::GenericPowerModel{T}, f_bus, t_bus, f_idx, t_idx, g, b, c, tr, ti, tm)
-    p_fr = pm.var[:p][f_idx]
-    q_fr = pm.var[:q][f_idx]
-    w_fr = pm.var[:w][f_bus]
-    wr = pm.var[:wr][(f_bus, t_bus)]
-    wi = pm.var[:wi][(f_bus, t_bus)]
+function constraint_ohms_yt_from{T <: AbstractWRForms}(pm::GenericPowerModel{T}, n::Int, f_bus, t_bus, f_idx, t_idx, g, b, c, tr, ti, tm)
+    p_fr = pm.var[:nw][n][:p][f_idx]
+    q_fr = pm.var[:nw][n][:q][f_idx]
+    w_fr = pm.var[:nw][n][:w][f_bus]
+    wr = pm.var[:nw][n][:wr][(f_bus, t_bus)]
+    wi = pm.var[:nw][n][:wi][(f_bus, t_bus)]
 
     c1 = @constraint(pm.model, p_fr == g/tm*w_fr + (-g*tr+b*ti)/tm*(wr) + (-b*tr-g*ti)/tm*( wi) )
     c2 = @constraint(pm.model, q_fr == -(b+c/2)/tm*w_fr - (-b*tr-g*ti)/tm*(wr) + (-g*tr+b*ti)/tm*( wi) )
@@ -116,12 +116,12 @@ end
 """
 Creates Ohms constraints (yt post fix indicates that Y and T values are in rectangular form)
 """
-function constraint_ohms_yt_to{T <: AbstractWRForms}(pm::GenericPowerModel{T}, f_bus, t_bus, f_idx, t_idx, g, b, c, tr, ti, tm)
-    q_to = pm.var[:q][t_idx]
-    p_to = pm.var[:p][t_idx]
-    w_to = pm.var[:w][t_bus]
-    wr = pm.var[:wr][(f_bus, t_bus)]
-    wi = pm.var[:wi][(f_bus, t_bus)]
+function constraint_ohms_yt_to{T <: AbstractWRForms}(pm::GenericPowerModel{T}, n::Int, f_bus, t_bus, f_idx, t_idx, g, b, c, tr, ti, tm)
+    q_to = pm.var[:nw][n][:q][t_idx]
+    p_to = pm.var[:nw][n][:p][t_idx]
+    w_to = pm.var[:nw][n][:w][t_bus]
+    wr = pm.var[:nw][n][:wr][(f_bus, t_bus)]
+    wi = pm.var[:nw][n][:wi][(f_bus, t_bus)]
 
     c1 = @constraint(pm.model, p_to == g*w_to + (-g*tr-b*ti)/tm*(wr) + (-b*tr+g*ti)/tm*(-wi) )
     c2 = @constraint(pm.model, q_to == -(b+c/2)*w_to - (-b*tr+g*ti)/tm*(wr) + (-g*tr-b*ti)/tm*(-wi) )

--- a/src/form/wrm.jl
+++ b/src/form/wrm.jl
@@ -14,24 +14,24 @@ const SDPWRMPowerModel = GenericPowerModel{SDPWRMForm}
 SDPWRMPowerModel(data::Dict{String,Any}; kwargs...) = GenericPowerModel(data, SDPWRMForm; kwargs...)
 
 ""
-variable_voltage{T <: AbstractWRMForm}(pm::GenericPowerModel{T}; kwargs...) = variable_voltage_product_matrix(pm; kwargs...)
+variable_voltage{T <: AbstractWRMForm}(pm::GenericPowerModel{T}, n::Int=0; kwargs...) = variable_voltage_product_matrix(pm, n; kwargs...)
 
 ""
-function variable_voltage_product_matrix{T <: AbstractWRMForm}(pm::GenericPowerModel{T})
-    wr_min, wr_max, wi_min, wi_max = calc_voltage_product_bounds(pm.ref[:buspairs])
+function variable_voltage_product_matrix{T <: AbstractWRMForm}(pm::GenericPowerModel{T}, n::Int)
+    wr_min, wr_max, wi_min, wi_max = calc_voltage_product_bounds(pm.ref[:nw][n][:buspairs])
 
-    w_index = 1:length(keys(pm.ref[:bus]))
-    lookup_w_index = Dict([(bi,i) for (i,bi) in enumerate(keys(pm.ref[:bus]))])
+    w_index = 1:length(keys(pm.ref[:nw][n][:bus]))
+    lookup_w_index = Dict([(bi,i) for (i,bi) in enumerate(keys(pm.ref[:nw][n][:bus]))])
 
-    WR = pm.var[:WR] = @variable(pm.model, 
-        [1:length(keys(pm.ref[:bus])), 1:length(keys(pm.ref[:bus]))], Symmetric, basename="WR"
+    WR = pm.var[:nw][n][:WR] = @variable(pm.model, 
+        [1:length(keys(pm.ref[:nw][n][:bus])), 1:length(keys(pm.ref[:nw][n][:bus]))], Symmetric, basename="WR"
     )
-    WI = pm.var[:WI] = @variable(pm.model, 
-        [1:length(keys(pm.ref[:bus])), 1:length(keys(pm.ref[:bus]))], basename="WI"
+    WI = pm.var[:nw][n][:WI] = @variable(pm.model, 
+        [1:length(keys(pm.ref[:nw][n][:bus])), 1:length(keys(pm.ref[:nw][n][:bus]))], basename="WI"
     )
 
     # bounds on diagonal
-    for (i, bus) in pm.ref[:bus]
+    for (i, bus) in pm.ref[:nw][n][:bus]
         w_idx = lookup_w_index[i]
         wr_ii = WR[w_idx,w_idx]
         wi_ii = WR[w_idx,w_idx]
@@ -45,7 +45,7 @@ function variable_voltage_product_matrix{T <: AbstractWRMForm}(pm::GenericPowerM
     end
 
     # bounds on off-diagonal
-    for (i,j) in keys(pm.ref[:buspairs])
+    for (i,j) in keys(pm.ref[:nw][n][:buspairs])
         wi_idx = lookup_w_index[i]
         wj_idx = lookup_w_index[j]
 
@@ -56,38 +56,38 @@ function variable_voltage_product_matrix{T <: AbstractWRMForm}(pm::GenericPowerM
         setlowerbound(WI[wi_idx, wj_idx], wi_min[(i,j)])
     end
 
-    pm.ext[:lookup_w_index] = lookup_w_index
+    pm.ext[:nw][n][:lookup_w_index] = lookup_w_index
     return WR, WI
 end
 
 ""
-function constraint_voltage{T <: AbstractWRMForm}(pm::GenericPowerModel{T})
-    WR = pm.var[:WR]
-    WI = pm.var[:WI]
+function constraint_voltage{T <: AbstractWRMForm}(pm::GenericPowerModel{T}, n::Int=0)
+    WR = pm.var[:nw][n][:WR]
+    WI = pm.var[:nw][n][:WI]
 
     c = @SDconstraint(pm.model, [WR WI; -WI WR] >= 0)
 
     # place holder while debugging sdp constraint
-    #for (i,j) in keys(pm.ref[:buspairs])
+    #for (i,j) in keys(pm.ref[:nw][n][:buspairs])
     #    relaxation_complex_product(pm.model, w[i], w[j], wr[(i,j)], wi[(i,j)])
     #end
     return Set([c])
 end
 
 "Do nothing, no way to represent this in these variables"
-constraint_theta_ref{T <: AbstractWRMForm}(pm::GenericPowerModel{T}, ref_bus::Int) = Set()
+constraint_theta_ref{T <: AbstractWRMForm}(pm::GenericPowerModel{T}, n::Int, ref_bus::Int) = Set()
 
 ""
-function constraint_kcl_shunt{T <: AbstractWRMForm}(pm::GenericPowerModel{T}, i, bus_arcs, bus_arcs_dc, bus_gens, pd, qd, gs, bs)
-    w_index = pm.ext[:lookup_w_index][i]
-    w = pm.var[:WR][w_index, w_index]
+function constraint_kcl_shunt{T <: AbstractWRMForm}(pm::GenericPowerModel{T}, n::Int, i, bus_arcs, bus_arcs_dc, bus_gens, pd, qd, gs, bs)
+    w_index = pm.ext[:nw][n][:lookup_w_index][i]
+    w = pm.var[:nw][n][:WR][w_index, w_index]
 
-    p = pm.var[:p]
-    q = pm.var[:q]
-    pg = pm.var[:pg]
-    qg = pm.var[:qg]
-    p_dc = pm.var[:p_dc]
-    q_dc = pm.var[:q_dc]
+    p = pm.var[:nw][n][:p]
+    q = pm.var[:nw][n][:q]
+    pg = pm.var[:nw][n][:pg]
+    qg = pm.var[:nw][n][:qg]
+    p_dc = pm.var[:nw][n][:p_dc]
+    q_dc = pm.var[:nw][n][:q_dc]
 
     c1 = @constraint(pm.model, sum(p[a] for a in bus_arcs) + sum(p_dc[a_dc] for a_dc in bus_arcs_dc) == sum(pg[g] for g in bus_gens) - pd - gs*w)
     c2 = @constraint(pm.model, sum(q[a] for a in bus_arcs) + sum(q_dc[a_dc] for a_dc in bus_arcs_dc) == sum(qg[g] for g in bus_gens) - qd + bs*w)
@@ -95,17 +95,17 @@ function constraint_kcl_shunt{T <: AbstractWRMForm}(pm::GenericPowerModel{T}, i,
 end
 
 "Creates Ohms constraints (yt post fix indicates that Y and T values are in rectangular form)"
-function constraint_ohms_yt_from{T <: AbstractWRMForm}(pm::GenericPowerModel{T}, f_bus, t_bus, f_idx, t_idx, g, b, c, tr, ti, tm)
-    p_fr = pm.var[:p][f_idx]
-    q_fr = pm.var[:q][f_idx]
+function constraint_ohms_yt_from{T <: AbstractWRMForm}(pm::GenericPowerModel{T}, n::Int, f_bus, t_bus, f_idx, t_idx, g, b, c, tr, ti, tm)
+    p_fr = pm.var[:nw][n][:p][f_idx]
+    q_fr = pm.var[:nw][n][:q][f_idx]
 
-    w_fr_index = pm.ext[:lookup_w_index][f_bus]
-    w_to_index = pm.ext[:lookup_w_index][t_bus]
+    w_fr_index = pm.ext[:nw][n][:lookup_w_index][f_bus]
+    w_to_index = pm.ext[:nw][n][:lookup_w_index][t_bus]
 
-    w_fr = pm.var[:WR][w_fr_index, w_fr_index]
-    w_to = pm.var[:WR][w_to_index, w_to_index]
-    wr   = pm.var[:WR][w_fr_index, w_to_index]
-    wi   = pm.var[:WI][w_fr_index, w_to_index]
+    w_fr = pm.var[:nw][n][:WR][w_fr_index, w_fr_index]
+    w_to = pm.var[:nw][n][:WR][w_to_index, w_to_index]
+    wr   = pm.var[:nw][n][:WR][w_fr_index, w_to_index]
+    wi   = pm.var[:nw][n][:WI][w_fr_index, w_to_index]
 
     c1 = @constraint(pm.model, p_fr == g/tm*w_fr + (-g*tr+b*ti)/tm*(wr) + (-b*tr-g*ti)/tm*( wi) )
     c2 = @constraint(pm.model, q_fr == -(b+c/2)/tm*w_fr - (-b*tr-g*ti)/tm*(wr) + (-g*tr+b*ti)/tm*( wi) )
@@ -113,17 +113,17 @@ function constraint_ohms_yt_from{T <: AbstractWRMForm}(pm::GenericPowerModel{T},
 end
 
 ""
-function constraint_ohms_yt_to{T <: AbstractWRMForm}(pm::GenericPowerModel{T}, f_bus, t_bus, f_idx, t_idx, g, b, c, tr, ti, tm)
-    q_to = pm.var[:q][t_idx]
-    p_to = pm.var[:p][t_idx]
+function constraint_ohms_yt_to{T <: AbstractWRMForm}(pm::GenericPowerModel{T}, n::Int, f_bus, t_bus, f_idx, t_idx, g, b, c, tr, ti, tm)
+    q_to = pm.var[:nw][n][:q][t_idx]
+    p_to = pm.var[:nw][n][:p][t_idx]
 
-    w_fr_index = pm.ext[:lookup_w_index][f_bus]
-    w_to_index = pm.ext[:lookup_w_index][t_bus]
+    w_fr_index = pm.ext[:nw][n][:lookup_w_index][f_bus]
+    w_to_index = pm.ext[:nw][n][:lookup_w_index][t_bus]
 
-    w_fr = pm.var[:WR][w_fr_index, w_fr_index]
-    w_to = pm.var[:WR][w_to_index, w_to_index]
-    wr   = pm.var[:WR][w_fr_index, w_to_index]
-    wi   = pm.var[:WI][w_fr_index, w_to_index]
+    w_fr = pm.var[:nw][n][:WR][w_fr_index, w_fr_index]
+    w_to = pm.var[:nw][n][:WR][w_to_index, w_to_index]
+    wr   = pm.var[:nw][n][:WR][w_fr_index, w_to_index]
+    wi   = pm.var[:nw][n][:WI][w_fr_index, w_to_index]
 
     c1 = @constraint(pm.model, p_to ==    g*w_to + (-g*tr-b*ti)/tm*(wr) + (-b*tr+g*ti)/tm*(-wi) )
     c2 = @constraint(pm.model, q_to ==    -(b+c/2)*w_to - (-b*tr+g*ti)/tm*(wr) + (-g*tr-b*ti)/tm*(-wi) )
@@ -131,14 +131,14 @@ function constraint_ohms_yt_to{T <: AbstractWRMForm}(pm::GenericPowerModel{T}, f
 end
 
 ""
-function constraint_phase_angle_difference{T <: AbstractWRMForm}(pm::GenericPowerModel{T}, f_bus, t_bus, angmin, angmax)
-    w_fr_index = pm.ext[:lookup_w_index][f_bus]
-    w_to_index = pm.ext[:lookup_w_index][t_bus]
+function constraint_phase_angle_difference{T <: AbstractWRMForm}(pm::GenericPowerModel{T}, n::Int, f_bus, t_bus, angmin, angmax)
+    w_fr_index = pm.ext[:nw][n][:lookup_w_index][f_bus]
+    w_to_index = pm.ext[:nw][n][:lookup_w_index][t_bus]
 
-    w_fr = pm.var[:WR][w_fr_index, w_fr_index]
-    w_to = pm.var[:WR][w_to_index, w_to_index]
-    wr   = pm.var[:WR][w_fr_index, w_to_index]
-    wi   = pm.var[:WI][w_fr_index, w_to_index]
+    w_fr = pm.var[:nw][n][:WR][w_fr_index, w_fr_index]
+    w_to = pm.var[:nw][n][:WR][w_to_index, w_to_index]
+    wr   = pm.var[:nw][n][:WR][w_fr_index, w_to_index]
+    wi   = pm.var[:nw][n][:WI][w_fr_index, w_to_index]
 
     c1 = @constraint(pm.model, wi <= tan(angmax)*wr)
     c2 = @constraint(pm.model, wi >= tan(angmin)*wr)
@@ -149,10 +149,10 @@ function constraint_phase_angle_difference{T <: AbstractWRMForm}(pm::GenericPowe
 end
 
 ""
-function add_bus_voltage_setpoint{T <: AbstractWRMForm}(sol, pm::GenericPowerModel{T})
-    add_setpoint(sol, pm, "bus", "bus_i", "vm", :WR; scale = (x,item) -> sqrt(x), extract_var = (var,idx,item) -> var[pm.ext[:lookup_w_index][idx], pm.ext[:lookup_w_index][idx]])
+function add_bus_voltage_setpoint{T <: AbstractWRMForm}(sol, pm::GenericPowerModel{T}, n::String)
+    add_setpoint(sol, pm, n, "bus", "bus_i", "vm", :WR; scale = (x,item) -> sqrt(x), extract_var = (var,idx,item) -> var[pm.ext[:lookup_w_index][idx], pm.ext[:lookup_w_index][idx]])
 
     # What should the default value be?
-    #add_setpoint(sol, pm, "bus", "bus_i", "va", :t; default_value = 0)
+    #add_setpoint(sol, pm, n, "bus", "bus_i", "va", :t; default_value = 0)
 end
 

--- a/src/io/common.jl
+++ b/src/io/common.jl
@@ -12,11 +12,13 @@ function parse_file(file::String)
 end
 
 ""
-function check_network_data(data::Dict{String,Any})
-    make_per_unit(data)
-    check_transformer_parameters(data)
-    check_phase_angle_differences(data)
-    check_thermal_limits(data)
-    check_bus_types(data)
-    check_dcline_limits(data)
+function check_network_data(networks::Dict{String,Any})
+    for (i,data) in networks
+        make_per_unit(data)
+        check_transformer_parameters(data)
+        check_phase_angle_differences(data)
+        check_thermal_limits(data)
+        check_bus_types(data)
+        check_dcline_limits(data)
+    end
 end

--- a/src/io/common.jl
+++ b/src/io/common.jl
@@ -14,7 +14,7 @@ end
 ""
 function check_network_data(data::Dict{String,Any})
     for (i,network_data) in data
-        make_per_unit(network_data)
+        make_network_per_unit(network_data)
         check_transformer_parameters(network_data)
         check_phase_angle_differences(network_data)
         check_thermal_limits(network_data)

--- a/src/io/common.jl
+++ b/src/io/common.jl
@@ -13,12 +13,12 @@ end
 
 ""
 function check_network_data(data::Dict{String,Any})
-    for (i,network_data) in data
-        make_network_per_unit(network_data)
-        check_transformer_parameters(network_data)
-        check_phase_angle_differences(network_data)
-        check_thermal_limits(network_data)
-        check_bus_types(network_data)
-        check_dcline_limits(network_data)
+    for (n,nw_data) in data["nw"]
+        make_network_per_unit(nw_data)
+        check_transformer_parameters(nw_data)
+        check_phase_angle_differences(nw_data)
+        check_thermal_limits(nw_data)
+        check_bus_types(nw_data)
+        check_dcline_limits(nw_data)
     end
 end

--- a/src/io/common.jl
+++ b/src/io/common.jl
@@ -1,24 +1,24 @@
 ""
 function parse_file(file::String)
     if endswith(file, ".m")
-        pm_data = PowerModels.parse_matpower(file)
+        data = PowerModels.parse_matpower(file)
     else
-        pm_data = PowerModels.parse_json(file)
+        data = PowerModels.parse_json(file)
     end
 
-    check_network_data(pm_data)
+    check_network_data(data)
 
-    return pm_data
+    return data
 end
 
 ""
-function check_network_data(networks::Dict{String,Any})
-    for (i,data) in networks
-        make_per_unit(data)
-        check_transformer_parameters(data)
-        check_phase_angle_differences(data)
-        check_thermal_limits(data)
-        check_bus_types(data)
-        check_dcline_limits(data)
+function check_network_data(data::Dict{String,Any})
+    for (i,network_data) in data
+        make_per_unit(network_data)
+        check_transformer_parameters(network_data)
+        check_phase_angle_differences(network_data)
+        check_thermal_limits(network_data)
+        check_bus_types(network_data)
+        check_dcline_limits(network_data)
     end
 end

--- a/src/io/matpower.jl
+++ b/src/io/matpower.jl
@@ -17,6 +17,8 @@ function parse_matpower(file_string::String)
     # after this call, Matpower data is consistent with PowerModels data
     mp_data_to_pm_data(mp_data)
 
+    mp_data = Dict{String,Any}("base" => mp_data)
+
     return mp_data
 end
 

--- a/src/io/matpower.jl
+++ b/src/io/matpower.jl
@@ -17,7 +17,7 @@ function parse_matpower(file_string::String)
     # after this call, Matpower data is consistent with PowerModels data
     mp_data_to_pm_data(mp_data)
 
-    data = Dict{String,Any}("base" => mp_data)
+    data = Dict{String,Any}("nw" => Dict{String,Any}("0" => mp_data))
 
     return data
 end

--- a/src/io/matpower.jl
+++ b/src/io/matpower.jl
@@ -17,9 +17,9 @@ function parse_matpower(file_string::String)
     # after this call, Matpower data is consistent with PowerModels data
     mp_data_to_pm_data(mp_data)
 
-    mp_data = Dict{String,Any}("base" => mp_data)
+    data = Dict{String,Any}("base" => mp_data)
 
-    return mp_data
+    return data
 end
 
 "ensures all polynomial costs functions have at least three terms"

--- a/src/prob/mpopf.jl
+++ b/src/prob/mpopf.jl
@@ -20,7 +20,7 @@ end
 
 ""
 function post_mpopf(pm::GenericPowerModel)
-    for (n,network) in pm.ref
+    for (n, network) in pm.ref[:nw]
         variable_voltage(pm, n)
         variable_generation(pm, n)
         variable_line_flow(pm, n)
@@ -28,15 +28,15 @@ function post_mpopf(pm::GenericPowerModel)
 
         constraint_voltage(pm, n)
 
-        for (i,bus) in getref(pm, n, :ref_buses)
+        for (i,bus) in nw_ref(pm, n, :ref_buses)
             constraint_theta_ref(pm, n, bus)
         end
 
-        for (i,bus) in getref(pm, n, :bus)
+        for (i,bus) in nw_ref(pm, n, :bus)
             constraint_kcl_shunt(pm, n, bus)
         end
 
-        for (i,branch) in getref(pm, n, :branch)
+        for (i,branch) in nw_ref(pm, n, :branch)
             constraint_ohms_yt_from(pm, n, branch)
             constraint_ohms_yt_to(pm, n, branch)
 
@@ -46,15 +46,15 @@ function post_mpopf(pm::GenericPowerModel)
             constraint_thermal_limit_to(pm, n, branch)
         end
 
-        for (i,dcline) in getref(pm, n, :dcline)
+        for (i,dcline) in nw_ref(pm, n, :dcline)
             constraint_dcline(pm, n, dcline)
         end
     end
 
     # cross network constraint, just for illustration purposes
     # designed to be feasible with two copies of case5_asym.m 
-    t1_pg = getvar(pm, :t1, :pg)
-    t2_pg = getvar(pm, :t2, :pg)
+    t1_pg = nw_var(pm, 1, :pg)
+    t2_pg = nw_var(pm, 2, :pg)
     @constraint(pm.model, t1_pg[1] == t2_pg[4])
 
     objective_min_fuel_cost(pm)

--- a/src/prob/mpopf.jl
+++ b/src/prob/mpopf.jl
@@ -1,0 +1,58 @@
+export run_mpopf, run_ac_mpopf, run_dc_mpopf
+
+""
+function run_ac_mpopf(file, solver; kwargs...)
+    return run_mpopf(file, ACPPowerModel, solver; kwargs...)
+end
+
+""
+function run_dc_mpopf(file, solver; kwargs...)
+    return run_mpopf(file, DCPPowerModel, solver; kwargs...)
+end
+
+""
+function run_mpopf(file, model_constructor, solver; kwargs...)
+    return run_generic_model(file, model_constructor, solver, post_mpopf; kwargs...)
+end
+
+""
+function post_mpopf(pm::GenericPowerModel)
+    for (n,network) in pm.ref
+        variable_voltage(pm, n)
+        variable_generation(pm, n)
+        variable_line_flow(pm, n)
+        variable_dcline_flow(pm, n)
+
+        constraint_voltage(pm, n)
+
+        for (i,bus) in getref(pm, n, :ref_buses)
+            constraint_theta_ref(pm, n, bus)
+        end
+
+        for (i,bus) in getref(pm, n, :bus)
+            constraint_kcl_shunt(pm, n, bus)
+        end
+
+        for (i,branch) in getref(pm, n, :branch)
+            constraint_ohms_yt_from(pm, n, branch)
+            constraint_ohms_yt_to(pm, n, branch)
+
+            constraint_phase_angle_difference(pm, n, branch)
+
+            constraint_thermal_limit_from(pm, n, branch)
+            constraint_thermal_limit_to(pm, n, branch)
+        end
+
+        for (i,dcline) in getref(pm, n, :dcline)
+            constraint_dcline(pm, n, dcline)
+        end
+    end
+
+    # cross network constraint, just for illustration purposes
+    # designed to be feasible with two copies of case5_asym.m 
+    t1_pg = getvar(pm, :t1, :pg)
+    t2_pg = getvar(pm, :t2, :pg)
+    @constraint(pm.model, t1_pg[1] == t2_pg[4])
+
+    objective_min_fuel_cost(pm)
+end

--- a/src/prob/mpopf.jl
+++ b/src/prob/mpopf.jl
@@ -1,4 +1,7 @@
-export run_mpopf, run_ac_mpopf, run_dc_mpopf
+#
+# NOTE: This is not a formulation of any particular problem
+# It is only for testing and illustration purposes
+#
 
 ""
 function run_ac_mpopf(file, solver; kwargs...)

--- a/src/prob/opf.jl
+++ b/src/prob/opf.jl
@@ -26,15 +26,15 @@ function post_opf(pm::GenericPowerModel)
 
     constraint_voltage(pm)
 
-    for (i,bus) in pm.ref[:ref_buses]
+    for (i,bus) in pm.ref[:base][:ref_buses]
         constraint_theta_ref(pm, bus)
     end
 
-    for (i,bus) in pm.ref[:bus]
+    for (i,bus) in pm.ref[:base][:bus]
         constraint_kcl_shunt(pm, bus)
     end
 
-    for (i,branch) in pm.ref[:branch]
+    for (i,branch) in pm.ref[:base][:branch]
         constraint_ohms_yt_from(pm, branch)
         constraint_ohms_yt_to(pm, branch)
 
@@ -43,7 +43,7 @@ function post_opf(pm::GenericPowerModel)
         constraint_thermal_limit_from(pm, branch)
         constraint_thermal_limit_to(pm, branch)
     end
-    for (i,dcline) in pm.ref[:dcline]
+    for (i,dcline) in pm.ref[:base][:dcline]
         constraint_dcline(pm, dcline)
     end
 end

--- a/src/prob/opf.jl
+++ b/src/prob/opf.jl
@@ -26,15 +26,15 @@ function post_opf(pm::GenericPowerModel)
 
     constraint_voltage(pm)
 
-    for (i,bus) in getref(pm, :ref_buses)
+    for (i,bus) in nw_ref(pm, :ref_buses)
         constraint_theta_ref(pm, bus)
     end
 
-    for (i,bus) in getref(pm, :bus)
+    for (i,bus) in nw_ref(pm, :bus)
         constraint_kcl_shunt(pm, bus)
     end
 
-    for (i,branch) in getref(pm, :branch)
+    for (i,branch) in nw_ref(pm, :branch)
         constraint_ohms_yt_from(pm, branch)
         constraint_ohms_yt_to(pm, branch)
 
@@ -44,7 +44,7 @@ function post_opf(pm::GenericPowerModel)
         constraint_thermal_limit_to(pm, branch)
     end
 
-    for (i,dcline) in getref(pm, :dcline)
+    for (i,dcline) in nw_ref(pm, :dcline)
         constraint_dcline(pm, dcline)
     end
 end

--- a/src/prob/opf.jl
+++ b/src/prob/opf.jl
@@ -26,15 +26,15 @@ function post_opf(pm::GenericPowerModel)
 
     constraint_voltage(pm)
 
-    for (i,bus) in pm.ref[:base][:ref_buses]
+    for (i,bus) in getref(pm, :ref_buses)
         constraint_theta_ref(pm, bus)
     end
 
-    for (i,bus) in pm.ref[:base][:bus]
+    for (i,bus) in getref(pm, :bus)
         constraint_kcl_shunt(pm, bus)
     end
 
-    for (i,branch) in pm.ref[:base][:branch]
+    for (i,branch) in getref(pm, :branch)
         constraint_ohms_yt_from(pm, branch)
         constraint_ohms_yt_to(pm, branch)
 
@@ -43,7 +43,8 @@ function post_opf(pm::GenericPowerModel)
         constraint_thermal_limit_from(pm, branch)
         constraint_thermal_limit_to(pm, branch)
     end
-    for (i,dcline) in pm.ref[:base][:dcline]
+
+    for (i,dcline) in getref(pm, :dcline)
         constraint_dcline(pm, dcline)
     end
 end

--- a/src/prob/pf.jl
+++ b/src/prob/pf.jl
@@ -24,33 +24,33 @@ function post_pf(pm::GenericPowerModel)
 
     constraint_voltage(pm)
 
-    for (i,bus) in pm.ref[:ref_buses]
+    for (i,bus) in nw_ref(pm, :ref_buses)
         constraint_theta_ref(pm, bus)
         constraint_voltage_magnitude_setpoint(pm, bus)
     end
 
-    for (i,bus) in pm.ref[:bus]
+    for (i,bus) in nw_ref(pm, :bus)
         constraint_kcl_shunt(pm, bus)
 
         # PV Bus Constraints
-        if length(pm.ref[:bus_gens][i]) > 0 && !(i in keys(pm.ref[:ref_buses]))
+        if length(nw_ref(pm, :bus_gens)[i]) > 0 && !(i in keys(nw_ref(pm, :ref_buses)))
             # this assumes inactive generators are filtered out of bus_gens
             @assert bus["bus_type"] == 2
 
             # soft equality needed becouse v in file is not precice enough to ensure feasiblity
             constraint_voltage_magnitude_setpoint(pm, bus; epsilon = 0.00001)
-            for j in pm.ref[:bus_gens][i]
-                constraint_active_gen_setpoint(pm, pm.ref[:gen][j])
+            for j in nw_ref(pm, :bus_gens)[i]
+                constraint_active_gen_setpoint(pm, nw_ref(pm, :gen)[j])
             end
         end
     end
 
-    for (i,branch) in pm.ref[:branch]
+    for (i,branch) in nw_ref(pm, :branch)
         constraint_ohms_yt_from(pm, branch)
         constraint_ohms_yt_to(pm, branch)
     end
 
-    for (i,dcline) in pm.ref[:dcline]
+    for (i,dcline) in nw_ref(pm, :dcline)
         #constraint_dcline(pm, dcline) not needed, active power flow fully defined by dc line setpoints
         constraint_active_dcline_setpoint(pm, dcline)
         constraint_voltage_dcline_setpoint(pm, dcline; epsilon = 0.00001)

--- a/test/docs.jl
+++ b/test/docs.jl
@@ -4,8 +4,8 @@
     @testset "DATA.md - The Network Data Dictionary" begin
         network_data = PowerModels.parse_file("../test/data/case14.m")
 
-        @test length(network_data["bus"]) == 14
-        @test length(network_data["branch"]) == 20
+        @test length(network_data["nw"]["0"]["bus"]) == 14
+        @test length(network_data["nw"]["0"]["branch"]) == 20
     end
 
     @testset "README.md - Modifying Network Data" begin
@@ -16,8 +16,8 @@
         @test result["status"] == :LocalOptimal
         @test isapprox(result["objective"], 5906.88; atol = 1e0)
 
-        network_data["bus"]["3"]["pd"] = 0.0
-        network_data["bus"]["3"]["qd"] = 0.0
+        network_data["nw"]["0"]["bus"]["3"]["pd"] = 0.0
+        network_data["nw"]["0"]["bus"]["3"]["qd"] = 0.0
 
         result = run_opf(network_data, ACPPowerModel, IpoptSolver(print_level=0))
 

--- a/test/matpower.jl
+++ b/test/matpower.jl
@@ -21,13 +21,13 @@ using JSON
 
     @testset "14-bus case file with bus names" begin
         data = PowerModels.parse_file("../test/data/case14.m")
-        @test data["bus"]["1"]["bus_name"] == "Bus 1     HV"
+        @test data["base"]["bus"]["1"]["bus_name"] == "Bus 1     HV"
         @test isa(JSON.json(data), String)
     end
 
     @testset "3-bus case file with hvdc lines" begin
         data = PowerModels.parse_file("../test/data/case3.m")
-        @test length(data["dcline"]) > 0
+        @test length(data["base"]["dcline"]) > 0
         @test isa(JSON.json(data), String)
     end
 
@@ -67,98 +67,98 @@ end
     @testset "3-bus extended constants" begin
         data = PowerModels.parse_file("../test/data/case3.m")
 
-        @test data["const_int"] == 123
-        @test data["const_float"] == 4.56
-        @test data["const_str"] == "a string"
+        @test data["base"]["const_int"] == 123
+        @test data["base"]["const_float"] == 4.56
+        @test data["base"]["const_str"] == "a string"
         @test isa(JSON.json(data), String)
     end
 
     @testset "3-bus extended matrix" begin
         data = PowerModels.parse_file("../test/data/case3.m")
 
-        @test haskey(data, "areas")
-        @test data["areas"]["1"]["col_1"] == 1
-        @test data["areas"]["1"]["col_2"] == 1
-        @test data["areas"]["2"]["col_1"] == 2
-        @test data["areas"]["2"]["col_2"] == 3
+        @test haskey(data["base"], "areas")
+        @test data["base"]["areas"]["1"]["col_1"] == 1
+        @test data["base"]["areas"]["1"]["col_2"] == 1
+        @test data["base"]["areas"]["2"]["col_1"] == 2
+        @test data["base"]["areas"]["2"]["col_2"] == 3
         @test isa(JSON.json(data), String)
     end
 
     @testset "3-bus extended named matrix" begin
         data = PowerModels.parse_file("../test/data/case3.m")
 
-        @test haskey(data, "areas_named")
-        @test data["areas_named"]["1"]["area"] == 4
-        @test data["areas_named"]["1"]["refbus"] == 5
-        @test data["areas_named"]["2"]["area"] == 5
-        @test data["areas_named"]["2"]["refbus"] == 6
+        @test haskey(data["base"], "areas_named")
+        @test data["base"]["areas_named"]["1"]["area"] == 4
+        @test data["base"]["areas_named"]["1"]["refbus"] == 5
+        @test data["base"]["areas_named"]["2"]["area"] == 5
+        @test data["base"]["areas_named"]["2"]["refbus"] == 6
         @test isa(JSON.json(data), String)
     end
 
     @testset "3-bus extended predefined matrix" begin
         data = PowerModels.parse_file("../test/data/case3.m")
 
-        @test haskey(data, "areas_named")
-        @test data["branch"]["1"]["rate_i"] == 50.2
-        @test data["branch"]["1"]["rate_p"] == 45
-        @test data["branch"]["2"]["rate_i"] == 36
-        @test data["branch"]["2"]["rate_p"] == 60.1
-        @test data["branch"]["3"]["rate_i"] == 12
-        @test data["branch"]["3"]["rate_p"] == 30
+        @test haskey(data["base"], "areas_named")
+        @test data["base"]["branch"]["1"]["rate_i"] == 50.2
+        @test data["base"]["branch"]["1"]["rate_p"] == 45
+        @test data["base"]["branch"]["2"]["rate_i"] == 36
+        @test data["base"]["branch"]["2"]["rate_p"] == 60.1
+        @test data["base"]["branch"]["3"]["rate_i"] == 12
+        @test data["base"]["branch"]["3"]["rate_p"] == 30
         @test isa(JSON.json(data), String)
     end
 
     @testset "3-bus extended matrix from cell" begin
         data = PowerModels.parse_file("../test/data/case3.m")
 
-        @test haskey(data, "areas_cells")
-        @test data["areas_cells"]["1"]["col_1"] == "Area 1"
-        @test data["areas_cells"]["1"]["col_2"] == 123
-        @test data["areas_cells"]["1"]["col_4"] == "Slack \\\"Bus\\\" 1"
-        @test data["areas_cells"]["1"]["col_5"] == 1.23
-        @test data["areas_cells"]["2"]["col_1"] == "Area 2"
-        @test data["areas_cells"]["2"]["col_2"] == 456
-        @test data["areas_cells"]["2"]["col_4"] == "Slack Bus 3"
-        @test data["areas_cells"]["2"]["col_5"] == 4.56
+        @test haskey(data["base"], "areas_cells")
+        @test data["base"]["areas_cells"]["1"]["col_1"] == "Area 1"
+        @test data["base"]["areas_cells"]["1"]["col_2"] == 123
+        @test data["base"]["areas_cells"]["1"]["col_4"] == "Slack \\\"Bus\\\" 1"
+        @test data["base"]["areas_cells"]["1"]["col_5"] == 1.23
+        @test data["base"]["areas_cells"]["2"]["col_1"] == "Area 2"
+        @test data["base"]["areas_cells"]["2"]["col_2"] == 456
+        @test data["base"]["areas_cells"]["2"]["col_4"] == "Slack Bus 3"
+        @test data["base"]["areas_cells"]["2"]["col_5"] == 4.56
         @test isa(JSON.json(data), String)
     end
 
     @testset "3-bus extended named matrix from cell" begin
         data = PowerModels.parse_file("../test/data/case3.m")
 
-        @test haskey(data, "areas_named_cells")
-        @test data["areas_named_cells"]["1"]["area_name"] == "Area 1"
-        @test data["areas_named_cells"]["1"]["area"] == 123
-        @test data["areas_named_cells"]["1"]["area2"] == 987
-        @test data["areas_named_cells"]["1"]["refbus_name"] == "Slack Bus 1"
-        @test data["areas_named_cells"]["1"]["refbus"] == 1.23
-        @test data["areas_named_cells"]["2"]["area_name"] == "Area 2"
-        @test data["areas_named_cells"]["2"]["area"] == 456
-        @test data["areas_named_cells"]["2"]["area2"] == 987
-        @test data["areas_named_cells"]["2"]["refbus_name"] == "Slack Bus 3"
-        @test data["areas_named_cells"]["2"]["refbus"] == 4.56
+        @test haskey(data["base"], "areas_named_cells")
+        @test data["base"]["areas_named_cells"]["1"]["area_name"] == "Area 1"
+        @test data["base"]["areas_named_cells"]["1"]["area"] == 123
+        @test data["base"]["areas_named_cells"]["1"]["area2"] == 987
+        @test data["base"]["areas_named_cells"]["1"]["refbus_name"] == "Slack Bus 1"
+        @test data["base"]["areas_named_cells"]["1"]["refbus"] == 1.23
+        @test data["base"]["areas_named_cells"]["2"]["area_name"] == "Area 2"
+        @test data["base"]["areas_named_cells"]["2"]["area"] == 456
+        @test data["base"]["areas_named_cells"]["2"]["area2"] == 987
+        @test data["base"]["areas_named_cells"]["2"]["refbus_name"] == "Slack Bus 3"
+        @test data["base"]["areas_named_cells"]["2"]["refbus"] == 4.56
         @test isa(JSON.json(data), String)
     end
 
     @testset "3-bus extended predefined matrix from cell" begin
         data = PowerModels.parse_file("../test/data/case3.m")
 
-        @test haskey(data, "areas_named")
-        @test data["branch"]["1"]["name"] == "Branch 1"
-        @test data["branch"]["1"]["number_id"] == 123
-        @test data["branch"]["2"]["name"] == "Branch 2"
-        @test data["branch"]["2"]["number_id"] == 456
-        @test data["branch"]["3"]["name"] == "Branch 3"
-        @test data["branch"]["3"]["number_id"] == 789
+        @test haskey(data["base"], "areas_named")
+        @test data["base"]["branch"]["1"]["name"] == "Branch 1"
+        @test data["base"]["branch"]["1"]["number_id"] == 123
+        @test data["base"]["branch"]["2"]["name"] == "Branch 2"
+        @test data["base"]["branch"]["2"]["number_id"] == 456
+        @test data["base"]["branch"]["3"]["name"] == "Branch 3"
+        @test data["base"]["branch"]["3"]["number_id"] == 789
         @test isa(JSON.json(data), String)
     end
 
     @testset "3-bus tnep case" begin
         data = PowerModels.parse_file("../test/data/case3_tnep.m")
 
-        @test haskey(data, "ne_branch")
-        @test data["ne_branch"]["1"]["f_bus"] == 1
-        @test data["ne_branch"]["1"]["construction_cost"] == 1
+        @test haskey(data["base"], "ne_branch")
+        @test data["base"]["ne_branch"]["1"]["f_bus"] == 1
+        @test data["base"]["ne_branch"]["1"]["construction_cost"] == 1
         @test isa(JSON.json(data), String)
     end
 
@@ -166,8 +166,8 @@ end
         data = PowerModels.parse_file("../test/data/case3_tnep.m")
         ref = PowerModels.build_ref(data)
 
-        @test haskey(data, "name")
-        @test haskey(ref, :name)
-        @test data["name"] == ref[:name]
+        @test haskey(data["base"], "name")
+        @test haskey(ref[:base], :name)
+        @test data["base"]["name"] == ref[:base][:name]
     end
 end

--- a/test/matpower.jl
+++ b/test/matpower.jl
@@ -21,13 +21,13 @@ using JSON
 
     @testset "14-bus case file with bus names" begin
         data = PowerModels.parse_file("../test/data/case14.m")
-        @test data["base"]["bus"]["1"]["bus_name"] == "Bus 1     HV"
+        @test data["nw"]["0"]["bus"]["1"]["bus_name"] == "Bus 1     HV"
         @test isa(JSON.json(data), String)
     end
 
     @testset "3-bus case file with hvdc lines" begin
         data = PowerModels.parse_file("../test/data/case3.m")
-        @test length(data["base"]["dcline"]) > 0
+        @test length(data["nw"]["0"]["dcline"]) > 0
         @test isa(JSON.json(data), String)
     end
 
@@ -67,98 +67,98 @@ end
     @testset "3-bus extended constants" begin
         data = PowerModels.parse_file("../test/data/case3.m")
 
-        @test data["base"]["const_int"] == 123
-        @test data["base"]["const_float"] == 4.56
-        @test data["base"]["const_str"] == "a string"
+        @test data["nw"]["0"]["const_int"] == 123
+        @test data["nw"]["0"]["const_float"] == 4.56
+        @test data["nw"]["0"]["const_str"] == "a string"
         @test isa(JSON.json(data), String)
     end
 
     @testset "3-bus extended matrix" begin
         data = PowerModels.parse_file("../test/data/case3.m")
 
-        @test haskey(data["base"], "areas")
-        @test data["base"]["areas"]["1"]["col_1"] == 1
-        @test data["base"]["areas"]["1"]["col_2"] == 1
-        @test data["base"]["areas"]["2"]["col_1"] == 2
-        @test data["base"]["areas"]["2"]["col_2"] == 3
+        @test haskey(data["nw"]["0"], "areas")
+        @test data["nw"]["0"]["areas"]["1"]["col_1"] == 1
+        @test data["nw"]["0"]["areas"]["1"]["col_2"] == 1
+        @test data["nw"]["0"]["areas"]["2"]["col_1"] == 2
+        @test data["nw"]["0"]["areas"]["2"]["col_2"] == 3
         @test isa(JSON.json(data), String)
     end
 
     @testset "3-bus extended named matrix" begin
         data = PowerModels.parse_file("../test/data/case3.m")
 
-        @test haskey(data["base"], "areas_named")
-        @test data["base"]["areas_named"]["1"]["area"] == 4
-        @test data["base"]["areas_named"]["1"]["refbus"] == 5
-        @test data["base"]["areas_named"]["2"]["area"] == 5
-        @test data["base"]["areas_named"]["2"]["refbus"] == 6
+        @test haskey(data["nw"]["0"], "areas_named")
+        @test data["nw"]["0"]["areas_named"]["1"]["area"] == 4
+        @test data["nw"]["0"]["areas_named"]["1"]["refbus"] == 5
+        @test data["nw"]["0"]["areas_named"]["2"]["area"] == 5
+        @test data["nw"]["0"]["areas_named"]["2"]["refbus"] == 6
         @test isa(JSON.json(data), String)
     end
 
     @testset "3-bus extended predefined matrix" begin
         data = PowerModels.parse_file("../test/data/case3.m")
 
-        @test haskey(data["base"], "areas_named")
-        @test data["base"]["branch"]["1"]["rate_i"] == 50.2
-        @test data["base"]["branch"]["1"]["rate_p"] == 45
-        @test data["base"]["branch"]["2"]["rate_i"] == 36
-        @test data["base"]["branch"]["2"]["rate_p"] == 60.1
-        @test data["base"]["branch"]["3"]["rate_i"] == 12
-        @test data["base"]["branch"]["3"]["rate_p"] == 30
+        @test haskey(data["nw"]["0"], "areas_named")
+        @test data["nw"]["0"]["branch"]["1"]["rate_i"] == 50.2
+        @test data["nw"]["0"]["branch"]["1"]["rate_p"] == 45
+        @test data["nw"]["0"]["branch"]["2"]["rate_i"] == 36
+        @test data["nw"]["0"]["branch"]["2"]["rate_p"] == 60.1
+        @test data["nw"]["0"]["branch"]["3"]["rate_i"] == 12
+        @test data["nw"]["0"]["branch"]["3"]["rate_p"] == 30
         @test isa(JSON.json(data), String)
     end
 
     @testset "3-bus extended matrix from cell" begin
         data = PowerModels.parse_file("../test/data/case3.m")
 
-        @test haskey(data["base"], "areas_cells")
-        @test data["base"]["areas_cells"]["1"]["col_1"] == "Area 1"
-        @test data["base"]["areas_cells"]["1"]["col_2"] == 123
-        @test data["base"]["areas_cells"]["1"]["col_4"] == "Slack \\\"Bus\\\" 1"
-        @test data["base"]["areas_cells"]["1"]["col_5"] == 1.23
-        @test data["base"]["areas_cells"]["2"]["col_1"] == "Area 2"
-        @test data["base"]["areas_cells"]["2"]["col_2"] == 456
-        @test data["base"]["areas_cells"]["2"]["col_4"] == "Slack Bus 3"
-        @test data["base"]["areas_cells"]["2"]["col_5"] == 4.56
+        @test haskey(data["nw"]["0"], "areas_cells")
+        @test data["nw"]["0"]["areas_cells"]["1"]["col_1"] == "Area 1"
+        @test data["nw"]["0"]["areas_cells"]["1"]["col_2"] == 123
+        @test data["nw"]["0"]["areas_cells"]["1"]["col_4"] == "Slack \\\"Bus\\\" 1"
+        @test data["nw"]["0"]["areas_cells"]["1"]["col_5"] == 1.23
+        @test data["nw"]["0"]["areas_cells"]["2"]["col_1"] == "Area 2"
+        @test data["nw"]["0"]["areas_cells"]["2"]["col_2"] == 456
+        @test data["nw"]["0"]["areas_cells"]["2"]["col_4"] == "Slack Bus 3"
+        @test data["nw"]["0"]["areas_cells"]["2"]["col_5"] == 4.56
         @test isa(JSON.json(data), String)
     end
 
     @testset "3-bus extended named matrix from cell" begin
         data = PowerModels.parse_file("../test/data/case3.m")
 
-        @test haskey(data["base"], "areas_named_cells")
-        @test data["base"]["areas_named_cells"]["1"]["area_name"] == "Area 1"
-        @test data["base"]["areas_named_cells"]["1"]["area"] == 123
-        @test data["base"]["areas_named_cells"]["1"]["area2"] == 987
-        @test data["base"]["areas_named_cells"]["1"]["refbus_name"] == "Slack Bus 1"
-        @test data["base"]["areas_named_cells"]["1"]["refbus"] == 1.23
-        @test data["base"]["areas_named_cells"]["2"]["area_name"] == "Area 2"
-        @test data["base"]["areas_named_cells"]["2"]["area"] == 456
-        @test data["base"]["areas_named_cells"]["2"]["area2"] == 987
-        @test data["base"]["areas_named_cells"]["2"]["refbus_name"] == "Slack Bus 3"
-        @test data["base"]["areas_named_cells"]["2"]["refbus"] == 4.56
+        @test haskey(data["nw"]["0"], "areas_named_cells")
+        @test data["nw"]["0"]["areas_named_cells"]["1"]["area_name"] == "Area 1"
+        @test data["nw"]["0"]["areas_named_cells"]["1"]["area"] == 123
+        @test data["nw"]["0"]["areas_named_cells"]["1"]["area2"] == 987
+        @test data["nw"]["0"]["areas_named_cells"]["1"]["refbus_name"] == "Slack Bus 1"
+        @test data["nw"]["0"]["areas_named_cells"]["1"]["refbus"] == 1.23
+        @test data["nw"]["0"]["areas_named_cells"]["2"]["area_name"] == "Area 2"
+        @test data["nw"]["0"]["areas_named_cells"]["2"]["area"] == 456
+        @test data["nw"]["0"]["areas_named_cells"]["2"]["area2"] == 987
+        @test data["nw"]["0"]["areas_named_cells"]["2"]["refbus_name"] == "Slack Bus 3"
+        @test data["nw"]["0"]["areas_named_cells"]["2"]["refbus"] == 4.56
         @test isa(JSON.json(data), String)
     end
 
     @testset "3-bus extended predefined matrix from cell" begin
         data = PowerModels.parse_file("../test/data/case3.m")
 
-        @test haskey(data["base"], "areas_named")
-        @test data["base"]["branch"]["1"]["name"] == "Branch 1"
-        @test data["base"]["branch"]["1"]["number_id"] == 123
-        @test data["base"]["branch"]["2"]["name"] == "Branch 2"
-        @test data["base"]["branch"]["2"]["number_id"] == 456
-        @test data["base"]["branch"]["3"]["name"] == "Branch 3"
-        @test data["base"]["branch"]["3"]["number_id"] == 789
+        @test haskey(data["nw"]["0"], "areas_named")
+        @test data["nw"]["0"]["branch"]["1"]["name"] == "Branch 1"
+        @test data["nw"]["0"]["branch"]["1"]["number_id"] == 123
+        @test data["nw"]["0"]["branch"]["2"]["name"] == "Branch 2"
+        @test data["nw"]["0"]["branch"]["2"]["number_id"] == 456
+        @test data["nw"]["0"]["branch"]["3"]["name"] == "Branch 3"
+        @test data["nw"]["0"]["branch"]["3"]["number_id"] == 789
         @test isa(JSON.json(data), String)
     end
 
     @testset "3-bus tnep case" begin
         data = PowerModels.parse_file("../test/data/case3_tnep.m")
 
-        @test haskey(data["base"], "ne_branch")
-        @test data["base"]["ne_branch"]["1"]["f_bus"] == 1
-        @test data["base"]["ne_branch"]["1"]["construction_cost"] == 1
+        @test haskey(data["nw"]["0"], "ne_branch")
+        @test data["nw"]["0"]["ne_branch"]["1"]["f_bus"] == 1
+        @test data["nw"]["0"]["ne_branch"]["1"]["construction_cost"] == 1
         @test isa(JSON.json(data), String)
     end
 
@@ -166,8 +166,8 @@ end
         data = PowerModels.parse_file("../test/data/case3_tnep.m")
         ref = PowerModels.build_ref(data)
 
-        @test haskey(data["base"], "name")
-        @test haskey(ref[:base], :name)
-        @test data["base"]["name"] == ref[:base][:name]
+        @test haskey(data["nw"]["0"], "name")
+        @test haskey(ref[:nw][0], :name)
+        @test data["nw"]["0"]["name"] == ref[:nw][0][:name]
     end
 end

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -6,21 +6,21 @@
 
         @test result["status"] == :LocalOptimal
         @test isapprox(result["objective"], 1.3371; atol = 1e-3)
-        @test isapprox(result["solution"]["bus"]["1"]["pd"], 1.471; atol = 1e-2)
+        @test isapprox(result["solution"]["nw"]["0"]["bus"]["1"]["pd"], 1.471; atol = 1e-2)
     end
     @testset "5-bus pjm case" begin
         result = run_api_opf("../test/data/case5.m", APIACPPowerModel, ipopt_solver)
 
         @test result["status"] == :LocalOptimal
         @test isapprox(result["objective"], 2.6872; atol = 1e-3)
-        @test isapprox(result["solution"]["bus"]["4"]["pd"], 10.754; atol = 1e-2)
+        @test isapprox(result["solution"]["nw"]["0"]["bus"]["4"]["pd"], 10.754; atol = 1e-2)
     end
     @testset "30-bus ieee case" begin
         result = run_api_opf("../test/data/case30.m", APIACPPowerModel, ipopt_solver)
 
         @test result["status"] == :LocalOptimal
         @test isapprox(result["objective"], 1.6628; atol = 1e-3)
-        @test isapprox(result["solution"]["bus"]["2"]["pd"], 0.361; atol = 1e-2)
+        @test isapprox(result["solution"]["nw"]["0"]["bus"]["2"]["pd"], 0.361; atol = 1e-2)
     end
 end
 

--- a/test/modify.jl
+++ b/test/modify.jl
@@ -8,20 +8,20 @@
         @test result["status"] == :LocalOptimal
         @test isapprox(result["objective"], 204.96; atol = 1e-1)
 
-        data["base"]["branch"]["6"]["br_status"] = 0
+        data["nw"]["0"]["branch"]["6"]["br_status"] = 0
 
         result = run_opf(data, ACPPowerModel, ipopt_solver)
         @test result["status"] == :LocalOptimal
         @test isapprox(result["objective"], 195.25; atol = 1e-1)
 
-        data["base"]["gen"]["6"]["gen_status"] = 0
+        data["nw"]["0"]["gen"]["6"]["gen_status"] = 0
 
         result = run_opf(data, ACPPowerModel, ipopt_solver)
         @test result["status"] == :LocalOptimal
         @test isapprox(result["objective"], 195.896; atol = 1e-1)
 
-        data["base"]["bus"]["5"]["pd"] = 0
-        data["base"]["bus"]["5"]["qd"] = 0
+        data["nw"]["0"]["bus"]["5"]["pd"] = 0
+        data["nw"]["0"]["bus"]["5"]["qd"] = 0
 
         result = run_opf(data, ACPPowerModel, ipopt_solver)
         @test result["status"] == :LocalOptimal
@@ -32,8 +32,8 @@
         data = PowerModels.parse_file("../test/data/case30.m")
 
         data_delta = JSON.parse("
-        {
-            \"base\":{
+        {\"nw\":{
+            \"0\":{
                 \"branch\":{
                     \"6\":{
                         \"br_status\":0
@@ -51,7 +51,7 @@
                     }
                 }
             }
-        }")
+        }}")
 
         PowerModels.update_data(data, data_delta)
 

--- a/test/modify.jl
+++ b/test/modify.jl
@@ -8,20 +8,20 @@
         @test result["status"] == :LocalOptimal
         @test isapprox(result["objective"], 204.96; atol = 1e-1)
 
-        data["branch"]["6"]["br_status"] = 0
+        data["base"]["branch"]["6"]["br_status"] = 0
 
         result = run_opf(data, ACPPowerModel, ipopt_solver)
         @test result["status"] == :LocalOptimal
         @test isapprox(result["objective"], 195.25; atol = 1e-1)
 
-        data["gen"]["6"]["gen_status"] = 0
+        data["base"]["gen"]["6"]["gen_status"] = 0
 
         result = run_opf(data, ACPPowerModel, ipopt_solver)
         @test result["status"] == :LocalOptimal
         @test isapprox(result["objective"], 195.896; atol = 1e-1)
 
-        data["bus"]["5"]["pd"] = 0
-        data["bus"]["5"]["qd"] = 0
+        data["base"]["bus"]["5"]["pd"] = 0
+        data["base"]["bus"]["5"]["qd"] = 0
 
         result = run_opf(data, ACPPowerModel, ipopt_solver)
         @test result["status"] == :LocalOptimal
@@ -33,20 +33,22 @@
 
         data_delta = JSON.parse("
         {
-            \"branch\":{
-                \"6\":{
-                    \"br_status\":0
-                }
-            },
-            \"gen\":{
-                \"6\":{
-                    \"gen_status\":0
-                }
-            },
-            \"bus\":{
-                \"5\":{
-                    \"pd\":0,
-                    \"qd\":0
+            \"base\":{
+                \"branch\":{
+                    \"6\":{
+                        \"br_status\":0
+                    }
+                },
+                \"gen\":{
+                    \"6\":{
+                        \"gen_status\":0
+                    }
+                },
+                \"bus\":{
+                    \"5\":{
+                        \"pd\":0,
+                        \"qd\":0
+                    }
                 }
             }
         }")

--- a/test/mpopf.jl
+++ b/test/mpopf.jl
@@ -2,15 +2,17 @@
 @testset "test ac polar opf" begin
     @testset "2 period 5-bus asymmetric case" begin
         mp_data = PowerModels.parse_file("../test/data/case5_asym.m")
-        mp_data["t1"] = mp_data["base"]; mp_data["t2"] = mp_data["base"]; delete!(mp_data, "base")
+        mp_data["nw"]["1"] = mp_data["nw"]["0"]
+        mp_data["nw"]["2"] = mp_data["nw"]["0"]
+        delete!(mp_data["nw"], "0")
 
-        result = run_ac_mpopf(mp_data, ipopt_solver)
+        result = PowerModels.run_ac_mpopf(mp_data, ipopt_solver)
 
         @test result["status"] == :LocalOptimal
         @test isapprox(result["objective"], 35117.1; atol = 1e0)
         @test isapprox(
-            result["solution"]["t1"]["gen"]["1"]["pg"],
-            result["solution"]["t2"]["gen"]["4"]["pg"]; 
+            result["solution"]["nw"]["1"]["gen"]["1"]["pg"],
+            result["solution"]["nw"]["2"]["gen"]["4"]["pg"]; 
             atol = 1e-3
         )
     end

--- a/test/mpopf.jl
+++ b/test/mpopf.jl
@@ -1,0 +1,17 @@
+
+@testset "test ac polar opf" begin
+    @testset "2 period 5-bus asymmetric case" begin
+        mp_data = PowerModels.parse_file("../test/data/case5_asym.m")
+        mp_data["t1"] = mp_data["base"]; mp_data["t2"] = mp_data["base"]; delete!(mp_data, "base")
+
+        result = run_ac_mpopf(mp_data, ipopt_solver)
+
+        @test result["status"] == :LocalOptimal
+        @test isapprox(result["objective"], 35117.1; atol = 1e0)
+        @test isapprox(
+            result["solution"]["t1"]["gen"]["1"]["pg"],
+            result["solution"]["t2"]["gen"]["4"]["pg"]; 
+            atol = 1e-3
+        )
+    end
+end

--- a/test/opf.jl
+++ b/test/opf.jl
@@ -24,8 +24,8 @@
 
         @test result["status"] == :LocalOptimal
         @test isapprox(result["objective"], 11567; atol = 1e0)
-        @test isapprox(result["solution"]["bus"]["1"]["va"], 0.0; atol = 1e-4)
-        @test isapprox(result["solution"]["bus"]["4"]["va"], 0.0; atol = 1e-4)
+        @test isapprox(result["solution"]["nw"]["0"]["bus"]["1"]["va"], 0.0; atol = 1e-4)
+        @test isapprox(result["solution"]["nw"]["0"]["bus"]["4"]["va"], 0.0; atol = 1e-4)
     end
     @testset "24-bus rts case" begin
         result = run_opf("../test/data/case24.m", ACPPowerModel, ipopt_solver)
@@ -55,8 +55,8 @@ end
 
         @test result["status"] == :LocalOptimal
         @test isapprox(result["objective"], 11567; atol = 1e0)
-        @test isapprox(result["solution"]["bus"]["1"]["va"], 0.0; atol = 1e-4)
-        @test isapprox(result["solution"]["bus"]["4"]["va"], 0.0; atol = 1e-4) 
+        @test isapprox(result["solution"]["nw"]["0"]["bus"]["1"]["va"], 0.0; atol = 1e-4)
+        @test isapprox(result["solution"]["nw"]["0"]["bus"]["4"]["va"], 0.0; atol = 1e-4) 
     end
     @testset "24-bus rts case" begin
         result = run_opf("../test/data/case24.m", ACRPowerModel, ipopt_solver)
@@ -85,8 +85,8 @@ end
 
         @test result["status"] == :LocalOptimal
         @test isapprox(result["objective"], 11567; atol = 1e0)
-        @test isapprox(result["solution"]["bus"]["1"]["va"], 0.0; atol = 1e-4)
-        @test isapprox(result["solution"]["bus"]["4"]["va"], 0.0; atol = 1e-4) 
+        @test isapprox(result["solution"]["nw"]["0"]["bus"]["1"]["va"], 0.0; atol = 1e-4)
+        @test isapprox(result["solution"]["nw"]["0"]["bus"]["4"]["va"], 0.0; atol = 1e-4) 
     end
     @testset "24-bus rts case" begin
         result = run_opf("../test/data/case24.m", ACTPowerModel, ipopt_solver)
@@ -115,8 +115,8 @@ end
 
         @test result["status"] == :LocalOptimal
         @test isapprox(result["objective"], 11396; atol = 1e0)
-        @test isapprox(result["solution"]["bus"]["1"]["va"], 0.0; atol = 1e-4)
-        @test isapprox(result["solution"]["bus"]["4"]["va"], 0.0; atol = 1e-4)
+        @test isapprox(result["solution"]["nw"]["0"]["bus"]["1"]["va"], 0.0; atol = 1e-4)
+        @test isapprox(result["solution"]["nw"]["0"]["bus"]["4"]["va"], 0.0; atol = 1e-4)
     end
     # TODO verify this is really infeasible
     #@testset "24-bus rts case" begin
@@ -174,8 +174,8 @@ end
 
         @test result["status"] == :LocalOptimal
         @test isapprox(result["objective"], 11567; atol = 1e0)
-        @test isapprox(result["solution"]["bus"]["1"]["va"], 0.0; atol = 1e-4)
-        @test isapprox(result["solution"]["bus"]["4"]["va"], 0.0; atol = 1e-4)
+        @test isapprox(result["solution"]["nw"]["0"]["bus"]["1"]["va"], 0.0; atol = 1e-4)
+        @test isapprox(result["solution"]["nw"]["0"]["bus"]["4"]["va"], 0.0; atol = 1e-4)
     end
     @testset "24-bus rts case" begin
         result = run_opf("../test/data/case24.m", QCWRPowerModel, ipopt_solver)

--- a/test/output.jl
+++ b/test/output.jl
@@ -11,12 +11,12 @@
         @test haskey(result, "machine") == true
         @test haskey(result, "data") == true
         @test haskey(result, "solution") == true
-        @test haskey(result["solution"], "branch") == false
+        @test haskey(result["solution"]["nw"]["0"], "branch") == false
 
         @test !isnan(result["solve_time"])
 
-        @test length(result["solution"]["bus"]) == 24
-        @test length(result["solution"]["gen"]) == 33
+        @test length(result["solution"]["nw"]["0"]["bus"]) == 24
+        @test length(result["solution"]["nw"]["0"]["gen"]) == 33
     end
 end
 
@@ -32,13 +32,13 @@ end
         @test haskey(result, "machine") == true
         @test haskey(result, "data") == true
         @test haskey(result, "solution") == true
-        @test haskey(result["solution"], "branch") == true
+        @test haskey(result["solution"]["nw"]["0"], "branch") == true
 
-        @test length(result["solution"]["bus"]) == 24
-        @test length(result["solution"]["gen"]) == 33
-        @test length(result["solution"]["branch"]) == 38
+        @test length(result["solution"]["nw"]["0"]["bus"]) == 24
+        @test length(result["solution"]["nw"]["0"]["gen"]) == 33
+        @test length(result["solution"]["nw"]["0"]["branch"]) == 38
 
-        branches = result["solution"]["branch"]
+        branches = result["solution"]["nw"]["0"]["branch"]
 
         @test isapprox(branches["2"]["pf"],  0.2001; atol = 1e-3)
         @test isapprox(branches["2"]["pt"], -0.1980; atol = 1e-3)
@@ -51,14 +51,14 @@ end
         result = run_opf("../test/data/case3.m", DCPPowerModel, ipopt_solver; setting = Dict("output" => Dict("line_flows" => true)))
 
         @test haskey(result, "solution") == true
-        @test haskey(result["solution"], "branch") == true
+        @test haskey(result["solution"]["nw"]["0"], "branch") == true
 
-        @test length(result["solution"]["bus"]) == 3
-        @test length(result["solution"]["gen"]) == 3
-        @test length(result["solution"]["branch"]) == 3
-        @test length(result["solution"]["dcline"]) == 1
+        @test length(result["solution"]["nw"]["0"]["bus"]) == 3
+        @test length(result["solution"]["nw"]["0"]["gen"]) == 3
+        @test length(result["solution"]["nw"]["0"]["branch"]) == 3
+        @test length(result["solution"]["nw"]["0"]["dcline"]) == 1
 
-        branches = result["solution"]["branch"]
+        branches = result["solution"]["nw"]["0"]["branch"]
 
         @test isapprox(branches["3"]["pf"], -0.103497; atol = 1e-3)
         @test isapprox(branches["3"]["pt"],  0.103497; atol = 1e-3)
@@ -76,26 +76,26 @@ end
         @test opf_result["status"] == :LocalOptimal
         @test isapprox(opf_result["objective"], 5907; atol = 1e0)
 
-        PowerModels.update_data(data, opf_result["solution"])
+        PowerModels.update_data(data, opf_result["solution"]["nw"]["0"])
 
         pf_result = run_ac_pf(data, ipopt_solver)
         @test pf_result["status"] == :LocalOptimal
         @test isapprox(pf_result["objective"], 0.0; atol = 1e-3)
 
         for (i,bus) in data["bus"]
-            @test isapprox(opf_result["solution"]["bus"][i]["va"], pf_result["solution"]["bus"][i]["va"]; atol = 1e-3)
-            @test isapprox(opf_result["solution"]["bus"][i]["vm"], pf_result["solution"]["bus"][i]["vm"]; atol = 1e-3)
+            @test isapprox(opf_result["solution"]["nw"]["0"]["bus"][i]["va"], pf_result["solution"]["nw"]["0"]["bus"][i]["va"]; atol = 1e-3)
+            @test isapprox(opf_result["solution"]["nw"]["0"]["bus"][i]["vm"], pf_result["solution"]["nw"]["0"]["bus"][i]["vm"]; atol = 1e-3)
         end
 
         for (i,gen) in data["gen"]
-            @test isapprox(opf_result["solution"]["gen"][i]["pg"], pf_result["solution"]["gen"][i]["pg"]; atol = 1e-3)
+            @test isapprox(opf_result["solution"]["nw"]["0"]["gen"][i]["pg"], pf_result["solution"]["nw"]["0"]["gen"][i]["pg"]; atol = 1e-3)
             # cannot check this value solution does not appeat to be unique; verify this!
-            #@test isapprox(opf_result["solution"]["gen"][i]["qg"], pf_result["solution"]["gen"][i]["qg"]; atol = 1e-3)
+            #@test isapprox(opf_result["solution"]["nw"]["0"]["gen"][i]["qg"], pf_result["solution"]["nw"]["0"]["gen"][i]["qg"]; atol = 1e-3)
         end
 
         for (i,dcline) in data["dcline"]
-            @test isapprox(opf_result["solution"]["dcline"][i]["pf"], pf_result["solution"]["dcline"][i]["pf"]; atol = 1e-3)
-            @test isapprox(opf_result["solution"]["dcline"][i]["pt"], pf_result["solution"]["dcline"][i]["pt"]; atol = 1e-3)
+            @test isapprox(opf_result["solution"]["nw"]["0"]["dcline"][i]["pf"], pf_result["solution"]["nw"]["0"]["dcline"][i]["pf"]; atol = 1e-3)
+            @test isapprox(opf_result["solution"]["nw"]["0"]["dcline"][i]["pt"], pf_result["solution"]["nw"]["0"]["dcline"][i]["pt"]; atol = 1e-3)
         end
     end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -21,22 +21,24 @@ ipopt_solver = IpoptSolver(tol=1e-6, print_level=0)
 pajarito_solver = PajaritoSolver(mip_solver=GLPKSolverMIP(), cont_solver=ipopt_solver, log_level=0)
 scs_solver = SCSSolver(max_iters=1000000, verbose=0)
 
-include("matpower.jl")
+#include("matpower.jl")
 
-include("output.jl")
+#include("output.jl")
 
-include("modify.jl")
+#include("modify.jl")
 
-include("data.jl")
+#include("data.jl")
 
-include("pf.jl")
+#include("pf.jl")
 
-include("opf.jl")
+#include("opf.jl")
 
-include("misc.jl")
+#include("misc.jl")
 
-include("ots.jl")
+#include("ots.jl")
 
-include("tnep.jl")
+#include("tnep.jl")
 
-include("docs.jl")
+include("mpopf.jl")
+
+#include("docs.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -21,19 +21,19 @@ ipopt_solver = IpoptSolver(tol=1e-6, print_level=0)
 pajarito_solver = PajaritoSolver(mip_solver=GLPKSolverMIP(), cont_solver=ipopt_solver, log_level=0)
 scs_solver = SCSSolver(max_iters=1000000, verbose=0)
 
-#include("matpower.jl")
+include("matpower.jl")
 
-#include("output.jl")
+include("output.jl")
 
-#include("modify.jl")
+include("modify.jl")
 
-#include("data.jl")
+include("data.jl")
 
 #include("pf.jl")
 
-#include("opf.jl")
+include("opf.jl")
 
-#include("misc.jl")
+include("misc.jl")
 
 #include("ots.jl")
 
@@ -41,4 +41,4 @@ scs_solver = SCSSolver(max_iters=1000000, verbose=0)
 
 include("mpopf.jl")
 
-#include("docs.jl")
+include("docs.jl")


### PR DESCRIPTION
@yeesian @rb004f @kaarthiksundar @frederikgeth @hakanergun

This is what I had in mind for how PowerModels could support multiple networks in one JuMP model, as discussed in #44, #112.  This is a work in progress, currently only the OPF problem is updated, but I think this sufficient to have a useful discussion on the design.

The core idea is to introduce a notion of "networks"(nw) into the data object, this same organization then follows through to all of the other structures in GenericPowerModel, i.e. ref, var, ext.

The top-level data schema becomes,
```
{
  "nw":{
    {"1":{<current single network data>},
    {"2":{<current single network data>},
    ...
  }
}
```
Problem metadata that spans multiple networks can be put at the top level of this data object.  Things like ref, var, ext have the following top-level organization,
```
{
  :nw:{
    {1:{<current single network items>}},
    {2:{<current single network items>}},
    ...
  }
}
```
Which follows the same organizational convention of components within in the networks.  Currently when we read in a single network data file (i.e. Matpower), it is assign the default network index of "0".

I have mocked up an example Multi-Period OPF (mpopf) problem to show how I imagined this structure would be used to do multi-network optimization,
https://github.com/lanl-ansi/PowerModels.jl/blob/networks/src/prob/mpopf.jl
https://github.com/lanl-ansi/PowerModels.jl/blob/networks/test/mpopf.jl

I have also added some helper functions (e.g. nw_ref), to help modelers ignore the multi-network structure, if their problem is only one network,
https://github.com/lanl-ansi/PowerModels.jl/blob/networks/src/prob/opf.jl

Pros of this proposal (as is)
- the information structure is self consistent with the rest of PowerModels
- this design is extremely generic and flexible, for example you could load two entirely different networks into "nw" and it would work fine
- having an explicit "nw" dictionary allows for data and variables that span multiple networks
- Any single-network function is easily extended to this multi-network structure (e.g. `make_per_unit`)

Cons of this proposal (as is)
- if you are __not__ solving a multi-network problem there is complexity that will feel cumbersome.  For example getting data is now `data["nw"]["0"]["bus"]["1"]["vm"]`, this `["nw"]["0"]` seems tedious.
- the modeling looks complex and may be intimidating to developers.  For example  `pm.var[:nw][n][:w] = @variable(pm.model,  ... lowerbound = pm.ref[:nw][n][:bus][i]["vmin"]^2 ...)`
- the price we pay for extremely generality is that having many copies of a similar network can be a space hog.  That said, it should not add more than 2-3x the size of the optimization model it self.

I think some of these cons can be addressed through further restructuring of the software, but I wanted to get some initial feedback before getting into that level of refinement.

For those of you who have been interested in using such an extension.  I don't have a super clear idea of what specific problems you are interested in solving.  It would be a great help to me if you could mock-up what your problem would look like, i.e. your version of `post_mpopf`.  This will help me understand if this proposal will fit your needs and if it is worth pursuing further.

General comments/questions/suggestions are encouraged. 


