### PR TITLE
Remove Variable and Constraint Return Values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ PowerModels.jl Change Log
 - Eliminated usage of pm.model.ext, for details see [#149](https://github.com/lanl-ansi/PowerModels.jl/pull/149)
 - Made solution default units per-unit (breaking)
 - Removed deprecated bus-less constraint_theta_ref function (breaking)
+- Removed variable and constraint function return values (breaking)
 - Moved check_cost_models into the objective building function
 - Fixed out of range bug in calc_theta_delta_bounds
 - Fixed bug in phase angle differences in AbstractACPForms

--- a/src/core/constraint.jl
+++ b/src/core/constraint.jl
@@ -9,32 +9,28 @@
 function constraint_thermal_limit_from(pm::GenericPowerModel, f_idx, rate_a)
     p_fr = pm.var[:p][f_idx]
     q_fr = pm.var[:q][f_idx]
-    c = @constraint(pm.model, p_fr^2 + q_fr^2 <= rate_a^2)
-    return Set([c])
+    @constraint(pm.model, p_fr^2 + q_fr^2 <= rate_a^2)
 end
 
 "`p[t_idx]^2 + q[t_idx]^2 <= rate_a^2`"
 function constraint_thermal_limit_to(pm::GenericPowerModel, t_idx, rate_a)
     p_to = pm.var[:p][t_idx]
     q_to = pm.var[:q][t_idx]
-    c = @constraint(pm.model, p_to^2 + q_to^2 <= rate_a^2)
-    return Set([c])
+    @constraint(pm.model, p_to^2 + q_to^2 <= rate_a^2)
 end
 
 "`norm([p[f_idx]; q[f_idx]]) <= rate_a`"
 function constraint_thermal_limit_from{T <: AbstractConicPowerFormulation}(pm::GenericPowerModel{T}, f_idx, rate_a)
     p_fr = pm.var[:p][f_idx]
     q_fr = pm.var[:q][f_idx]
-    c = @constraint(pm.model, norm([p_fr; q_fr]) <= rate_a)
-    return Set([c])
+    @constraint(pm.model, norm([p_fr; q_fr]) <= rate_a)
 end
 
 "`norm([p[t_idx]; q[t_idx]]) <= rate_a`"
 function constraint_thermal_limit_to{T <: AbstractConicPowerFormulation}(pm::GenericPowerModel{T}, t_idx, rate_a)
     p_to = pm.var[:p][t_idx]
     q_to = pm.var[:q][t_idx]
-    c = @constraint(pm.model, norm([p_to; q_to]) <= rate_a)
-    return Set([c])
+    @constraint(pm.model, norm([p_to; q_to]) <= rate_a)
 end
 
 # Generic on/off thermal limit constraint
@@ -44,8 +40,7 @@ function constraint_thermal_limit_from_on_off(pm::GenericPowerModel, i, f_idx, r
     p_fr = pm.var[:p][f_idx]
     q_fr = pm.var[:q][f_idx]
     z = pm.var[:line_z][i]
-    c = @constraint(pm.model, p_fr^2 + q_fr^2 <= rate_a^2*z^2)
-    return Set([c])
+    @constraint(pm.model, p_fr^2 + q_fr^2 <= rate_a^2*z^2)
 end
 
 "`p[t_idx]^2 + q[t_idx]^2 <= (rate_a * line_z[i])^2`"
@@ -53,8 +48,7 @@ function constraint_thermal_limit_to_on_off(pm::GenericPowerModel, i, t_idx, rat
     p_to = pm.var[:p][t_idx]
     q_to = pm.var[:q][t_idx]
     z = pm.var[:line_z][i]
-    c = @constraint(pm.model, p_to^2 + q_to^2 <= rate_a^2*z^2)
-    return Set([c])
+    @constraint(pm.model, p_to^2 + q_to^2 <= rate_a^2*z^2)
 end
 
 "`p_ne[f_idx]^2 + q_ne[f_idx]^2 <= (rate_a * line_ne[i])^2`"
@@ -62,8 +56,7 @@ function constraint_thermal_limit_from_ne(pm::GenericPowerModel, i, f_idx, rate_
     p_fr = pm.var[:p_ne][f_idx]
     q_fr = pm.var[:q_ne][f_idx]
     z = pm.var[:line_ne][i]
-    c = @constraint(pm.model, p_fr^2 + q_fr^2 <= rate_a^2*z^2)
-    return Set([c])
+    @constraint(pm.model, p_fr^2 + q_fr^2 <= rate_a^2*z^2)
 end
 
 "`p_ne[t_idx]^2 + q_ne[t_idx]^2 <= (rate_a * line_ne[i])^2`"
@@ -71,22 +64,19 @@ function constraint_thermal_limit_to_ne(pm::GenericPowerModel, i, t_idx, rate_a)
     p_to = pm.var[:p_ne][t_idx]
     q_to = pm.var[:q_ne][t_idx]
     z = pm.var[:line_ne][i]
-    c = @constraint(pm.model, p_to^2 + q_to^2 <= rate_a^2*z^2)
-    return Set([c])
+    @constraint(pm.model, p_to^2 + q_to^2 <= rate_a^2*z^2)
 end
 
 "`pg[i] == pg`"
 function constraint_active_gen_setpoint(pm::GenericPowerModel, i, pg)
     pg_var = pm.var[:pg][i]
-    c = @constraint(pm.model, pg_var == pg)
-    return Set([c])
+    @constraint(pm.model, pg_var == pg)
 end
 
 "`qq[i] == qq`"
 function constraint_reactive_gen_setpoint(pm::GenericPowerModel, i, qg)
     qg_var = pm.var[:qg][i]
-    c = @constraint(pm.model, qg_var == qg)
-    return Set([c])
+    @constraint(pm.model, qg_var == qg)
 end
 
 """
@@ -100,8 +90,7 @@ function constraint_dcline{T}(pm::GenericPowerModel{T}, f_bus, t_bus, f_idx, t_i
     p_fr = pm.var[:p_dc][f_idx]
     p_to = pm.var[:p_dc][t_idx]
 
-    c1 = @constraint(pm.model, (1-loss1) * p_fr + (p_to - loss0) == 0)
-    return Set([c1])
+    @constraint(pm.model, (1-loss1) * p_fr + (p_to - loss0) == 0)
 end
 
 "`pf[i] == pf, pt[i] == pt`"
@@ -110,15 +99,12 @@ function constraint_active_dcline_setpoint(pm::GenericPowerModel, i, f_idx, t_id
     p_to = pm.var[:p_dc][t_idx]
 
     if epsilon == 0.0
-        c1 = @constraint(pm.model, p_fr == pf)
-        c2 = @constraint(pm.model, p_to == pt)
-        return Set([c1,c2])
+        @constraint(pm.model, p_fr == pf)
+        @constraint(pm.model, p_to == pt)
     else
-        c1 = @constraint(pm.model, p_fr >= pf - epsilon)
-        c2 = @constraint(pm.model, p_to >= pt - epsilon)
-        c3 = @constraint(pm.model, p_fr <= pf + epsilon)
-        c4 = @constraint(pm.model, p_to <= pt + epsilon)
-        return Set([c1,c2,c3,c4])
+        @constraint(pm.model, p_fr >= pf - epsilon)
+        @constraint(pm.model, p_to >= pt - epsilon)
+        @constraint(pm.model, p_fr <= pf + epsilon)
+        @constraint(pm.model, p_to <= pt + epsilon)
     end
-
 end

--- a/src/core/constraint_template.jl
+++ b/src/core/constraint_template.jl
@@ -1,5 +1,6 @@
 #
 # Constraint Template Definitions
+#
 # Constraint templates help simplify data wrangling across multiple Power
 # Flow formulations by providing an abstraction layer between the network data
 # and network constraint definitions.  The constraint template's job is to
@@ -14,25 +15,25 @@
 ### Generator Constraints ###
 ""
 function constraint_active_gen_setpoint(pm::GenericPowerModel, gen)
-    return constraint_active_gen_setpoint(pm, gen["index"], gen["pg"])
+    constraint_active_gen_setpoint(pm, gen["index"], gen["pg"])
 end
 
 ""
 function constraint_reactive_gen_setpoint(pm::GenericPowerModel, gen)
-    return constraint_reactive_gen_setpoint(pm, gen["index"], gen["qg"])
+    constraint_reactive_gen_setpoint(pm, gen["index"], gen["qg"])
 end
 
 ### Bus - Setpoint Constraints ###
 
 ""
 function constraint_theta_ref(pm::GenericPowerModel, bus)
-    return constraint_theta_ref(pm, bus["index"])
+    constraint_theta_ref(pm, bus["index"])
 end
 
 ""
 function constraint_voltage_magnitude_setpoint(pm::GenericPowerModel, bus; epsilon = 0.0)
     @assert epsilon >= 0.0
-    return constraint_voltage_magnitude_setpoint(pm, bus["index"], bus["vm"], epsilon)
+    constraint_voltage_magnitude_setpoint(pm, bus["index"], bus["vm"], epsilon)
 end
 
 ### Bus - KCL Constraints ###
@@ -44,7 +45,7 @@ function constraint_kcl_shunt(pm::GenericPowerModel, bus)
     bus_arcs_dc = pm.ref[:bus_arcs_dc][i]
     bus_gens = pm.ref[:bus_gens][i]
 
-    return constraint_kcl_shunt(pm, i, bus_arcs, bus_arcs_dc, bus_gens, bus["pd"], bus["qd"], bus["gs"], bus["bs"])
+    constraint_kcl_shunt(pm, i, bus_arcs, bus_arcs_dc, bus_gens, bus["pd"], bus["qd"], bus["gs"], bus["bs"])
 end
 
 ""
@@ -55,7 +56,7 @@ function constraint_kcl_shunt_ne(pm::GenericPowerModel, bus)
     bus_arcs_ne = pm.ref[:ne_bus_arcs][i]
     bus_gens = pm.ref[:bus_gens][i]
 
-    return constraint_kcl_shunt_ne(pm, i, bus_arcs, bus_arcs_dc, bus_arcs_ne, bus_gens, bus["pd"], bus["qd"], bus["gs"], bus["bs"])
+    constraint_kcl_shunt_ne(pm, i, bus_arcs, bus_arcs_dc, bus_arcs_ne, bus_gens, bus["pd"], bus["qd"], bus["gs"], bus["bs"])
 end
 
 ### Branch - Ohm's Law Constraints ###
@@ -73,7 +74,7 @@ function constraint_ohms_yt_from(pm::GenericPowerModel, branch)
     c = branch["br_b"]
     tm = branch["tap"]^2
 
-    return constraint_ohms_yt_from(pm, f_bus, t_bus, f_idx, t_idx, g, b, c, tr, ti, tm)
+    constraint_ohms_yt_from(pm, f_bus, t_bus, f_idx, t_idx, g, b, c, tr, ti, tm)
 end
 
 ### Branch - Loss Constraints DC LINES###
@@ -88,7 +89,7 @@ function constraint_dcline(pm::GenericPowerModel, dcline)
     loss0 = dcline["loss0"]
     loss1 = dcline["loss1"]
 
-    return constraint_dcline(pm, f_bus, t_bus, f_idx, t_idx, loss0, loss1)
+    constraint_dcline(pm, f_bus, t_bus, f_idx, t_idx, loss0, loss1)
 end
 
 
@@ -101,7 +102,7 @@ function constraint_voltage_dcline_setpoint(pm::GenericPowerModel, dcline; epsil
     vf = dcline["vf"]
     vt = dcline["vt"]
 
-    return constraint_voltage_dcline_setpoint(pm, f_bus, t_bus, vf, vt, epsilon)
+    constraint_voltage_dcline_setpoint(pm, f_bus, t_bus, vf, vt, epsilon)
 end
 
 function constraint_active_dcline_setpoint(pm::GenericPowerModel, dcline; epsilon = 0.0)
@@ -113,7 +114,7 @@ function constraint_active_dcline_setpoint(pm::GenericPowerModel, dcline; epsilo
     pf = dcline["pf"]
     pt = dcline["pt"]
 
-    return constraint_active_dcline_setpoint(pm, i, f_idx, t_idx, pf, pt, epsilon)
+    constraint_active_dcline_setpoint(pm, i, f_idx, t_idx, pf, pt, epsilon)
 end
 
 ""
@@ -129,7 +130,7 @@ function constraint_ohms_yt_to(pm::GenericPowerModel, branch)
     c = branch["br_b"]
     tm = branch["tap"]^2
 
-    return constraint_ohms_yt_to(pm, f_bus, t_bus, f_idx, t_idx, g, b, c, tr, ti, tm)
+    constraint_ohms_yt_to(pm, f_bus, t_bus, f_idx, t_idx, g, b, c, tr, ti, tm)
 end
 
 ""
@@ -145,7 +146,7 @@ function constraint_ohms_y_from(pm::GenericPowerModel, branch)
     tr = branch["tap"]
     as = branch["shift"]
 
-    return constraint_ohms_y_from(pm, f_bus, t_bus, f_idx, t_idx, g, b, c, tr, as)
+    constraint_ohms_y_from(pm, f_bus, t_bus, f_idx, t_idx, g, b, c, tr, as)
 end
 
 ""
@@ -161,7 +162,7 @@ function constraint_ohms_y_to(pm::GenericPowerModel, branch)
     tr = branch["tap"]
     as = branch["shift"]
 
-    return constraint_ohms_y_to(pm, f_bus, t_bus, f_idx, t_idx, g, b, c, tr, as)
+    constraint_ohms_y_to(pm, f_bus, t_bus, f_idx, t_idx, g, b, c, tr, as)
 end
 
 ### Branch - On/Off Ohm's Law Constraints ###
@@ -182,7 +183,7 @@ function constraint_ohms_yt_from_on_off(pm::GenericPowerModel, branch)
     t_min = pm.ref[:off_angmin]
     t_max = pm.ref[:off_angmax]
 
-    return constraint_ohms_yt_from_on_off(pm, i, f_bus, t_bus, f_idx, t_idx, g, b, c, tr, ti, tm, t_min, t_max)
+    constraint_ohms_yt_from_on_off(pm, i, f_bus, t_bus, f_idx, t_idx, g, b, c, tr, ti, tm, t_min, t_max)
 end
 
 ""
@@ -201,7 +202,7 @@ function constraint_ohms_yt_to_on_off(pm::GenericPowerModel, branch)
     t_min = pm.ref[:off_angmin]
     t_max = pm.ref[:off_angmax]
 
-    return constraint_ohms_yt_to_on_off(pm, i, f_bus, t_bus, f_idx, t_idx, g, b, c, tr, ti, tm, t_min, t_max)
+    constraint_ohms_yt_to_on_off(pm, i, f_bus, t_bus, f_idx, t_idx, g, b, c, tr, ti, tm, t_min, t_max)
 end
 
 ""
@@ -220,7 +221,7 @@ function constraint_ohms_yt_from_ne(pm::GenericPowerModel, branch)
     t_min = pm.ref[:off_angmin]
     t_max = pm.ref[:off_angmax]
 
-    return constraint_ohms_yt_from_ne(pm, i, f_bus, t_bus, f_idx, t_idx, g, b, c, tr, ti, tm, t_min, t_max)
+    constraint_ohms_yt_from_ne(pm, i, f_bus, t_bus, f_idx, t_idx, g, b, c, tr, ti, tm, t_min, t_max)
 end
 
 ""
@@ -239,7 +240,7 @@ function constraint_ohms_yt_to_ne(pm::GenericPowerModel, branch)
     t_min = pm.ref[:off_angmin]
     t_max = pm.ref[:off_angmax]
 
-    return constraint_ohms_yt_to_ne(pm, i, f_bus, t_bus, f_idx, t_idx, g, b, c, tr, ti, tm, t_min, t_max)
+    constraint_ohms_yt_to_ne(pm, i, f_bus, t_bus, f_idx, t_idx, g, b, c, tr, ti, tm, t_min, t_max)
 end
 
 ### Branch - Current ###
@@ -253,7 +254,7 @@ function constraint_power_magnitude_sqr(pm::GenericPowerModel, branch)
 
     tm = branch["tap"]^2
 
-    return constraint_power_magnitude_sqr(pm, f_bus, t_bus, arc_from, tm)
+    constraint_power_magnitude_sqr(pm, f_bus, t_bus, arc_from, tm)
 end
 
 ""
@@ -265,7 +266,7 @@ function constraint_power_magnitude_sqr_on_off(pm::GenericPowerModel, branch)
 
     tm = branch["tap"]^2
 
-    return constraint_power_magnitude_sqr_on_off(pm, i, f_bus, arc_from, tm)
+    constraint_power_magnitude_sqr_on_off(pm, i, f_bus, arc_from, tm)
 end
 
 ""
@@ -280,7 +281,7 @@ function constraint_power_magnitude_link(pm::GenericPowerModel, branch)
     c = branch["br_b"]
     tm = branch["tap"]^2
 
-    return constraint_power_magnitude_link(pm, f_bus, t_bus, arc_from, g, b, c, tr, ti, tm)
+    constraint_power_magnitude_link(pm, f_bus, t_bus, arc_from, g, b, c, tr, ti, tm)
 end
 
 ""
@@ -295,7 +296,7 @@ function constraint_power_magnitude_link_on_off(pm::GenericPowerModel, branch)
     c = branch["br_b"]
     tm = branch["tap"]^2
 
-    return constraint_power_magnitude_link_on_off(pm, i, arc_from, g, b, c, tr, ti, tm)
+    constraint_power_magnitude_link_on_off(pm, i, arc_from, g, b, c, tr, ti, tm)
 end
 
 ### Branch - Thermal Limit Constraints ###
@@ -307,7 +308,7 @@ function constraint_thermal_limit_from(pm::GenericPowerModel, branch; scale = 1.
     t_bus = branch["t_bus"]
     f_idx = (i, f_bus, t_bus)
 
-    return constraint_thermal_limit_from(pm, f_idx, branch["rate_a"]*scale)
+    constraint_thermal_limit_from(pm, f_idx, branch["rate_a"]*scale)
 end
 
 ""
@@ -317,7 +318,7 @@ function constraint_thermal_limit_to(pm::GenericPowerModel, branch; scale = 1.0)
     t_bus = branch["t_bus"]
     t_idx = (i, t_bus, f_bus)
 
-    return constraint_thermal_limit_to(pm, t_idx, branch["rate_a"]*scale)
+    constraint_thermal_limit_to(pm, t_idx, branch["rate_a"]*scale)
 end
 
 ""
@@ -327,7 +328,7 @@ function constraint_thermal_limit_from_on_off(pm::GenericPowerModel, branch)
     t_bus = branch["t_bus"]
     f_idx = (i, f_bus, t_bus)
 
-    return constraint_thermal_limit_from_on_off(pm, i, f_idx, branch["rate_a"])
+    constraint_thermal_limit_from_on_off(pm, i, f_idx, branch["rate_a"])
 end
 
 ""
@@ -337,7 +338,7 @@ function constraint_thermal_limit_to_on_off(pm::GenericPowerModel, branch)
     t_bus = branch["t_bus"]
     t_idx = (i, t_bus, f_bus)
 
-    return constraint_thermal_limit_to_on_off(pm, i, t_idx, branch["rate_a"])
+    constraint_thermal_limit_to_on_off(pm, i, t_idx, branch["rate_a"])
 end
 
 ""
@@ -347,7 +348,7 @@ function constraint_thermal_limit_from_ne(pm::GenericPowerModel, branch)
     t_bus = branch["t_bus"]
     f_idx = (i, f_bus, t_bus)
 
-    return constraint_thermal_limit_from_ne(pm, i, f_idx, branch["rate_a"])
+    constraint_thermal_limit_from_ne(pm, i, f_idx, branch["rate_a"])
 end
 
 ""
@@ -357,7 +358,7 @@ function constraint_thermal_limit_to_ne(pm::GenericPowerModel, branch)
     t_bus = branch["t_bus"]
     t_idx = (i, t_bus, f_bus)
 
-    return constraint_thermal_limit_to_ne(pm, i, t_idx, branch["rate_a"])
+    constraint_thermal_limit_to_ne(pm, i, t_idx, branch["rate_a"])
 end
 
 ### Branch - Phase Angle Difference Constraints ###
@@ -371,9 +372,8 @@ function constraint_phase_angle_difference(pm::GenericPowerModel, branch)
     buspair = pm.ref[:buspairs][pair]
 
     if buspair["line"] == i
-        return constraint_phase_angle_difference(pm, f_bus, t_bus, buspair["angmin"], buspair["angmax"])
+        constraint_phase_angle_difference(pm, f_bus, t_bus, buspair["angmin"], buspair["angmax"])
     end
-    return Set()
 end
 
 ""
@@ -385,7 +385,7 @@ function constraint_phase_angle_difference_on_off(pm::GenericPowerModel, branch)
     t_min = pm.ref[:off_angmin]
     t_max = pm.ref[:off_angmax]
 
-    return constraint_phase_angle_difference_on_off(pm, i, f_bus, t_bus, branch["angmin"], branch["angmax"], t_min, t_max)
+    constraint_phase_angle_difference_on_off(pm, i, f_bus, t_bus, branch["angmin"], branch["angmax"], t_min, t_max)
 end
 
 ""
@@ -397,7 +397,7 @@ function constraint_phase_angle_difference_ne(pm::GenericPowerModel, branch)
     t_min = pm.ref[:off_angmin]
     t_max = pm.ref[:off_angmax]
 
-    return constraint_phase_angle_difference_ne(pm, i, f_bus, t_bus, branch["angmin"], branch["angmax"], t_min, t_max)
+    constraint_phase_angle_difference_ne(pm, i, f_bus, t_bus, branch["angmin"], branch["angmax"], t_min, t_max)
 end
 
 ### Branch - Loss Constraints ###
@@ -415,5 +415,5 @@ function constraint_loss_lb(pm::GenericPowerModel, branch)
     c = branch["br_b"]
     tr = branch["tr"]
 
-    return constraint_loss_lb(pm, f_bus, t_bus, f_idx, t_idx, c, tr)
+    constraint_loss_lb(pm, f_bus, t_bus, f_idx, t_idx, c, tr)
 end

--- a/src/core/relaxation_scheme.jl
+++ b/src/core/relaxation_scheme.jl
@@ -1,7 +1,6 @@
 "constraint: `c^2 + d^2 <= a*b`"
 function relaxation_complex_product(m, a, b, c, d)
-    c = @constraint(m, c^2 + d^2 <= a*b)
-    return Set([c])
+    @constraint(m, c^2 + d^2 <= a*b)
 end
 
 "In the literature this constraints are called the Lifted Nonlinear Cuts (LNCs)"
@@ -23,10 +22,8 @@ function cut_complex_product_and_angle_difference(m, wf, wt, wr, wi, angmin, ang
     sf = vflb + vfub
     st = vtlb + vtub
 
-    c1 = @constraint(m, sf*st*(cos(phi)*wr + sin(phi)*wi) - vtub*cos(d)*st*wf - vfub*cos(d)*sf*wt >=  vfub*vtub*cos(d)*(vflb*vtlb - vfub*vtub))
-    c2 = @constraint(m, sf*st*(cos(phi)*wr + sin(phi)*wi) - vtlb*cos(d)*st*wf - vflb*cos(d)*sf*wt >= -vflb*vtlb*cos(d)*(vflb*vtlb - vfub*vtub))
-
-    return Set([c1, c2])
+    @constraint(m, sf*st*(cos(phi)*wr + sin(phi)*wi) - vtub*cos(d)*st*wf - vfub*cos(d)*sf*wt >=  vfub*vtub*cos(d)*(vflb*vtlb - vfub*vtub))
+    @constraint(m, sf*st*(cos(phi)*wr + sin(phi)*wi) - vtlb*cos(d)*st*wf - vflb*cos(d)*sf*wt >= -vflb*vtlb*cos(d)*(vflb*vtlb - vfub*vtub))
 end
 
 """
@@ -46,10 +43,9 @@ function relaxation_complex_product_on_off(m, a, b, c, d, z)
     b_ub = getupperbound(b)
     z_ub = getupperbound(z)
 
-    c1 = @constraint(m, c^2 + d^2 <= a*b*z_ub)
-    c2 = @constraint(m, c^2 + d^2 <= a_ub*b*z)
-    c3 = @constraint(m, c^2 + d^2 <= a*b_ub*z)
-    return Set([c1, c2, c3])
+    @constraint(m, c^2 + d^2 <= a*b*z_ub)
+    @constraint(m, c^2 + d^2 <= a_ub*b*z)
+    @constraint(m, c^2 + d^2 <= a*b_ub*z)
 end
 
 "`x - getupperbound(x)*(1-z) <= y <= x - getlowerbound(x)*(1-z)`"
@@ -59,10 +55,8 @@ function relaxation_equality_on_off(m, x, y, z)
     x_ub = getupperbound(x)
     x_lb = getlowerbound(x)
 
-    c1 = @constraint(m, y >= x - x_ub*(1-z))
-    c2 = @constraint(m, y <= x - x_lb*(1-z))
-
-    return Set([c1, c2])
+    @constraint(m, y >= x - x_ub*(1-z))
+    @constraint(m, y <= x - x_lb*(1-z))
 end
 
 """
@@ -73,9 +67,8 @@ x^2 <= y <= (getupperbound(x)+getlowerbound(x))*x - getupperbound(x)*getlowerbou
 ```
 """
 function relaxation_sqr(m, x, y)
-    c1 = @constraint(m, y >= x^2)
-    c2 = @constraint(m, y <= (getupperbound(x)+getlowerbound(x))*x - getupperbound(x)*getlowerbound(x))
-    return Set([c1, c2])
+    @constraint(m, y >= x^2)
+    @constraint(m, y <= (getupperbound(x)+getlowerbound(x))*x - getupperbound(x)*getlowerbound(x))
 end
 
 "general relaxation of a sine term, in -pi/2 to pi/2"
@@ -87,18 +80,17 @@ function relaxation_sin(m, x, y)
     max_ad = max(abs(lb),abs(ub))
 
     if lb < 0 && ub > 0
-        c1 = @constraint(m, y <= cos(max_ad/2)*(x - max_ad/2) + sin(max_ad/2))
-        c2 = @constraint(m, y >= cos(max_ad/2)*(x + max_ad/2) - sin(max_ad/2))
+        @constraint(m, y <= cos(max_ad/2)*(x - max_ad/2) + sin(max_ad/2))
+        @constraint(m, y >= cos(max_ad/2)*(x + max_ad/2) - sin(max_ad/2))
     end
     if ub <= 0
-        c1 = @constraint(m, y <= (sin(lb) - sin(ub))/(lb-ub)*(x - lb) + sin(lb))
-        c2 = @constraint(m, y >= cos(max_ad/2)*(x + max_ad/2) - sin(max_ad/2))
+        @constraint(m, y <= (sin(lb) - sin(ub))/(lb-ub)*(x - lb) + sin(lb))
+        @constraint(m, y >= cos(max_ad/2)*(x + max_ad/2) - sin(max_ad/2))
     end
     if lb >= 0
-        c1 = @constraint(m, y <= cos(max_ad/2)*(x - max_ad/2) + sin(max_ad/2))
-        c2 = @constraint(m, y >= (sin(lb) - sin(ub))/(lb-ub)*(x - lb) + sin(lb))
+        @constraint(m, y <= cos(max_ad/2)*(x - max_ad/2) + sin(max_ad/2))
+        @constraint(m, y >= (sin(lb) - sin(ub))/(lb-ub)*(x - lb) + sin(lb))
     end
-    return Set([c1, c2])
 end
 
 
@@ -110,9 +102,8 @@ function relaxation_cos(m, x, y)
 
     max_ad = max(abs(lb),abs(ub))
 
-    c1 = @constraint(m, y <= 1 - (1-cos(max_ad))/(max_ad*max_ad)*(x^2))
-    c2 = @constraint(m, y >= (cos(lb) - cos(ub))/(lb-ub)*(x - lb) + cos(lb))
-    return Set([c1, c2])
+    @constraint(m, y <= 1 - (1-cos(max_ad))/(max_ad*max_ad)*(x^2))
+    @constraint(m, y >= (cos(lb) - cos(ub))/(lb-ub)*(x - lb) + cos(lb))
 end
 
 
@@ -124,19 +115,17 @@ function relaxation_sin_on_off(m, x, y, z, M_x)
 
     max_ad = max(abs(lb),abs(ub))
 
-    c1 = @constraint(m, y <= z*sin(ub))
-    c2 = @constraint(m, y >= z*sin(lb))
+    @constraint(m, y <= z*sin(ub))
+    @constraint(m, y >= z*sin(lb))
 
-    c3 = @constraint(m,  y - cos(max_ad/2)*(x) <= z*(sin(max_ad/2) - cos(max_ad/2)*max_ad/2) + (1-z)*(cos(max_ad/2)*M_x))
-    c4 = @constraint(m, -y + cos(max_ad/2)*(x) <= z*(sin(max_ad/2) + cos(max_ad/2)*max_ad/2) + (1-z)*(cos(max_ad/2)*M_x))
+    @constraint(m,  y - cos(max_ad/2)*(x) <= z*(sin(max_ad/2) - cos(max_ad/2)*max_ad/2) + (1-z)*(cos(max_ad/2)*M_x))
+    @constraint(m, -y + cos(max_ad/2)*(x) <= z*(sin(max_ad/2) + cos(max_ad/2)*max_ad/2) + (1-z)*(cos(max_ad/2)*M_x))
 
-    c5 = @constraint(m, y <= z*(sin(max_ad/2) + cos(max_ad/2)*max_ad/2))
-    c6 = @constraint(m, -y <= z*(sin(max_ad/2) + cos(max_ad/2)*max_ad/2))
+    @constraint(m, y <= z*(sin(max_ad/2) + cos(max_ad/2)*max_ad/2))
+    @constraint(m, -y <= z*(sin(max_ad/2) + cos(max_ad/2)*max_ad/2))
 
-    c7 = @constraint(m, cos(max_ad/2)*x <= z*(sin(max_ad/2) - cos(max_ad/2)*max_ad/2 + sin(max_ad)) + (1-z)*(cos(max_ad/2)*M_x))
-    c8 = @constraint(m, -cos(max_ad/2)*x <= z*(sin(max_ad/2) - cos(max_ad/2)*max_ad/2 + sin(max_ad)) + (1-z)*(cos(max_ad/2)*M_x))
-
-    return Set([c1, c2, c3, c4, c5, c6, c7, c8])
+    @constraint(m, cos(max_ad/2)*x <= z*(sin(max_ad/2) - cos(max_ad/2)*max_ad/2 + sin(max_ad)) + (1-z)*(cos(max_ad/2)*M_x))
+    @constraint(m, -cos(max_ad/2)*x <= z*(sin(max_ad/2) - cos(max_ad/2)*max_ad/2 + sin(max_ad)) + (1-z)*(cos(max_ad/2)*M_x))
 end
 
 
@@ -148,14 +137,12 @@ function relaxation_cos_on_off(m, x, y, z, M_x)
 
     max_ad = max(abs(lb),abs(ub))
 
-    c1 = @constraint(m, y <= z)
-    c2 = @constraint(m, y >= z*cos(max_ad))
+    @constraint(m, y <= z)
+    @constraint(m, y >= z*cos(max_ad))
     # can this be integrated?
-    #c2 = @constraint(m, y >= (cos(lb) - cos(ub))/(lb-ub)*(x - lb) + cos(lb))
+    #@constraint(m, y >= (cos(lb) - cos(ub))/(lb-ub)*(x - lb) + cos(lb))
 
-    c3 = @constraint(m, y <= z - (1-cos(max_ad))/(max_ad^2)*(x^2) + (1-z)*((1-cos(max_ad))/(max_ad^2)*(M_x^2)))
-
-    return Set([c1, c2, c3])
+    @constraint(m, y <= z - (1-cos(max_ad))/(max_ad^2)*(x^2) + (1-z)*((1-cos(max_ad))/(max_ad^2)*(M_x^2)))
 end
 
 
@@ -175,12 +162,10 @@ function relaxation_product(m, x, y, z)
     y_ub = getupperbound(y)
     y_lb = getlowerbound(y)
 
-    c1 = @constraint(m, z >= x_lb*y + y_lb*x - x_lb*y_lb)
-    c2 = @constraint(m, z >= x_ub*y + y_ub*x - x_ub*y_ub)
-    c3 = @constraint(m, z <= x_lb*y + y_ub*x - x_lb*y_ub)
-    c4 = @constraint(m, z <= x_ub*y + y_lb*x - x_ub*y_lb)
-
-    return Set([c1, c2, c3, c4])
+    @constraint(m, z >= x_lb*y + y_lb*x - x_lb*y_lb)
+    @constraint(m, z >= x_ub*y + y_ub*x - x_ub*y_ub)
+    @constraint(m, z <= x_lb*y + y_ub*x - x_lb*y_ub)
+    @constraint(m, z <= x_ub*y + y_lb*x - x_ub*y_lb)
 end
 
 
@@ -194,10 +179,8 @@ function relaxation_product_on_off(m, x, y, z, ind)
     y_ub = getupperbound(y)
     y_lb = getlowerbound(y)
 
-    c1 = @constraint(m, z >= x_lb*y + y_lb*x - ind*x_lb*y_lb)
-    c2 = @constraint(m, z >= x_ub*y + y_ub*x - ind*x_ub*y_ub)
-    c3 = @constraint(m, z <= x_lb*y + y_ub*x - ind*x_lb*y_ub)
-    c4 = @constraint(m, z <= x_ub*y + y_lb*x - ind*x_ub*y_lb)
-
-    return Set([c1, c2, c3, c4])
+    @constraint(m, z >= x_lb*y + y_lb*x - ind*x_lb*y_lb)
+    @constraint(m, z >= x_ub*y + y_ub*x - ind*x_ub*y_ub)
+    @constraint(m, z <= x_lb*y + y_ub*x - ind*x_lb*y_ub)
+    @constraint(m, z <= x_ub*y + y_lb*x - ind*x_ub*y_lb)
 end

--- a/src/core/variable.jl
+++ b/src/core/variable.jl
@@ -15,7 +15,6 @@ function variable_phase_angle(pm::GenericPowerModel; bounded::Bool = true)
         [i in keys(pm.ref[:bus])], basename="t",
         start = getstart(pm.ref[:bus], i, "t_start")
     )
-    return pm.var[:t]
 end
 
 "variable: `v[i]` for `i` in `bus`es"
@@ -33,7 +32,6 @@ function variable_voltage_magnitude(pm::GenericPowerModel; bounded = true)
             lowerbound = 0,
             start = getstart(pm.ref[:bus], i, "v_start", 1.0))
     end
-    return pm.var[:v]
 end
 
 
@@ -45,7 +43,6 @@ function variable_voltage_real(pm::GenericPowerModel; bounded::Bool = true)
         upperbound =  pm.ref[:bus][i]["vmax"], 
         start = getstart(pm.ref[:bus], i, "vr_start", 1.0)
     )
-    return pm.var[:vr]
 end
 
 "real part of the voltage variable `i` in `bus`es"
@@ -56,7 +53,6 @@ function variable_voltage_imaginary(pm::GenericPowerModel; bounded::Bool = true)
         upperbound =  pm.ref[:bus][i]["vmax"],
         start = getstart(pm.ref[:bus], i, "vi_start")
     )
