### PR TITLE
fixing angle difference bug in acp models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ PowerModels.jl Change Log
 - Removed deprecated bus-less constraint_theta_ref function (breaking)
 - Moved check_cost_models into the objective building function
 - Fixed out of range bug in calc_theta_delta_bounds
+- Fixed bug in phase angle differences in AbstractACPForms
 
 ### v0.3.4
 - Added support for Matpower data with dclines (thanks to @frederikgeth, @hakanergun)

--- a/src/form/acp.jl
+++ b/src/form/acp.jl
@@ -149,7 +149,7 @@ function constraint_ohms_yt_to{T <: AbstractACPForm}(pm::GenericPowerModel{T}, f
     t_to = pm.var[:t][t_bus]
 
     c1 = @NLconstraint(pm.model, p_to == g*v_to^2 + (-g*tr-b*ti)/tm*(v_to*v_fr*cos(t_to-t_fr)) + (-b*tr+g*ti)/tm*(v_to*v_fr*sin(t_to-t_fr)) )
-    c2 = @NLconstraint(pm.model, q_to == -(b+c/2)*v_to^2 - (-b*tr+g*ti)/tm*(v_to*v_fr*cos(t_fr-t_to)) + (-g*tr-b*ti)/tm*(v_to*v_fr*sin(t_to-t_fr)) )
+    c2 = @NLconstraint(pm.model, q_to == -(b+c/2)*v_to^2 - (-b*tr+g*ti)/tm*(v_to*v_fr*cos(t_to-t_fr)) + (-g*tr-b*ti)/tm*(v_to*v_fr*sin(t_to-t_fr)) )
     return Set([c1, c2])
 end
 
@@ -191,7 +191,7 @@ function constraint_ohms_y_to{T <: AbstractACPForm}(pm::GenericPowerModel{T}, f_
     t_to = pm.var[:t][t_bus]
 
     c1 = @NLconstraint(pm.model, p_to == g*v_to^2 + -g*v_to*v_fr/tr*cos(t_to-t_fr+as) + -b*v_to*v_fr/tr*sin(t_to-t_fr+as) )
-    c2 = @NLconstraint(pm.model, q_to == -(b+c/2)*v_to^2 + b*v_to*v_fr/tr*cos(t_fr-t_to+as) + -g*v_to*v_fr/tr*sin(t_to-t_fr+as) )
+    c2 = @NLconstraint(pm.model, q_to == -(b+c/2)*v_to^2 + b*v_to*v_fr/tr*cos(t_to-t_fr+as) + -g*v_to*v_fr/tr*sin(t_to-t_fr+as) )
     return Set([c1, c2])
 end
 
@@ -241,7 +241,7 @@ function constraint_ohms_yt_to_on_off{T <: AbstractACPForm}(pm::GenericPowerMode
     z = pm.var[:line_z][i]
 
     c1 = @NLconstraint(pm.model, p_to == z*(g*v_to^2 + (-g*tr-b*ti)/tm*(v_to*v_fr*cos(t_to-t_fr)) + (-b*tr+g*ti)/tm*(v_to*v_fr*sin(t_to-t_fr))) )
-    c2 = @NLconstraint(pm.model, q_to == z*(-(b+c/2)*v_to^2 - (-b*tr+g*ti)/tm*(v_to*v_fr*cos(t_fr-t_to)) + (-g*tr-b*ti)/tm*(v_to*v_fr*sin(t_to-t_fr))) )
+    c2 = @NLconstraint(pm.model, q_to == z*(-(b+c/2)*v_to^2 - (-b*tr+g*ti)/tm*(v_to*v_fr*cos(t_to-t_fr)) + (-g*tr-b*ti)/tm*(v_to*v_fr*sin(t_to-t_fr))) )
     return Set([c1, c2])
 end
 
@@ -281,7 +281,7 @@ function constraint_ohms_yt_to_ne{T <: AbstractACPForm}(pm::GenericPowerModel{T}
     z = pm.var[:line_ne][i]
 
     c1 = @NLconstraint(pm.model, p_to == z*(g*v_to^2 + (-g*tr-b*ti)/tm*(v_to*v_fr*cos(t_to-t_fr)) + (-b*tr+g*ti)/tm*(v_to*v_fr*sin(t_to-t_fr))) )
-    c2 = @NLconstraint(pm.model, q_to == z*(-(b+c/2)*v_to^2 - (-b*tr+g*ti)/tm*(v_to*v_fr*cos(t_fr-t_to)) + (-g*tr-b*ti)/tm*(v_to*v_fr*sin(t_to-t_fr))) )
+    c2 = @NLconstraint(pm.model, q_to == z*(-(b+c/2)*v_to^2 - (-b*tr+g*ti)/tm*(v_to*v_fr*cos(t_to-t_fr)) + (-g*tr-b*ti)/tm*(v_to*v_fr*sin(t_to-t_fr))) )
     return Set([c1, c2])
 end
 

--- a/test/opf.jl
+++ b/test/opf.jl
@@ -214,3 +214,77 @@ end
     #    @test isapprox(result["objective"], 75153; atol = 1e0)
     #end
 end
+
+
+
+
+@testset "test ac v+t polar opf" begin
+    PMs = PowerModels
+
+    function post_opf_var(pm::GenericPowerModel)
+        PMs.variable_voltage(pm)
+        PMs.variable_generation(pm)
+        PMs.variable_line_flow(pm)
+        PMs.variable_dcline_flow(pm)
+
+        PMs.objective_min_fuel_cost(pm)
+
+        PMs.constraint_voltage(pm)
+
+        for (i,bus) in pm.ref[:ref_buses]
+            PMs.constraint_theta_ref(pm, bus)
+        end
+
+        for (i,bus) in pm.ref[:bus]
+            PMs.constraint_kcl_shunt(pm, bus)
+        end
+
+        for (i,branch) in pm.ref[:branch]
+            # these are the functions to be tested
+            PMs.constraint_ohms_y_from(pm, branch)
+            PMs.constraint_ohms_y_to(pm, branch)
+
+            PMs.constraint_phase_angle_difference(pm, branch)
+
+            PMs.constraint_thermal_limit_from(pm, branch)
+            PMs.constraint_thermal_limit_to(pm, branch)
+        end
+        for (i,dcline) in pm.ref[:dcline]
+            PMs.constraint_dcline(pm, dcline)
+        end
+    end
+
+    @testset "3-bus case" begin
+        result = run_generic_model("../test/data/case3.m", ACPPowerModel, ipopt_solver, post_opf_var)
+
+        @test result["status"] == :LocalOptimal
+        @test isapprox(result["objective"], 5907; atol = 1e0)
+    end
+    @testset "5-bus asymmetric case" begin
+        result = run_generic_model("../test/data/case5_asym.m", ACPPowerModel, ipopt_solver, post_opf_var)
+
+        @test result["status"] == :LocalOptimal
+        @test isapprox(result["objective"], 17551; atol = 1e0)
+    end
+    @testset "5-bus with dcline costs" begin
+        result = run_generic_model("../test/data/case5_dc.m", ACPPowerModel, ipopt_solver, post_opf_var)
+
+        @test result["status"] == :LocalOptimal
+        @test isapprox(result["objective"], 17760.2; atol = 1e0)
+    end
+    @testset "6-bus case" begin
+        result = run_generic_model("../test/data/case6.m", ACPPowerModel, ipopt_solver, post_opf_var)
+
+        @test result["status"] == :LocalOptimal
+        @test isapprox(result["objective"], 11567; atol = 1e0)
+        @test isapprox(result["solution"]["bus"]["1"]["va"], 0.0; atol = 1e-4)
+        @test isapprox(result["solution"]["bus"]["4"]["va"], 0.0; atol = 1e-4)
+    end
+    @testset "24-bus rts case" begin
+        result = run_generic_model("../test/data/case24.m", ACPPowerModel, ipopt_solver, post_opf_var)
+
+        @test result["status"] == :LocalOptimal
+        @test isapprox(result["objective"], 79805; atol = 1e0)
+    end
+end
+


### PR DESCRIPTION
Special thanks to @hakanergun for finding this one!

This was well hidden becouse `cos(x) == cos(-x)`.  However, it surely would cause issues in the `ohms_y` formulation!  Hence, #154.