### PR TITLE
Support for Dual Values in Solutions

### DIFF
--- a/src/core/base.jl
+++ b/src/core/base.jl
@@ -47,6 +47,7 @@ type GenericPowerModel{T<:AbstractPowerFormulation}
 
     ref::Dict{Symbol,Any} # data reference data
     var::Dict{Symbol,Any} # JuMP variables
+    con::Dict{Symbol,Any} # JuMP constraint references
     cnw::Int # current network index value
 
     # Extension dictionary
@@ -65,8 +66,10 @@ function GenericPowerModel(data::Dict{String,Any}, T::DataType; ext = Dict{Strin
     ref = build_ref(data) # refrence data
 
     var = Dict{Symbol,Any}(:nw => Dict{Int,Any}())
+    con = Dict{Symbol,Any}(:nw => Dict{Int,Any}())
     for nw_id in keys(ref[:nw])
         var[:nw][nw_id] = Dict{Symbol,Any}()
+        con[:nw][nw_id] = Dict{Symbol,Any}()
     end
 
     cnw = minimum([k for k in keys(ref[:nw])])
@@ -77,9 +80,10 @@ function GenericPowerModel(data::Dict{String,Any}, T::DataType; ext = Dict{Strin
         setting, # setting
         Dict{String,Any}(), # solution
         ref,
-        var, # vars
+        var,
+        con,
         cnw,
-        ext # ext
+        ext
     )
 
     return pm
@@ -99,6 +103,11 @@ Base.var(pm::GenericPowerModel, key::Symbol) = var(pm, pm.cnw, key)
 Base.var(pm::GenericPowerModel, key::Symbol, idx) = var(pm, pm.cnw, key, idx)
 Base.var(pm::GenericPowerModel, n::Int, key::Symbol) = pm.var[:nw][n][key]
 Base.var(pm::GenericPowerModel, n::Int, key::Symbol, idx) = pm.var[:nw][n][key][idx]
+
+con(pm::GenericPowerModel, key::Symbol) = con(pm, pm.cnw, key)
+con(pm::GenericPowerModel, key::Symbol, idx) = con(pm, pm.cnw, key, idx)
+con(pm::GenericPowerModel, n::Int, key::Symbol) = pm.con[:nw][n][key]
+con(pm::GenericPowerModel, n::Int, key::Symbol, idx) = pm.con[:nw][n][key][idx]
 
 ext(pm::GenericPowerModel, key::Symbol) = ext(pm, pm.cnw, key)
 ext(pm::GenericPowerModel, key::Symbol, idx) = ext(pm, pm.cnw, key, idx)

--- a/src/core/constraint_template.jl
+++ b/src/core/constraint_template.jl
@@ -59,6 +59,13 @@ constraint_voltage_magnitude_setpoint(pm::GenericPowerModel, i::Int) = constrain
 
 ""
 function constraint_kcl_shunt(pm::GenericPowerModel, n::Int, i::Int)
+    if !haskey(pm.con[:nw][n], :kcl_p)
+        pm.con[:nw][n][:kcl_p] = Dict{Int,ConstraintRef}()
+    end
+    if !haskey(pm.con[:nw][n], :kcl_q)
+        pm.con[:nw][n][:kcl_q] = Dict{Int,ConstraintRef}()
+    end
+
     bus = ref(pm, n, :bus, i)
     bus_arcs = ref(pm, n, :bus_arcs, i)
     bus_arcs_dc = ref(pm, n, :bus_arcs_dc, i)

--- a/src/core/data.jl
+++ b/src/core/data.jl
@@ -172,7 +172,8 @@ function make_per_unit(data::Dict{String,Any})
 end
 
 function _make_per_unit(data::Dict{String,Any}, mva_base::Real)
-    rescale = x -> x/mva_base
+    rescale      = x -> x/mva_base
+    rescale_dual = x -> x*mva_base
 
     if haskey(data, "bus")
         for (i, bus) in data["bus"]
@@ -183,6 +184,9 @@ function _make_per_unit(data::Dict{String,Any}, mva_base::Real)
             apply_func(bus, "bs", rescale)
 
             apply_func(bus, "va", deg2rad)
+
+            apply_func(bus, "lam_kcl_r", rescale_dual)
+            apply_func(bus, "lam_kcl_i", rescale_dual)
         end
     end
 
@@ -268,7 +272,8 @@ function make_mixed_units(data::Dict{String,Any})
 end
 
 function _make_mixed_units(data::Dict{String,Any}, mva_base::Real)
-    rescale = x -> x*mva_base
+    rescale      = x -> x*mva_base
+    rescale_dual = x -> x/mva_base
 
     if haskey(data, "bus")
         for (i, bus) in data["bus"]
@@ -279,6 +284,9 @@ function _make_mixed_units(data::Dict{String,Any}, mva_base::Real)
             apply_func(bus, "bs", rescale)
 
             apply_func(bus, "va", rad2deg)
+
+            apply_func(bus, "lam_kcl_r", rescale_dual)
+            apply_func(bus, "lam_kcl_i", rescale_dual)
         end
     end
 

--- a/src/form/acp.jl
+++ b/src/form/acp.jl
@@ -58,8 +58,8 @@ function constraint_kcl_shunt{T <: AbstractACPForm}(pm::GenericPowerModel{T}, n:
     p_dc = pm.var[:nw][n][:p_dc]
     q_dc = pm.var[:nw][n][:q_dc]
 
-    @constraint(pm.model, sum(p[a] for a in bus_arcs) + sum(p_dc[a_dc] for a_dc in bus_arcs_dc) == sum(pg[g] for g in bus_gens) - pd - gs*vm^2)
-    @constraint(pm.model, sum(q[a] for a in bus_arcs) + sum(q_dc[a_dc] for a_dc in bus_arcs_dc) == sum(qg[g] for g in bus_gens) - qd + bs*vm^2)
+    pm.con[:nw][n][:kcl_p][i] = @constraint(pm.model, sum(p[a] for a in bus_arcs) + sum(p_dc[a_dc] for a_dc in bus_arcs_dc) == sum(pg[g] for g in bus_gens) - pd - gs*vm^2)
+    pm.con[:nw][n][:kcl_q][i] = @constraint(pm.model, sum(q[a] for a in bus_arcs) + sum(q_dc[a_dc] for a_dc in bus_arcs_dc) == sum(qg[g] for g in bus_gens) - qd + bs*vm^2)
 end
 
 """

--- a/src/form/dcp.jl
+++ b/src/form/dcp.jl
@@ -97,7 +97,7 @@ function constraint_kcl_shunt{T <: AbstractDCPForm}(pm::GenericPowerModel{T}, n:
     p = pm.var[:nw][n][:p]
     p_dc = pm.var[:nw][n][:p_dc]
 
-    @constraint(pm.model, sum(p[a] for a in bus_arcs) + sum(p_dc[a_dc] for a_dc in bus_arcs_dc) == sum(pg[g] for g in bus_gens) - pd - gs*1.0^2)
+    pm.con[:nw][n][:kcl_p][i] = @constraint(pm.model, sum(p[a] for a in bus_arcs) + sum(p_dc[a_dc] for a_dc in bus_arcs_dc) == sum(pg[g] for g in bus_gens) - pd - gs*1.0^2)
     # omit reactive constraint
 end
 


### PR DESCRIPTION
A preliminary implementation of how to add dual values to PowerModels solutions.

Usage example:
```
result = run_dc_opf("case.m", IpoptSolver(), setting = Dict("output" => Dict("duals" => true)))
PowerModels.make_mixed_units(result["solution"])
result["solution"]["bus"]
```
A key open question is what is the best way to initialize the constraint reference dictionaries structures.  Constraint temples work, but is this the best place?