-    return pm.var[:vi]
 end
 
 
@@ -72,8 +68,6 @@ function variable_voltage_magnitude_from_on_off(pm::GenericPowerModel)
         upperbound = buses[branches[i]["f_bus"]]["vmax"],
         start = getstart(pm.ref[:bus], i, "v_from_start", 1.0)
     )
-
-    return pm.var[:v_from]
 end
 
 "variable: `0 <= v_to[l] <= buses[branches[l][\"t_bus\"]][\"vmax\"]` for `l` in `branch`es"
@@ -87,8 +81,6 @@ function variable_voltage_magnitude_to_on_off(pm::GenericPowerModel)
         upperbound = buses[branches[i]["t_bus"]]["vmax"],
         start = getstart(pm.ref[:bus], i, "v_to_start", 1.0)
     )
-
-    return pm.var[:v_to]
 end
 
 
@@ -108,7 +100,6 @@ function variable_voltage_magnitude_sqr(pm::GenericPowerModel; bounded = true)
             start = getstart(pm.ref[:bus], i, "w_start", 1.001)
         )
     end
-    return pm.var[:w]
 end
 
 "variable: `0 <= w_from[l] <= buses[branches[l][\"f_bus\"]][\"vmax\"]^2` for `l` in `branch`es"
@@ -122,8 +113,6 @@ function variable_voltage_magnitude_sqr_from_on_off(pm::GenericPowerModel)
         upperbound = buses[branches[i]["f_bus"]]["vmax"]^2,
         start = getstart(pm.ref[:bus], i, "w_from_start", 1.001)
     )
-
-    return pm.var[:w_from]
 end
 
 "variable: `0 <= w_to[l] <= buses[branches[l][\"t_bus\"]][\"vmax\"]^2` for `l` in `branch`es"
@@ -137,8 +126,6 @@ function variable_voltage_magnitude_sqr_to_on_off(pm::GenericPowerModel)
         upperbound = buses[branches[i]["t_bus"]]["vmax"]^2,
         start = getstart(pm.ref[:bus], i, "w_to_start", 1.001)
     )
-
-    return pm.var[:w_to]
 end
 
 
@@ -169,7 +156,6 @@ function variable_voltage_product(pm::GenericPowerModel; bounded = true)
             start = getstart(pm.ref[:buspairs], bp, "wi_start")
         )
     end
-    return pm.var[:wr], pm.var[:wi]
 end
 
 ""
@@ -189,8 +175,6 @@ function variable_voltage_product_on_off(pm::GenericPowerModel)
         upperbound = max(0, wi_max[bi_bp[b]]),
         start = getstart(pm.ref[:buspairs], bi_bp[b], "wi_start")
     )
-
-    return pm.var[:wr], pm.var[:wi]
 end
 
 
@@ -216,7 +200,6 @@ function variable_active_generation(pm::GenericPowerModel; bounded = true)
             start = getstart(pm.ref[:gen], i, "pg_start")
         )
     end
-    return pm.var[:pg]
 end
 
 "variable: `qq[j]` for `j` in `gen`"
@@ -234,7 +217,6 @@ function variable_reactive_generation(pm::GenericPowerModel; bounded = true)
             start = getstart(pm.ref[:gen], i, "qg_start")
         )
     end
-    return pm.var[:qg]
 end
 
 ""
@@ -259,7 +241,6 @@ function variable_active_line_flow(pm::GenericPowerModel; bounded = true)
             start = getstart(pm.ref[:branch], l, "p_start")
         )
     end
-    return pm.var[:p]
 end
 
 "variable: `q[l,i,j]` for `(l,i,j)` in `arcs`"
@@ -277,7 +258,6 @@ function variable_reactive_line_flow(pm::GenericPowerModel; bounded = true)
             start = getstart(pm.ref[:branch], l, "q_start")
         )
     end
-    return pm.var[:q]
 end
 
 function variable_dcline_flow(pm::GenericPowerModel; kwargs...)
@@ -315,7 +295,6 @@ function variable_active_dcline_flow(pm::GenericPowerModel; bounded = true)
             start = pref[(l,i,j)]
         )
     end
-    return pm.var[:p_dc]
 end
 
 "variable: `q_dc[l,i,j]` for `(l,i,j)` in `arcs_dc`"
@@ -348,7 +327,6 @@ function variable_reactive_dcline_flow(pm::GenericPowerModel; bounded = true)
             start = qref[(l,i,j)]
         )
     end
-    return pm.var[:q_dc]
 end
 
 ##################################################################
@@ -367,7 +345,6 @@ function variable_active_line_flow_ne(pm::GenericPowerModel)
         upperbound =  pm.ref[:ne_branch][l]["rate_a"], 
         start = getstart(pm.ref[:ne_branch], l, "p_start")
     )
-    return pm.var[:p_ne]
 end
 
 "variable: `-ne_branch[l][\"rate_a\"] <= q_ne[l,i,j] <= ne_branch[l][\"rate_a\"]` for `(l,i,j)` in `ne_arcs`"
@@ -378,7 +355,6 @@ function variable_reactive_line_flow_ne(pm::GenericPowerModel)
         upperbound =  pm.ref[:ne_branch][l]["rate_a"],
         start = getstart(pm.ref[:ne_branch], l, "q_start")
     )
-    return pm.var[:q_ne]
 end
 
 "variable: `0 <= line_z[l] <= 1` for `l` in `branch`es"
@@ -390,7 +366,6 @@ function variable_line_indicator(pm::GenericPowerModel)
         category = :Int,
         start = getstart(pm.ref[:branch], l, "line_z_start", 1.0)
     )
-    return pm.var[:line_z]
 end
 
 "variable: `0 <= line_ne[l] <= 1` for `l` in `branch`es"
@@ -403,5 +378,4 @@ function variable_line_ne(pm::GenericPowerModel)
         category = :Int,
         start = getstart(branches, l, "line_tnep_start", 1.0)
     )
-    return pm.var[:line_ne]
 end

--- a/src/form/acp.jl
+++ b/src/form/acp.jl
@@ -24,25 +24,26 @@ function variable_voltage{T <: AbstractACPForm}(pm::GenericPowerModel{T}; kwargs
 end
 
 ""
-variable_voltage_ne{T <: AbstractACPForm}(pm::GenericPowerModel{T}; kwargs...) = nothing
+function variable_voltage_ne{T <: AbstractACPForm}(pm::GenericPowerModel{T}; kwargs...)
+end
 
 "do nothing, this model does not have complex voltage constraints"
-constraint_voltage{T <: AbstractACPForm}(pm::GenericPowerModel{T}) = Set()
+function constraint_voltage{T <: AbstractACPForm}(pm::GenericPowerModel{T})
+end
 
 "do nothing, this model does not have complex voltage constraints"
-constraint_voltage_ne{T <: AbstractACPForm}(pm::GenericPowerModel{T}) = nothing
+function constraint_voltage_ne{T <: AbstractACPForm}(pm::GenericPowerModel{T})
+end
 
 "`vm - epsilon <= v[i] <= vm + epsilon`"
 function constraint_voltage_magnitude_setpoint{T <: AbstractACPForm}(pm::GenericPowerModel{T}, i, vm, epsilon)
     v = pm.var[:v][i]
 
     if epsilon == 0.0
-        c = @constraint(pm.model, v == vm)
-        return Set([c])
+        @constraint(pm.model, v == vm)
     else
-        c1 = @constraint(pm.model, v <= vm + epsilon)
-        c2 = @constraint(pm.model, v >= vm - epsilon)
-        return Set([c1, c2])
+        @constraint(pm.model, v <= vm + epsilon)
+        @constraint(pm.model, v >= vm - epsilon)
     end
 end
 
@@ -57,15 +58,13 @@ function constraint_voltage_dcline_setpoint{T <: AbstractACPForm}(pm::GenericPow
     v_t = pm.var[:v][t_bus]
 
     if epsilon == 0.0
-        c1 = @constraint(pm.model, v_f == vf)
-        c2 = @constraint(pm.model, v_t == vt)
-        return Set([c1, c2])
+        @constraint(pm.model, v_f == vf)
+        @constraint(pm.model, v_t == vt)
     else
-        c1 = @constraint(pm.model, v_f <= vf + epsilon)
-        c2 = @constraint(pm.model, v_f >= vf - epsilon)
-        c3 = @constraint(pm.model, v_t <= vt + epsilon)
-        c4 = @constraint(pm.model, v_t >= vt - epsilon)
-        return Set([c1, c2, c3, c4])
+        @constraint(pm.model, v_f <= vf + epsilon)
+        @constraint(pm.model, v_f >= vf - epsilon)
+        @constraint(pm.model, v_t <= vt + epsilon)
+        @constraint(pm.model, v_t >= vt - epsilon)
     end
 end
 
@@ -84,9 +83,8 @@ function constraint_kcl_shunt{T <: AbstractACPForm}(pm::GenericPowerModel{T}, i,
     p_dc = pm.var[:p_dc]
     q_dc = pm.var[:q_dc]
 
-    c1 = @constraint(pm.model, sum(p[a] for a in bus_arcs) + sum(p_dc[a_dc] for a_dc in bus_arcs_dc) == sum(pg[g] for g in bus_gens) - pd - gs*v^2)
-    c2 = @constraint(pm.model, sum(q[a] for a in bus_arcs) + sum(q_dc[a_dc] for a_dc in bus_arcs_dc) == sum(qg[g] for g in bus_gens) - qd + bs*v^2)
-    return Set([c1, c2])
+    @constraint(pm.model, sum(p[a] for a in bus_arcs) + sum(p_dc[a_dc] for a_dc in bus_arcs_dc) == sum(pg[g] for g in bus_gens) - pd - gs*v^2)
+    @constraint(pm.model, sum(q[a] for a in bus_arcs) + sum(q_dc[a_dc] for a_dc in bus_arcs_dc) == sum(qg[g] for g in bus_gens) - qd + bs*v^2)
 end
 
 """
@@ -106,9 +104,8 @@ function constraint_kcl_shunt_ne{T <: AbstractACPForm}(pm::GenericPowerModel{T},
     p_dc = pm.var[:p_dc]
     q_dc = pm.var[:q_dc]
 
-    c1 = @constraint(pm.model, sum(p[a] for a in bus_arcs) + sum(p_dc[a_dc] for a_dc in bus_arcs_dc)  + sum(p_ne[a] for a in bus_arcs_ne) == sum(pg[g] for g in bus_gens) - pd - gs*v^2)
-    c2 = @constraint(pm.model, sum(q[a] for a in bus_arcs) + sum(q_dc[a_dc] for a_dc in bus_arcs_dc)  + sum(q_ne[a] for a in bus_arcs_ne) == sum(qg[g] for g in bus_gens) - qd + bs*v^2)
-    return Set([c1, c2])
+    @constraint(pm.model, sum(p[a] for a in bus_arcs) + sum(p_dc[a_dc] for a_dc in bus_arcs_dc)  + sum(p_ne[a] for a in bus_arcs_ne) == sum(pg[g] for g in bus_gens) - pd - gs*v^2)
+    @constraint(pm.model, sum(q[a] for a in bus_arcs) + sum(q_dc[a_dc] for a_dc in bus_arcs_dc)  + sum(q_ne[a] for a in bus_arcs_ne) == sum(qg[g] for g in bus_gens) - qd + bs*v^2)
 end
 
 """
@@ -127,9 +124,8 @@ function constraint_ohms_yt_from{T <: AbstractACPForm}(pm::GenericPowerModel{T},
     t_fr = pm.var[:t][f_bus]
     t_to = pm.var[:t][t_bus]
 
-    c1 = @NLconstraint(pm.model, p_fr == g/tm*v_fr^2 + (-g*tr+b*ti)/tm*(v_fr*v_to*cos(t_fr-t_to)) + (-b*tr-g*ti)/tm*(v_fr*v_to*sin(t_fr-t_to)) )
-    c2 = @NLconstraint(pm.model, q_fr == -(b+c/2)/tm*v_fr^2 - (-b*tr-g*ti)/tm*(v_fr*v_to*cos(t_fr-t_to)) + (-g*tr+b*ti)/tm*(v_fr*v_to*sin(t_fr-t_to)) )
-    return Set([c1, c2])
+    @NLconstraint(pm.model, p_fr == g/tm*v_fr^2 + (-g*tr+b*ti)/tm*(v_fr*v_to*cos(t_fr-t_to)) + (-b*tr-g*ti)/tm*(v_fr*v_to*sin(t_fr-t_to)) )
+    @NLconstraint(pm.model, q_fr == -(b+c/2)/tm*v_fr^2 - (-b*tr-g*ti)/tm*(v_fr*v_to*cos(t_fr-t_to)) + (-g*tr+b*ti)/tm*(v_fr*v_to*sin(t_fr-t_to)) )
 end
 
 """
@@ -148,9 +144,8 @@ function constraint_ohms_yt_to{T <: AbstractACPForm}(pm::GenericPowerModel{T}, f
     t_fr = pm.var[:t][f_bus]
     t_to = pm.var[:t][t_bus]
 
-    c1 = @NLconstraint(pm.model, p_to == g*v_to^2 + (-g*tr-b*ti)/tm*(v_to*v_fr*cos(t_to-t_fr)) + (-b*tr+g*ti)/tm*(v_to*v_fr*sin(t_to-t_fr)) )
-    c2 = @NLconstraint(pm.model, q_to == -(b+c/2)*v_to^2 - (-b*tr+g*ti)/tm*(v_to*v_fr*cos(t_to-t_fr)) + (-g*tr-b*ti)/tm*(v_to*v_fr*sin(t_to-t_fr)) )
-    return Set([c1, c2])
+    @NLconstraint(pm.model, p_to == g*v_to^2 + (-g*tr-b*ti)/tm*(v_to*v_fr*cos(t_to-t_fr)) + (-b*tr+g*ti)/tm*(v_to*v_fr*sin(t_to-t_fr)) )
+    @NLconstraint(pm.model, q_to == -(b+c/2)*v_to^2 - (-b*tr+g*ti)/tm*(v_to*v_fr*cos(t_to-t_fr)) + (-g*tr-b*ti)/tm*(v_to*v_fr*sin(t_to-t_fr)) )
 end
 
 """
@@ -169,9 +164,8 @@ function constraint_ohms_y_from{T <: AbstractACPForm}(pm::GenericPowerModel{T}, 
     t_fr = pm.var[:t][f_bus]
     t_to = pm.var[:t][t_bus]
 
-    c1 = @NLconstraint(pm.model, p_fr == g*(v_fr/tr)^2 + -g*v_fr/tr*v_to*cos(t_fr-t_to-as) + -b*v_fr/tr*v_to*sin(t_fr-t_to-as) )
-    c2 = @NLconstraint(pm.model, q_fr == -(b+c/2)*(v_fr/tr)^2 + b*v_fr/tr*v_to*cos(t_fr-t_to-as) + -g*v_fr/tr*v_to*sin(t_fr-t_to-as) )
-    return Set([c1, c2])
+    @NLconstraint(pm.model, p_fr == g*(v_fr/tr)^2 + -g*v_fr/tr*v_to*cos(t_fr-t_to-as) + -b*v_fr/tr*v_to*sin(t_fr-t_to-as) )
+    @NLconstraint(pm.model, q_fr == -(b+c/2)*(v_fr/tr)^2 + b*v_fr/tr*v_to*cos(t_fr-t_to-as) + -g*v_fr/tr*v_to*sin(t_fr-t_to-as) )
 end
 
 """
@@ -190,9 +184,8 @@ function constraint_ohms_y_to{T <: AbstractACPForm}(pm::GenericPowerModel{T}, f_
     t_fr = pm.var[:t][f_bus]
     t_to = pm.var[:t][t_bus]
 
-    c1 = @NLconstraint(pm.model, p_to == g*v_to^2 + -g*v_to*v_fr/tr*cos(t_to-t_fr+as) + -b*v_to*v_fr/tr*sin(t_to-t_fr+as) )
-    c2 = @NLconstraint(pm.model, q_to == -(b+c/2)*v_to^2 + b*v_to*v_fr/tr*cos(t_to-t_fr+as) + -g*v_to*v_fr/tr*sin(t_to-t_fr+as) )
-    return Set([c1, c2])
+    @NLconstraint(pm.model, p_to == g*v_to^2 + -g*v_to*v_fr/tr*cos(t_to-t_fr+as) + -b*v_to*v_fr/tr*sin(t_to-t_fr+as) )
+    @NLconstraint(pm.model, q_to == -(b+c/2)*v_to^2 + b*v_to*v_fr/tr*cos(t_to-t_fr+as) + -g*v_to*v_fr/tr*sin(t_to-t_fr+as) )
 end
 
 
@@ -220,9 +213,8 @@ function constraint_ohms_yt_from_on_off{T <: AbstractACPForm}(pm::GenericPowerMo
     t_to = pm.var[:t][t_bus]
     z = pm.var[:line_z][i]
 
-    c1 = @NLconstraint(pm.model, p_fr == z*(g/tm*v_fr^2 + (-g*tr+b*ti)/tm*(v_fr*v_to*cos(t_fr-t_to)) + (-b*tr-g*ti)/tm*(v_fr*v_to*sin(t_fr-t_to))) )
-    c2 = @NLconstraint(pm.model, q_fr == z*(-(b+c/2)/tm*v_fr^2 - (-b*tr-g*ti)/tm*(v_fr*v_to*cos(t_fr-t_to)) + (-g*tr+b*ti)/tm*(v_fr*v_to*sin(t_fr-t_to))) )
-    return Set([c1, c2])
+    @NLconstraint(pm.model, p_fr == z*(g/tm*v_fr^2 + (-g*tr+b*ti)/tm*(v_fr*v_to*cos(t_fr-t_to)) + (-b*tr-g*ti)/tm*(v_fr*v_to*sin(t_fr-t_to))) )
+    @NLconstraint(pm.model, q_fr == z*(-(b+c/2)/tm*v_fr^2 - (-b*tr-g*ti)/tm*(v_fr*v_to*cos(t_fr-t_to)) + (-g*tr+b*ti)/tm*(v_fr*v_to*sin(t_fr-t_to))) )
 end
 
 """
@@ -240,9 +232,8 @@ function constraint_ohms_yt_to_on_off{T <: AbstractACPForm}(pm::GenericPowerMode
     t_to = pm.var[:t][t_bus]
     z = pm.var[:line_z][i]
 
-    c1 = @NLconstraint(pm.model, p_to == z*(g*v_to^2 + (-g*tr-b*ti)/tm*(v_to*v_fr*cos(t_to-t_fr)) + (-b*tr+g*ti)/tm*(v_to*v_fr*sin(t_to-t_fr))) )
-    c2 = @NLconstraint(pm.model, q_to == z*(-(b+c/2)*v_to^2 - (-b*tr+g*ti)/tm*(v_to*v_fr*cos(t_to-t_fr)) + (-g*tr-b*ti)/tm*(v_to*v_fr*sin(t_to-t_fr))) )
-    return Set([c1, c2])
+    @NLconstraint(pm.model, p_to == z*(g*v_to^2 + (-g*tr-b*ti)/tm*(v_to*v_fr*cos(t_to-t_fr)) + (-b*tr+g*ti)/tm*(v_to*v_fr*sin(t_to-t_fr))) )
+    @NLconstraint(pm.model, q_to == z*(-(b+c/2)*v_to^2 - (-b*tr+g*ti)/tm*(v_to*v_fr*cos(t_to-t_fr)) + (-g*tr-b*ti)/tm*(v_to*v_fr*sin(t_to-t_fr))) )
 end
 
 """
@@ -260,9 +251,8 @@ function constraint_ohms_yt_from_ne{T <: AbstractACPForm}(pm::GenericPowerModel{
     t_to = pm.var[:t][t_bus]
     z = pm.var[:line_ne][i]
 
-    c1 = @NLconstraint(pm.model, p_fr == z*(g/tm*v_fr^2 + (-g*tr+b*ti)/tm*(v_fr*v_to*cos(t_fr-t_to)) + (-b*tr-g*ti)/tm*(v_fr*v_to*sin(t_fr-t_to))) )
-    c2 = @NLconstraint(pm.model, q_fr == z*(-(b+c/2)/tm*v_fr^2 - (-b*tr-g*ti)/tm*(v_fr*v_to*cos(t_fr-t_to)) + (-g*tr+b*ti)/tm*(v_fr*v_to*sin(t_fr-t_to))) )
-    return Set([c1, c2])
+    @NLconstraint(pm.model, p_fr == z*(g/tm*v_fr^2 + (-g*tr+b*ti)/tm*(v_fr*v_to*cos(t_fr-t_to)) + (-b*tr-g*ti)/tm*(v_fr*v_to*sin(t_fr-t_to))) )
+    @NLconstraint(pm.model, q_fr == z*(-(b+c/2)/tm*v_fr^2 - (-b*tr-g*ti)/tm*(v_fr*v_to*cos(t_fr-t_to)) + (-g*tr+b*ti)/tm*(v_fr*v_to*sin(t_fr-t_to))) )
 end
 
 """
@@ -280,9 +270,8 @@ function constraint_ohms_yt_to_ne{T <: AbstractACPForm}(pm::GenericPowerModel{T}
     t_to = pm.var[:t][t_bus]
     z = pm.var[:line_ne][i]
 
-    c1 = @NLconstraint(pm.model, p_to == z*(g*v_to^2 + (-g*tr-b*ti)/tm*(v_to*v_fr*cos(t_to-t_fr)) + (-b*tr+g*ti)/tm*(v_to*v_fr*sin(t_to-t_fr))) )
-    c2 = @NLconstraint(pm.model, q_to == z*(-(b+c/2)*v_to^2 - (-b*tr+g*ti)/tm*(v_to*v_fr*cos(t_to-t_fr)) + (-g*tr-b*ti)/tm*(v_to*v_fr*sin(t_to-t_fr))) )
-    return Set([c1, c2])
+    @NLconstraint(pm.model, p_to == z*(g*v_to^2 + (-g*tr-b*ti)/tm*(v_to*v_fr*cos(t_to-t_fr)) + (-b*tr+g*ti)/tm*(v_to*v_fr*sin(t_to-t_fr))) )
+    @NLconstraint(pm.model, q_to == z*(-(b+c/2)*v_to^2 - (-b*tr+g*ti)/tm*(v_to*v_fr*cos(t_to-t_fr)) + (-g*tr-b*ti)/tm*(v_to*v_fr*sin(t_to-t_fr))) )
 end
 
 "`angmin <= line_z[i]*(t[f_bus] - t[t_bus]) <= angmax`"
@@ -291,9 +280,8 @@ function constraint_phase_angle_difference_on_off{T <: AbstractACPForm}(pm::Gene
     t_to = pm.var[:t][t_bus]
     z = pm.var[:line_z][i]
 
-    c1 = @constraint(pm.model, z*(t_fr - t_to) <= angmax)
-    c2 = @constraint(pm.model, z*(t_fr - t_to) >= angmin)
-    return Set([c1, c2])
+    @constraint(pm.model, z*(t_fr - t_to) <= angmax)
+    @constraint(pm.model, z*(t_fr - t_to) >= angmin)
 end
 
 "`angmin <= line_ne[i]*(t[f_bus] - t[t_bus]) <= angmax`"
@@ -302,9 +290,8 @@ function constraint_phase_angle_difference_ne{T <: AbstractACPForm}(pm::GenericP
     t_to = pm.var[:t][t_bus]
     z = pm.var[:line_ne][i]
 
-    c1 = @constraint(pm.model, z*(t_fr - t_to) <= angmax)
-    c2 = @constraint(pm.model, z*(t_fr - t_to) >= angmin)
-    return Set([c1, c2])
+    @constraint(pm.model, z*(t_fr - t_to) <= angmax)
+    @constraint(pm.model, z*(t_fr - t_to) >= angmin)
 end
 
 """
@@ -321,9 +308,8 @@ function constraint_loss_lb{T <: AbstractACPForm}(pm::GenericPowerModel{T}, f_bu
     p_to = pm.var[:p][t_idx]
     q_to = pm.var[:q][t_idx]
 
-    c1 = @constraint(m, p_fr + p_to >= 0)
-    c2 = @constraint(m, q_fr + q_to >= -c/2*(v_fr^2/tr^2 + v_to^2))
-    return Set([c1, c2])
+    @constraint(m, p_fr + p_to >= 0)
+    @constraint(m, q_fr + q_to >= -c/2*(v_fr^2/tr^2 + v_to^2))
 end
 
 
@@ -345,12 +331,12 @@ function variable_load_factor(pm::GenericPowerModel)
         lowerbound=1.0,
         start = 1.0
     )
-    return pm.var[:load_factor]
 end
 
 "objective: Max. load_factor"
-objective_max_loading(pm::GenericPowerModel) =
+function objective_max_loading(pm::GenericPowerModel)
     @objective(pm.model, Max, pm.var[:load_factor])
+end
 
 ""
 function objective_max_loading_voltage_norm(pm::GenericPowerModel)
@@ -360,7 +346,7 @@ function objective_max_loading_voltage_norm(pm::GenericPowerModel)
     scale = length(pm.ref[:bus])
     v = pm.var[:v]
 
-    return @objective(pm.model, Max, 10*scale*load_factor - sum(((bus["vmin"] + bus["vmax"])/2 - v[i])^2 for (i,bus) in pm.ref[:bus]))
+    @objective(pm.model, Max, 10*scale*load_factor - sum(((bus["vmin"] + bus["vmax"])/2 - v[i])^2 for (i,bus) in pm.ref[:bus]))
 end
 
 ""
@@ -372,7 +358,7 @@ function objective_max_loading_gen_output(pm::GenericPowerModel)
     pg = pm.var[:pg]
     qg = pm.var[:qg]
 
-    return @NLobjective(pm.model, Max, 100*scale*load_factor - sum( (pg[i]^2 - (2*qg[i])^2)^2 for (i,gen) in pm.ref[:gen] ))
+    @NLobjective(pm.model, Max, 100*scale*load_factor - sum( (pg[i]^2 - (2*qg[i])^2)^2 for (i,gen) in pm.ref[:gen] ))
 end
 
 ""
@@ -408,15 +394,13 @@ function constraint_kcl_shunt_scaled(pm::APIACPPowerModel, bus)
     qg = pm.var[:qg]
 
     if bus["pd"] > 0 && bus["qd"] > 0
-        c1 = @constraint(pm.model, sum(p[a] for a in bus_arcs) == sum(pg[g] for g in bus_gens) - bus["pd"]*load_factor - bus["gs"]*v[i]^2)
+        @constraint(pm.model, sum(p[a] for a in bus_arcs) == sum(pg[g] for g in bus_gens) - bus["pd"]*load_factor - bus["gs"]*v[i]^2)
     else
         # super fallback impl
-        c1 = @constraint(pm.model, sum(p[a] for a in bus_arcs) == sum(pg[g] for g in bus_gens) - bus["pd"] - bus["gs"]*v[i]^2)
+        @constraint(pm.model, sum(p[a] for a in bus_arcs) == sum(pg[g] for g in bus_gens) - bus["pd"] - bus["gs"]*v[i]^2)
     end
 
-    c2 = @constraint(pm.model, sum(q[a] for a in bus_arcs) == sum(qg[g] for g in bus_gens) - bus["qd"] + bus["bs"]*v[i]^2)
-
-    return Set([c1, c2])
+    @constraint(pm.model, sum(q[a] for a in bus_arcs) == sum(qg[g] for g in bus_gens) - bus["qd"] + bus["bs"]*v[i]^2)
 end
 
 ""

--- a/src/form/acr.jl
+++ b/src/form/acr.jl
@@ -29,34 +29,27 @@ function constraint_voltage{T <: AbstractACRForm}(pm::GenericPowerModel{T}; kwar
     vr = pm.var[:vr]
     vi = pm.var[:vi]
 
-    cs = Set([])
     for (i,bus) in pm.ref[:bus]
-        c1 = @constraint(pm.model, bus["vmin"]^2 <= (vr[i]^2 + vi[i]^2))
-        c2 = @constraint(pm.model, bus["vmax"]^2 >= (vr[i]^2 + vi[i]^2))
-        push!(cs, Set([c1, c2]))
+        @constraint(pm.model, bus["vmin"]^2 <= (vr[i]^2 + vi[i]^2))
+        @constraint(pm.model, bus["vmax"]^2 >= (vr[i]^2 + vi[i]^2))
     end
 
     # does not seem to improve convergence
     #wr_min, wr_max, wi_min, wi_max = calc_voltage_product_bounds(pm.ref[:buspairs])
     #for bp in keys(pm.ref[:buspairs])
     #    i,j = bp
-    #    c1 = @constraint(pm.model, wr_min[bp] <= vr[i]*vr[j] + vi[i]*vi[j])
-    #    c2 = @constraint(pm.model, wr_max[bp] >= vr[i]*vr[j] + vi[i]*vi[j])
+    #    @constraint(pm.model, wr_min[bp] <= vr[i]*vr[j] + vi[i]*vi[j])
+    #    @constraint(pm.model, wr_max[bp] >= vr[i]*vr[j] + vi[i]*vi[j])
     #
-    #    c3 = @constraint(pm.model, wi_min[bp] <= vi[i]*vr[j] - vr[i]*vi[j])
-    #    c4 = @constraint(pm.model, wi_max[bp] >= vi[i]*vr[j] - vr[i]*vi[j])
-    #
-    #    push!(cs, Set([c1, c2, c3, c4]))
+    #    @constraint(pm.model, wi_min[bp] <= vi[i]*vr[j] - vr[i]*vi[j])
+    #    @constraint(pm.model, wi_max[bp] >= vi[i]*vr[j] - vr[i]*vi[j])
     #end
-
-    return cs
 end
 
 
 "reference bus angle constraint"
 function constraint_theta_ref{T <: AbstractACRForm}(pm::GenericPowerModel{T}, ref_bus::Int)
-    c = @constraint(pm.model, pm.var[:vi][ref_bus] == 0)
-    return Set([c])
+    @constraint(pm.model, pm.var[:vi][ref_bus] == 0)
 end
 
 
@@ -70,9 +63,8 @@ function constraint_kcl_shunt{T <: AbstractACRForm}(pm::GenericPowerModel{T}, i,
     p_dc = pm.var[:p_dc]
     q_dc = pm.var[:q_dc]
 
-    c1 = @constraint(pm.model, sum(p[a] for a in bus_arcs) + sum(p_dc[a_dc] for a_dc in bus_arcs_dc) == sum(pg[g] for g in bus_gens) - pd - gs*(vr^2 + vi^2))
-    c2 = @constraint(pm.model, sum(q[a] for a in bus_arcs) + sum(q_dc[a_dc] for a_dc in bus_arcs_dc) == sum(qg[g] for g in bus_gens) - qd + bs*(vr^2 + vi^2))
-    return Set([c1, c2])
+    @constraint(pm.model, sum(p[a] for a in bus_arcs) + sum(p_dc[a_dc] for a_dc in bus_arcs_dc) == sum(pg[g] for g in bus_gens) - pd - gs*(vr^2 + vi^2))
+    @constraint(pm.model, sum(q[a] for a in bus_arcs) + sum(q_dc[a_dc] for a_dc in bus_arcs_dc) == sum(qg[g] for g in bus_gens) - qd + bs*(vr^2 + vi^2))
 end
 
 
@@ -87,9 +79,8 @@ function constraint_ohms_yt_from{T <: AbstractACRForm}(pm::GenericPowerModel{T},
     vi_fr = pm.var[:vi][f_bus]
     vi_to = pm.var[:vi][t_bus]
 
-    c1 = @NLconstraint(pm.model, p_fr ==        g/tm*(vr_fr^2 + vi_fr^2) + (-g*tr+b*ti)/tm*(vr_fr*vr_to + vi_fr*vi_to) + (-b*tr-g*ti)/tm*(vi_fr*vr_to - vr_fr*vi_to) )
-    c2 = @NLconstraint(pm.model, q_fr == -(b+c/2)/tm*(vr_fr^2 + vi_fr^2) - (-b*tr-g*ti)/tm*(vr_fr*vr_to + vi_fr*vi_to) + (-g*tr+b*ti)/tm*(vi_fr*vr_to - vr_fr*vi_to) )
-    return Set([c1, c2])
+    @NLconstraint(pm.model, p_fr ==        g/tm*(vr_fr^2 + vi_fr^2) + (-g*tr+b*ti)/tm*(vr_fr*vr_to + vi_fr*vi_to) + (-b*tr-g*ti)/tm*(vi_fr*vr_to - vr_fr*vi_to) )
+    @NLconstraint(pm.model, q_fr == -(b+c/2)/tm*(vr_fr^2 + vi_fr^2) - (-b*tr-g*ti)/tm*(vr_fr*vr_to + vi_fr*vi_to) + (-g*tr+b*ti)/tm*(vi_fr*vr_to - vr_fr*vi_to) )
 end
 
 """
@@ -103,9 +94,8 @@ function constraint_ohms_yt_to{T <: AbstractACRForm}(pm::GenericPowerModel{T}, f
     vi_fr = pm.var[:vi][f_bus]
     vi_to = pm.var[:vi][t_bus]
 
-    c1 = @NLconstraint(pm.model, p_to ==        g*(vr_to^2 + vi_to^2) + (-g*tr-b*ti)/tm*(vr_fr*vr_to + vi_fr*vi_to) + (-b*tr+g*ti)/tm*(-(vi_fr*vr_to - vr_fr*vi_to)) )
-    c2 = @NLconstraint(pm.model, q_to == -(b+c/2)*(vr_to^2 + vi_to^2) - (-b*tr+g*ti)/tm*(vr_fr*vr_to + vi_fr*vi_to) + (-g*tr-b*ti)/tm*(-(vi_fr*vr_to - vr_fr*vi_to)) )
-    return Set([c1, c2])
+    @NLconstraint(pm.model, p_to ==        g*(vr_to^2 + vi_to^2) + (-g*tr-b*ti)/tm*(vr_fr*vr_to + vi_fr*vi_to) + (-b*tr+g*ti)/tm*(-(vi_fr*vr_to - vr_fr*vi_to)) )
+    @NLconstraint(pm.model, q_to == -(b+c/2)*(vr_to^2 + vi_to^2) - (-b*tr+g*ti)/tm*(vr_fr*vr_to + vi_fr*vi_to) + (-g*tr-b*ti)/tm*(-(vi_fr*vr_to - vr_fr*vi_to)) )
 end
 
 
@@ -119,13 +109,11 @@ function constraint_phase_angle_difference{T <: AbstractACRForm}(pm::GenericPowe
     vi_to = pm.var[:vi][t_bus]
 
     # this form appears to be more numerically stable than the one below
-    c1 = @NLconstraint(pm.model, (vi_fr*vr_to - vr_fr*vi_to)/(vr_fr*vr_to + vi_fr*vi_to) <= tan(angmax))
-    c2 = @NLconstraint(pm.model, (vi_fr*vr_to - vr_fr*vi_to)/(vr_fr*vr_to + vi_fr*vi_to) >= tan(angmin))
+    @NLconstraint(pm.model, (vi_fr*vr_to - vr_fr*vi_to)/(vr_fr*vr_to + vi_fr*vi_to) <= tan(angmax))
+    @NLconstraint(pm.model, (vi_fr*vr_to - vr_fr*vi_to)/(vr_fr*vr_to + vi_fr*vi_to) >= tan(angmin))
 
-    #c1 = @NLconstraint(pm.model, (vi_fr*vr_to - vr_fr*vi_to) <= tan(angmax)*(vr_fr*vr_to + vi_fr*vi_to))
-    #c2 = @NLconstraint(pm.model, (vi_fr*vr_to - vr_fr*vi_to) >= tan(angmin)*(vr_fr*vr_to + vi_fr*vi_to))
-
-    return Set([c1, c2])
+    #@NLconstraint(pm.model, (vi_fr*vr_to - vr_fr*vi_to) <= tan(angmax)*(vr_fr*vr_to + vi_fr*vi_to))
+    #@NLconstraint(pm.model, (vi_fr*vr_to - vr_fr*vi_to) >= tan(angmin)*(vr_fr*vr_to + vi_fr*vi_to))
 end
 
 

--- a/src/form/dcp.jl
+++ b/src/form/dcp.jl
@@ -16,20 +16,25 @@ DCPPowerModel(data::Dict{String,Any}; kwargs...) =
     GenericPowerModel(data, StandardDCPForm; kwargs...)
 
 ""
-variable_voltage{T <: AbstractDCPForm}(pm::GenericPowerModel{T}; kwargs...) =
+function variable_voltage{T <: AbstractDCPForm}(pm::GenericPowerModel{T}; kwargs...)
     variable_phase_angle(pm; kwargs...)
+end
 
 "nothing to add, there are no voltage variables on branches"
-variable_voltage_ne{T <: AbstractDCPForm}(pm::GenericPowerModel{T}; kwargs...) = Set([])
+function variable_voltage_ne{T <: AbstractDCPForm}(pm::GenericPowerModel{T}; kwargs...)
+end
 
 "dc models ignore reactive power flows"
-variable_reactive_generation{T <: AbstractDCPForm}(pm::GenericPowerModel{T}; bounded = true) = Set()
+function variable_reactive_generation{T <: AbstractDCPForm}(pm::GenericPowerModel{T}; bounded = true)
+end
 
 "dc models ignore reactive power flows"
-variable_reactive_line_flow{T <: AbstractDCPForm}(pm::GenericPowerModel{T}; bounded = true) = Set()
+function variable_reactive_line_flow{T <: AbstractDCPForm}(pm::GenericPowerModel{T}; bounded = true)
+end
 
 "dc models ignore reactive power flows"
-variable_reactive_line_flow_ne{T <: AbstractDCPForm}(pm::GenericPowerModel{T}) = Set([])
+function variable_reactive_line_flow_ne{T <: AbstractDCPForm}(pm::GenericPowerModel{T})
+end
 
 
 ""
@@ -52,8 +57,6 @@ function variable_active_line_flow{T <: StandardDCPForm}(pm::GenericPowerModel{T
     p_expr = Dict{Any,Any}([((l,i,j), pm.var[:p][(l,i,j)]) for (l,i,j) in pm.ref[:arcs_from]])
     p_expr = merge(p_expr, Dict([((l,j,i), -1.0*pm.var[:p][(l,i,j)]) for (l,i,j) in pm.ref[:arcs_from]]))
     pm.var[:p] = p_expr
-
-    return pm.var[:p]
 end
 
 ""
@@ -69,24 +72,27 @@ function variable_active_line_flow_ne{T <: StandardDCPForm}(pm::GenericPowerMode
     p_ne_expr = Dict{Any,Any}([((l,i,j), 1.0*pm.var[:p_ne][(l,i,j)]) for (l,i,j) in pm.ref[:ne_arcs_from]])
     p_ne_expr = merge(p_ne_expr, Dict([((l,j,i), -1.0*pm.var[:p_ne][(l,i,j)]) for (l,i,j) in pm.ref[:ne_arcs_from]]))
     pm.var[:p_ne] = p_ne_expr
-
-    return pm.var[:p_ne]
 end
 
 "do nothing, this model does not have complex voltage variables"
-constraint_voltage{T <: AbstractDCPForm}(pm::GenericPowerModel{T}) = nothing
+function constraint_voltage{T <: AbstractDCPForm}(pm::GenericPowerModel{T})
+end
 
 "do nothing, this model does not have complex voltage variables"
-constraint_voltage_ne{T <: AbstractDCPForm}(pm::GenericPowerModel{T}) = nothing
+function constraint_voltage_ne{T <: AbstractDCPForm}(pm::GenericPowerModel{T})
+end
 
 "do nothing, this model does not have voltage variables"
-constraint_voltage_magnitude_setpoint{T <: AbstractDCPForm}(pm::GenericPowerModel{T}, i, vm, epsilon) = Set()
+function constraint_voltage_magnitude_setpoint{T <: AbstractDCPForm}(pm::GenericPowerModel{T}, i, vm, epsilon)
+end
 
 "do nothing, this model does not have reactive variables"
-constraint_reactive_gen_setpoint{T <: AbstractDCPForm}(pm::GenericPowerModel{T}, i, qg) = Set()
+function constraint_reactive_gen_setpoint{T <: AbstractDCPForm}(pm::GenericPowerModel{T}, i, qg)
+end
 
 "do nothing, this model does not have voltage variables"
-constraint_voltage_dcline_setpoint{T <: AbstractDCPForm}(pm::GenericPowerModel{T}, f_bus, t_bus, vf, vt, epsilon) = Set()
+function constraint_voltage_dcline_setpoint{T <: AbstractDCPForm}(pm::GenericPowerModel{T}, f_bus, t_bus, vf, vt, epsilon)
+end
 
 ""
 function constraint_kcl_shunt{T <: AbstractDCPForm}(pm::GenericPowerModel{T}, i, bus_arcs, bus_arcs_dc, bus_gens, pd, qd, gs, bs)
@@ -94,9 +100,8 @@ function constraint_kcl_shunt{T <: AbstractDCPForm}(pm::GenericPowerModel{T}, i,
     p = pm.var[:p]
     p_dc = pm.var[:p_dc]
 
-    c = @constraint(pm.model, sum(p[a] for a in bus_arcs) + sum(p_dc[a_dc] for a_dc in bus_arcs_dc) == sum(pg[g] for g in bus_gens) - pd - gs*1.0^2)
+    @constraint(pm.model, sum(p[a] for a in bus_arcs) + sum(p_dc[a_dc] for a_dc in bus_arcs_dc) == sum(pg[g] for g in bus_gens) - pd - gs*1.0^2)
     # omit reactive constraint
-    return Set([c])
 end
 
 ""
@@ -106,8 +111,7 @@ function constraint_kcl_shunt_ne{T <: AbstractDCPForm}(pm::GenericPowerModel{T},
     p_ne = pm.var[:p_ne]
     p_dc = pm.var[:p_dc]
 
-    c = @constraint(pm.model, sum(p[a] for a in bus_arcs) + sum(p_ne[a] for a in bus_arcs_ne) + sum(p_dc[a_dc] for a_dc in bus_arcs_dc) == sum(pg[g] for g in bus_gens) - pd - gs*1.0^2)
-    return Set([c])
+    @constraint(pm.model, sum(p[a] for a in bus_arcs) + sum(p_ne[a] for a in bus_arcs_ne) + sum(p_dc[a_dc] for a_dc in bus_arcs_dc) == sum(pg[g] for g in bus_gens) - pd - gs*1.0^2)
 end
 
 """
@@ -122,9 +126,8 @@ function constraint_ohms_yt_from{T <: AbstractDCPForm}(pm::GenericPowerModel{T},
     t_fr = pm.var[:t][f_bus]
     t_to = pm.var[:t][t_bus]
 
-    c = @constraint(pm.model, p_fr == -b*(t_fr - t_to))
+    @constraint(pm.model, p_fr == -b*(t_fr - t_to))
     # omit reactive constraint
-    return Set([c])
 end
 
 "Do nothing, this model is symmetric"
@@ -136,9 +139,8 @@ function constraint_ohms_yt_from_ne{T <: AbstractDCPForm}(pm::GenericPowerModel{
     t_to = pm.var[:t][t_bus]
     z = pm.var[:line_ne][i]
 
-    c1 = @constraint(pm.model, p_fr <= -b*(t_fr - t_to + t_max*(1-z)) )
-    c2 = @constraint(pm.model, p_fr >= -b*(t_fr - t_to + t_min*(1-z)) )
-    return Set([c1, c2])
+    @constraint(pm.model, p_fr <= -b*(t_fr - t_to + t_max*(1-z)) )
+    @constraint(pm.model, p_fr >= -b*(t_fr - t_to + t_min*(1-z)) )
 end
 
 "Do nothing, this model is symmetric"
@@ -156,8 +158,6 @@ function constraint_thermal_limit_from{T <: AbstractDCPForm}(pm::GenericPowerMod
     if getupperbound(p_fr) > rate_a
         setupperbound(p_fr, rate_a)
     end
-
-    return Set()
 end
 
 "Do nothing, this model is symmetric"
@@ -182,9 +182,8 @@ function constraint_ohms_yt_from_on_off{T <: AbstractDCPForm}(pm::GenericPowerMo
     t_to = pm.var[:t][t_bus]
     z = pm.var[:line_z][i]
 
-    c1 = @constraint(pm.model, p_fr <= -b*(t_fr - t_to + t_max*(1-z)) )
-    c2 = @constraint(pm.model, p_fr >= -b*(t_fr - t_to + t_min*(1-z)) )
-    return Set([c1, c2])
+    @constraint(pm.model, p_fr <= -b*(t_fr - t_to + t_max*(1-z)) )
+    @constraint(pm.model, p_fr >= -b*(t_fr - t_to + t_min*(1-z)) )
 end
 
 "Do nothing, this model is symmetric"
@@ -201,9 +200,8 @@ function constraint_thermal_limit_from_on_off{T <: AbstractDCPForm}(pm::GenericP
     p_fr = pm.var[:p][f_idx]
     z = pm.var[:line_z][i]
 
-    c1 = @constraint(pm.model, p_fr <=  rate_a*z)
-    c2 = @constraint(pm.model, p_fr >= -rate_a*z)
-    return Set([c1, c2])
+    @constraint(pm.model, p_fr <=  rate_a*z)
+    @constraint(pm.model, p_fr >= -rate_a*z)
 end
 
 """
@@ -217,9 +215,8 @@ function constraint_thermal_limit_from_ne{T <: AbstractDCPForm}(pm::GenericPower
     p_fr = pm.var[:p_ne][f_idx]
     z = pm.var[:line_ne][i]
 
-    c1 = @constraint(pm.model, p_fr <=  rate_a*z)
-    c2 = @constraint(pm.model, p_fr >= -rate_a*z)
-    return Set([c1, c2])
+    @constraint(pm.model, p_fr <=  rate_a*z)
+    @constraint(pm.model, p_fr >= -rate_a*z)
 end
 
 "nothing to do, from handles both sides"
@@ -234,9 +231,8 @@ function constraint_phase_angle_difference_on_off{T <: AbstractDCPForm}(pm::Gene
     t_to = pm.var[:t][t_bus]
     z = pm.var[:line_z][i]
 
-    c1 = @constraint(pm.model, t_fr - t_to <= angmax*z + t_max*(1-z))
-    c2 = @constraint(pm.model, t_fr - t_to >= angmin*z + t_min*(1-z))
-    return Set([c1, c2])
+    @constraint(pm.model, t_fr - t_to <= angmax*z + t_max*(1-z))
+    @constraint(pm.model, t_fr - t_to >= angmin*z + t_min*(1-z))
 end
 
 "`angmin*line_ne[i] + t_min*(1-line_ne[i]) <= t[f_bus] - t[t_bus] <= angmax*line_ne[i] + t_max*(1-line_ne[i])`"
@@ -245,9 +241,8 @@ function constraint_phase_angle_difference_ne{T <: AbstractDCPForm}(pm::GenericP
     t_to = pm.var[:t][t_bus]
     z = pm.var[:line_ne][i]
 
-    c1 = @constraint(pm.model, t_fr - t_to <= angmax*z + t_max*(1-z))
-    c2 = @constraint(pm.model, t_fr - t_to >= angmin*z + t_min*(1-z))
-    return Set([c1, c2])
+    @constraint(pm.model, t_fr - t_to <= angmax*z + t_max*(1-z))
+    @constraint(pm.model, t_fr - t_to >= angmin*z + t_min*(1-z))
 end
 
 ""
@@ -268,8 +263,7 @@ function constraint_kcl_shunt{T <: AbstractDCPLLForm}(pm::GenericPowerModel{T}, 
     p = pm.var[:p]
     p_dc = pm.var[:p_dc]
 
-    c = @constraint(pm.model, sum(p[a] for a in bus_arcs) + sum(p_dc[a_dc] for a_dc in bus_arcs_dc) == sum(pg[g] for g in bus_gens) - pd - gs*1.0^2)
-    return Set([c])
+    @constraint(pm.model, sum(p[a] for a in bus_arcs) + sum(p_dc[a_dc] for a_dc in bus_arcs_dc) == sum(pg[g] for g in bus_gens) - pd - gs*1.0^2)
 end
 
 "`sum(p[a] for a in bus_arcs) + sum(p_ne[a] for a in bus_arcs_ne) + sum(p_dc[a_dc] for a_dc in bus_arcs_dc) == sum(pg[g] for g in bus_gens) - pd - gs*1.0^2`"
@@ -279,8 +273,7 @@ function constraint_kcl_shunt_ne{T <: AbstractDCPLLForm}(pm::GenericPowerModel{T
     p_dc = pm.var[:p_dc]
     pg = pm.var[:pg]
 
-    c = @constraint(pm.model, sum(p[a] for a in bus_arcs) + sum(p_ne[a] for a in bus_arcs_ne) + sum(p_dc[a_dc] for a_dc in bus_arcs_dc) == sum(pg[g] for g in bus_gens) - pd - gs*1.0^2)
-    return Set([c])
+    @constraint(pm.model, sum(p[a] for a in bus_arcs) + sum(p_ne[a] for a in bus_arcs_ne) + sum(p_dc[a_dc] for a_dc in bus_arcs_dc) == sum(pg[g] for g in bus_gens) - pd - gs*1.0^2)
 end
 
 """
@@ -297,10 +290,8 @@ function constraint_ohms_yt_from_on_off{T <: AbstractDCPLLForm}(pm::GenericPower
     t_to = pm.var[:t][t_bus]
     z = pm.var[:line_z][i]
 
-    c1 = @constraint(pm.model, p_fr <= -b*(t_fr - t_to + t_max*(1-z)) )
-    c2 = @constraint(pm.model, p_fr >= -b*(t_fr - t_to + t_min*(1-z)) )
-
-    return Set([c1, c2])
+    @constraint(pm.model, p_fr <= -b*(t_fr - t_to + t_max*(1-z)) )
+    @constraint(pm.model, p_fr >= -b*(t_fr - t_to + t_min*(1-z)) )
 end
 
 """
@@ -320,8 +311,7 @@ function constraint_ohms_yt_to_on_off{T <: AbstractDCPLLForm}(pm::GenericPowerMo
 
     r = g/(g^2 + b^2)
     t_m = max(abs(t_min),abs(t_max))
-    c = @constraint(pm.model, p_fr + p_to >= r*( (-b*(t_fr - t_to))^2 - (-b*(t_m))^2*(1-z) ) )
-    return Set([c])
+    @constraint(pm.model, p_fr + p_to >= r*( (-b*(t_fr - t_to))^2 - (-b*(t_m))^2*(1-z) ) )
 end
 
 """
@@ -338,10 +328,8 @@ function constraint_ohms_yt_from_ne{T <: AbstractDCPLLForm}(pm::GenericPowerMode
     t_to = pm.var[:t][t_bus]
     z = pm.var[:line_ne][i]
 
-    c1 = @constraint(pm.model, p_fr <= -b*(t_fr - t_to + t_max*(1-z)) )
-    c2 = @constraint(pm.model, p_fr >= -b*(t_fr - t_to + t_min*(1-z)) )
-
-    return Set([c1, c2])
+    @constraint(pm.model, p_fr <= -b*(t_fr - t_to + t_max*(1-z)) )
+    @constraint(pm.model, p_fr >= -b*(t_fr - t_to + t_min*(1-z)) )
 end
 
 """
@@ -361,8 +349,7 @@ function constraint_ohms_yt_to_ne{T <: AbstractDCPLLForm}(pm::GenericPowerModel{
 
     r = g/(g^2 + b^2)
     t_m = max(abs(t_min),abs(t_max))
-    c = @constraint(pm.model, p_fr + p_to >= r*( (-b*(t_fr - t_to))^2 - (-b*(t_m))^2*(1-z) ) )
-    return Set([c])
+    @constraint(pm.model, p_fr + p_to >= r*( (-b*(t_fr - t_to))^2 - (-b*(t_m))^2*(1-z) ) )
 end
 
 "`-rate_a*line_z[i] <= p[t_idx] <= rate_a*line_z[i]`"
@@ -370,9 +357,8 @@ function constraint_thermal_limit_to_on_off{T <: AbstractDCPLLForm}(pm::GenericP
     p_to = pm.var[:p][t_idx]
     z = pm.var[:line_z][i]
 
-    c1 = @constraint(pm.model, p_to <=  rate_a*z)
-    c2 = @constraint(pm.model, p_to >= -rate_a*z)
-    return Set([c1, c2])
+    @constraint(pm.model, p_to <=  rate_a*z)
+    @constraint(pm.model, p_to >= -rate_a*z)
 end
 
 "`-rate_a*line_ne[i] <= p_ne[t_idx] <=  rate_a*line_ne[i]`"
@@ -380,7 +366,6 @@ function constraint_thermal_limit_to_ne{T <: AbstractDCPLLForm}(pm::GenericPower
     p_to = pm.var[:p_ne][t_idx]
     z = pm.var[:line_ne][i]
 
-    c1 = @constraint(pm.model, p_to <=  rate_a*z)
-    c2 = @constraint(pm.model, p_to >= -rate_a*z)
-    return Set([c1, c2])
+    @constraint(pm.model, p_to <=  rate_a*z)
+    @constraint(pm.model, p_to >= -rate_a*z)
 end

--- a/src/form/shared.jl
+++ b/src/form/shared.jl
@@ -22,8 +22,9 @@ AbstractWRForms = Union{AbstractACTForm, AbstractWRForm}
 AbstractPForms = Union{AbstractACPForm, AbstractACTForm, AbstractDCPForm}
 
 "`t[ref_bus] == 0`"
-constraint_theta_ref{T <: AbstractPForms}(pm::GenericPowerModel{T}, ref_bus::Int) =
-    Set([@constraint(pm.model, pm.var[:t][ref_bus] == 0)])
+function constraint_theta_ref{T <: AbstractPForms}(pm::GenericPowerModel{T}, ref_bus::Int)
+    @constraint(pm.model, pm.var[:t][ref_bus] == 0)
+end
 
 """
 ```
@@ -35,9 +36,8 @@ function constraint_phase_angle_difference{T <: AbstractPForms}(pm::GenericPower
     t_fr = pm.var[:t][f_bus]
     t_to = pm.var[:t][t_bus]
 
-    c1 = @constraint(pm.model, t_fr - t_to <= angmax)
-    c2 = @constraint(pm.model, t_fr - t_to >= angmin)
-    return Set([c1, c2])
+    @constraint(pm.model, t_fr - t_to <= angmax)
+    @constraint(pm.model, t_fr - t_to >= angmin)
 end
 
 
@@ -45,13 +45,11 @@ function constraint_voltage_magnitude_setpoint{T <: AbstractWRForms}(pm::Generic
     w = pm.var[:w][i]
 
     if epsilon == 0.0
-        c = @constraint(pm.model, w == vm^2)
-        return Set([c])
+        @constraint(pm.model, w == vm^2)
     else
         @assert epsilon > 0.0
-        c1 = @constraint(pm.model, w <= (vm + epsilon)^2)
-        c2 = @constraint(pm.model, w >= (vm - epsilon)^2)
-        return Set([c1, c2])
+        @constraint(pm.model, w <= (vm + epsilon)^2)
+        @constraint(pm.model, w >= (vm - epsilon)^2)
     end
 end
 
@@ -63,15 +61,13 @@ function constraint_voltage_dcline_setpoint{T <: AbstractWRForms}(pm::GenericPow
     w_f = pm.var[:w][f_bus]
     w_t = pm.var[:w][t_bus]
     if epsilon == 0.0
-        c1 = @constraint(pm.model, w_f == vf^2)
-        c2 = @constraint(pm.model, w_t == vt^2)
-        return Set([c1, c2])
+        @constraint(pm.model, w_f == vf^2)
+        @constraint(pm.model, w_t == vt^2)
     else
-        c1 = @constraint(pm.model, w_f <= (vf + epsilon)^2)
-        c2 = @constraint(pm.model, w_f >= (vf - epsilon)^2)
-        c3 = @constraint(pm.model, w_t <= (vt + epsilon)^2)
-        c4 = @constraint(pm.model, w_t >= (vt - epsilon)^2)
-        return Set([c1, c2, c3, c4])
+        @constraint(pm.model, w_f <= (vf + epsilon)^2)
+        @constraint(pm.model, w_f >= (vf - epsilon)^2)
+        @constraint(pm.model, w_t <= (vt + epsilon)^2)
+        @constraint(pm.model, w_t >= (vt - epsilon)^2)
     end
 end
 
@@ -91,9 +87,8 @@ function constraint_kcl_shunt{T <: AbstractWRForms}(pm::GenericPowerModel{T}, i,
     p_dc = pm.var[:p_dc]
     q_dc = pm.var[:q_dc]
 
-    c1 = @constraint(pm.model, sum(p[a] for a in bus_arcs) + sum(p_dc[a_dc] for a_dc in bus_arcs_dc) == sum(pg[g] for g in bus_gens) - pd - gs*w)
-    c2 = @constraint(pm.model, sum(q[a] for a in bus_arcs) + sum(q_dc[a_dc] for a_dc in bus_arcs_dc) == sum(qg[g] for g in bus_gens) - qd + bs*w)
-    return Set([c1, c2])
+    @constraint(pm.model, sum(p[a] for a in bus_arcs) + sum(p_dc[a_dc] for a_dc in bus_arcs_dc) == sum(pg[g] for g in bus_gens) - pd - gs*w)
+    @constraint(pm.model, sum(q[a] for a in bus_arcs) + sum(q_dc[a_dc] for a_dc in bus_arcs_dc) == sum(qg[g] for g in bus_gens) - qd + bs*w)
 end
 
 
@@ -107,9 +102,8 @@ function constraint_ohms_yt_from{T <: AbstractWRForms}(pm::GenericPowerModel{T},
     wr = pm.var[:wr][(f_bus, t_bus)]
     wi = pm.var[:wi][(f_bus, t_bus)]
 
-    c1 = @constraint(pm.model, p_fr == g/tm*w_fr + (-g*tr+b*ti)/tm*(wr) + (-b*tr-g*ti)/tm*( wi) )
-    c2 = @constraint(pm.model, q_fr == -(b+c/2)/tm*w_fr - (-b*tr-g*ti)/tm*(wr) + (-g*tr+b*ti)/tm*( wi) )
-    return Set([c1, c2])
+    @constraint(pm.model, p_fr == g/tm*w_fr + (-g*tr+b*ti)/tm*(wr) + (-b*tr-g*ti)/tm*( wi) )
+    @constraint(pm.model, q_fr == -(b+c/2)/tm*w_fr - (-b*tr-g*ti)/tm*(wr) + (-g*tr+b*ti)/tm*( wi) )
 end
 
 
@@ -123,8 +117,7 @@ function constraint_ohms_yt_to{T <: AbstractWRForms}(pm::GenericPowerModel{T}, f
     wr = pm.var[:wr][(f_bus, t_bus)]
     wi = pm.var[:wi][(f_bus, t_bus)]
 
-    c1 = @constraint(pm.model, p_to == g*w_to + (-g*tr-b*ti)/tm*(wr) + (-b*tr+g*ti)/tm*(-wi) )
-    c2 = @constraint(pm.model, q_to == -(b+c/2)*w_to - (-b*tr+g*ti)/tm*(wr) + (-g*tr-b*ti)/tm*(-wi) )
-    return Set([c1, c2])
+    @constraint(pm.model, p_to == g*w_to + (-g*tr-b*ti)/tm*(wr) + (-b*tr+g*ti)/tm*(-wi) )
+    @constraint(pm.model, q_to == -(b+c/2)*w_to - (-b*tr+g*ti)/tm*(wr) + (-g*tr-b*ti)/tm*(-wi) )
 end
 

--- a/src/form/wrm.jl
+++ b/src/form/wrm.jl
@@ -57,7 +57,6 @@ function variable_voltage_product_matrix{T <: AbstractWRMForm}(pm::GenericPowerM
     end
 
     pm.ext[:lookup_w_index] = lookup_w_index
-    return WR, WI
 end
 
 ""
@@ -65,13 +64,12 @@ function constraint_voltage{T <: AbstractWRMForm}(pm::GenericPowerModel{T})
     WR = pm.var[:WR]
     WI = pm.var[:WI]
 
-    c = @SDconstraint(pm.model, [WR WI; -WI WR] >= 0)
+    @SDconstraint(pm.model, [WR WI; -WI WR] >= 0)
 
     # place holder while debugging sdp constraint
     #for (i,j) in keys(pm.ref[:buspairs])
     #    relaxation_complex_product(pm.model, w[i], w[j], wr[(i,j)], wi[(i,j)])
     #end
-    return Set([c])
 end
 
 "Do nothing, no way to represent this in these variables"
@@ -89,9 +87,8 @@ function constraint_kcl_shunt{T <: AbstractWRMForm}(pm::GenericPowerModel{T}, i,
     p_dc = pm.var[:p_dc]
     q_dc = pm.var[:q_dc]
 
-    c1 = @constraint(pm.model, sum(p[a] for a in bus_arcs) + sum(p_dc[a_dc] for a_dc in bus_arcs_dc) == sum(pg[g] for g in bus_gens) - pd - gs*w)
-    c2 = @constraint(pm.model, sum(q[a] for a in bus_arcs) + sum(q_dc[a_dc] for a_dc in bus_arcs_dc) == sum(qg[g] for g in bus_gens) - qd + bs*w)
-    return Set([c1, c2])
+    @constraint(pm.model, sum(p[a] for a in bus_arcs) + sum(p_dc[a_dc] for a_dc in bus_arcs_dc) == sum(pg[g] for g in bus_gens) - pd - gs*w)
+    @constraint(pm.model, sum(q[a] for a in bus_arcs) + sum(q_dc[a_dc] for a_dc in bus_arcs_dc) == sum(qg[g] for g in bus_gens) - qd + bs*w)
 end
 
 "Creates Ohms constraints (yt post fix indicates that Y and T values are in rectangular form)"
@@ -107,9 +104,8 @@ function constraint_ohms_yt_from{T <: AbstractWRMForm}(pm::GenericPowerModel{T},
     wr   = pm.var[:WR][w_fr_index, w_to_index]
     wi   = pm.var[:WI][w_fr_index, w_to_index]
 
-    c1 = @constraint(pm.model, p_fr == g/tm*w_fr + (-g*tr+b*ti)/tm*(wr) + (-b*tr-g*ti)/tm*( wi) )
-    c2 = @constraint(pm.model, q_fr == -(b+c/2)/tm*w_fr - (-b*tr-g*ti)/tm*(wr) + (-g*tr+b*ti)/tm*( wi) )
-    return Set([c1, c2])
+    @constraint(pm.model, p_fr == g/tm*w_fr + (-g*tr+b*ti)/tm*(wr) + (-b*tr-g*ti)/tm*( wi) )
+    @constraint(pm.model, q_fr == -(b+c/2)/tm*w_fr - (-b*tr-g*ti)/tm*(wr) + (-g*tr+b*ti)/tm*( wi) )
 end
 
 ""
@@ -125,9 +121,8 @@ function constraint_ohms_yt_to{T <: AbstractWRMForm}(pm::GenericPowerModel{T}, f
     wr   = pm.var[:WR][w_fr_index, w_to_index]
     wi   = pm.var[:WI][w_fr_index, w_to_index]
 
-    c1 = @constraint(pm.model, p_to ==    g*w_to + (-g*tr-b*ti)/tm*(wr) + (-b*tr+g*ti)/tm*(-wi) )
-    c2 = @constraint(pm.model, q_to ==    -(b+c/2)*w_to - (-b*tr+g*ti)/tm*(wr) + (-g*tr-b*ti)/tm*(-wi) )
-    return Set([c1, c2])
+    @constraint(pm.model, p_to ==    g*w_to + (-g*tr-b*ti)/tm*(wr) + (-b*tr+g*ti)/tm*(-wi) )
+    @constraint(pm.model, q_to ==    -(b+c/2)*w_to - (-b*tr+g*ti)/tm*(wr) + (-g*tr-b*ti)/tm*(-wi) )
 end
 
 ""
@@ -140,12 +135,10 @@ function constraint_phase_angle_difference{T <: AbstractWRMForm}(pm::GenericPowe
     wr   = pm.var[:WR][w_fr_index, w_to_index]
     wi   = pm.var[:WI][w_fr_index, w_to_index]
 
-    c1 = @constraint(pm.model, wi <= tan(angmax)*wr)
-    c2 = @constraint(pm.model, wi >= tan(angmin)*wr)
+    @constraint(pm.model, wi <= tan(angmax)*wr)
+    @constraint(pm.model, wi >= tan(angmin)*wr)
 
-    c3 = cut_complex_product_and_angle_difference(pm.model, w_fr, w_to, wr, wi, angmin, angmax)
-
-    return Set([c1, c2, c3])
+    cut_complex_product_and_angle_difference(pm.model, w_fr, w_to, wr, wi, angmin, angmax)
 end
 
 ""


### PR DESCRIPTION
These were not tested and partly broken and also causing a significant performance issue, so dropping support for this feature seems apt.  Closes #124.