### PR TITLE
Memento Logging

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,13 +3,11 @@ os:
   - linux
   - osx
 julia:
-  - 0.5
   - 0.6
   - nightly
 matrix:
   allow_failures:
     - julia: nightly
-    - julia: 0.5
 cache:
  directories:
    - /home/travis/.julia

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
-julia 0.5
+julia 0.6
 JSON 0.6.0
 MathProgBase 0.5.4
 JuMP 0.17 0.19-

--- a/REQUIRE
+++ b/REQUIRE
@@ -2,4 +2,5 @@ julia 0.6
 JSON 0.6.0
 MathProgBase 0.5.4
 JuMP 0.17 0.19-
-Compat 0.17
+Compat 0.26.0
+Memento 0.5.0

--- a/src/PowerModels.jl
+++ b/src/PowerModels.jl
@@ -6,6 +6,16 @@ using JSON
 using MathProgBase
 using JuMP
 using Compat
+using Memento
+
+import Compat: @__MODULE__
+
+# Create our module level logger (this will get precompiled)
+const LOGGER = getlogger(@__MODULE__)
+
+# Register the module level logger at runtime so that folks can access the logger via `getlogger(PowerModels)`
+# NOTE: If this line is not included then the precompiled `PowerModels.LOGGER` won't be registered at runtime.
+__init__() = Memento.register(LOGGER)
 
 include("io/matlab.jl")
 include("io/matpower.jl")

--- a/src/core/base.jl
+++ b/src/core/base.jl
@@ -126,7 +126,7 @@ function JuMP.solve(pm::GenericPowerModel)
     try
         solve_time = getsolvetime(pm.model)
     catch
-        warn("there was an issue with getsolvetime() on the solver, falling back on @timed.  This is not a rigorous timing value.");
+        warn(LOGGER, "there was an issue with getsolvetime() on the solver, falling back on @timed.  This is not a rigorous timing value.");
     end
 
     return status, solve_time
@@ -159,7 +159,7 @@ function build_generic_model(data::Dict{String,Any}, model_constructor, post_met
     pm = model_constructor(data; kwargs...)
 
     if !multinetwork && data["multinetwork"]
-        warn("building a single network model with multinetwork data, only network ($(pm.cnw)) will be used.")
+        warn(LOGGER, "building a single network model with multinetwork data, only network ($(pm.cnw)) will be used.")
     end
 
     post_method(pm)
@@ -295,11 +295,11 @@ function build_ref(data::Dict{String,Any})
             big_gen = biggest_generator(ref[:gen])
             gen_bus = big_gen["gen_bus"]
             ref_buses[gen_bus] = ref[:bus][gen_bus]
-            warn("no reference bus found, setting bus $(gen_bus) as reference based on generator $(big_gen["index"])")
+            warn(LOGGER, "no reference bus found, setting bus $(gen_bus) as reference based on generator $(big_gen["index"])")
         end
 
         if length(ref_buses) > 1
-            warn("multiple reference buses found, $(keys(ref_buses)), this can cause infeasibility if they are in the same connected component")
+            warn(LOGGER, "multiple reference buses found, $(keys(ref_buses)), this can cause infeasibility if they are in the same connected component")
         end
 
         ref[:ref_buses] = ref_buses

--- a/src/core/solution.jl
+++ b/src/core/solution.jl
@@ -231,7 +231,7 @@ function add_dual(
             constraint = extract_con(con(pm, con_symbol), idx, item)
             sol_item[param_name] = scale(getdual(constraint), item)
         catch
-            # info("No constraint: $(con_symbol), $(idx)") # if we want to log this info.
+            info(LOGGER, "No constraint: $(con_symbol), $(idx)")
         end
     end
 end

--- a/src/io/matlab.jl
+++ b/src/io/matlab.jl
@@ -36,7 +36,7 @@ function parse_matlab_string(data_string::String; extended=false)
             if contains(line, "[")
                 matrix_dict = parse_matlab_matrix(data_lines, index)
                 matlab_dict[matrix_dict["name"]] = matrix_dict["data"]
-                if haskey(matrix_dict, "column_names") 
+                if haskey(matrix_dict, "column_names")
                     column_names[matrix_dict["name"]] = matrix_dict["column_names"]
                 end
                 index = index + matrix_dict["line_count"]-1
@@ -53,7 +53,7 @@ function parse_matlab_string(data_string::String; extended=false)
                 matlab_dict[name] = value
             end
         else
-            warn("Matlab parser skipping the following line:\n  $(line)")
+            warn(LOGGER, "Matlab parser skipping the following line:\n  $(line)")
         end
 
         index += 1

--- a/src/io/matpower.jl
+++ b/src/io/matpower.jl
@@ -143,21 +143,21 @@ function parse_matpower_string(data_string::String)
     if func_name != nothing
         case["name"] = func_name
     else
-        warn(string("no case name found in matpower file.  The file seems to be missing \"function mpc = ...\""))
+        warn(LOGGER, string("no case name found in matpower file.  The file seems to be missing \"function mpc = ...\""))
         case["name"] = "no_name_found"
     end
 
     if haskey(matlab_data, "mpc.version")
         case["version"] = matlab_data["mpc.version"]
     else
-        warn(string("no case version found in matpower file.  The file seems to be missing \"mpc.version = ...\""))
+        warn(LOGGER, string("no case version found in matpower file.  The file seems to be missing \"mpc.version = ...\""))
         case["version"] = "unknown"
     end
 
     if haskey(matlab_data, "mpc.baseMVA")
         case["baseMVA"] = matlab_data["mpc.baseMVA"]
     else
-        warn(string("no baseMVA found in matpower file.  The file seems to be missing \"mpc.baseMVA = ...\""))
+        warn(LOGGER, string("no baseMVA found in matpower file.  The file seems to be missing \"mpc.baseMVA = ...\""))
         case["baseMVA"] = 1.0
     end
 
@@ -267,10 +267,10 @@ function parse_matpower_string(data_string::String)
                     push!(tbl, row_data)
                 end
                 case[case_name] = tbl
-                info("extending matpower format with data: $(case_name) $(length(tbl))x$(length(tbl[1])-1)")
+                info(LOGGER, "extending matpower format with data: $(case_name) $(length(tbl))x$(length(tbl[1])-1)")
             else
                 case[case_name] = value
-                info("extending matpower format with constant data: $(case_name)")
+                info(LOGGER, "extending matpower format with constant data: $(case_name)")
             end
         end
     end
@@ -380,7 +380,7 @@ function standardize_cost_terms(data::Dict{String,Any})
                 end
 
                 if max_nonzero_index > 1
-                    warn("removing $(max_nonzero_index-1) zeros from generator cost model ($(gencost["index"]))")
+                    warn(LOGGER, "removing $(max_nonzero_index-1) zeros from generator cost model ($(gencost["index"]))")
                     #println(gencost["cost"])
                     gencost["cost"] = gencost["cost"][max_nonzero_index:length(gencost["cost"])]
                     #println(gencost["cost"])
@@ -394,7 +394,7 @@ function standardize_cost_terms(data::Dict{String,Any})
                 gencost["cost"] = cost_3
                 gencost["ncost"] = 3
                 #println("   ",gencost["cost"])
-                warn("added zeros to make generator cost ($(gencost["index"])) a quadratic function: $(cost_3)")
+                warn(LOGGER, "added zeros to make generator cost ($(gencost["index"])) a quadratic function: $(cost_3)")
             end
         end
     end
@@ -411,7 +411,7 @@ function standardize_cost_terms(data::Dict{String,Any})
                 end
 
                 if max_nonzero_index > 1
-                    warn("removing $(max_nonzero_index-1) zeros from dcline cost model ($(dclinecost["index"]))")
+                    warn(LOGGER, "removing $(max_nonzero_index-1) zeros from dcline cost model ($(dclinecost["index"]))")
                     #println(dclinecost["cost"])
                     dclinecost["cost"] = dclinecost["cost"][max_nonzero_index:length(dclinecost["cost"])]
                     #println(dclinecost["cost"])
@@ -425,7 +425,7 @@ function standardize_cost_terms(data::Dict{String,Any})
                 dclinecost["cost"] = cost_3
                 dclinecost["ncost"] = 3
                 #println("   ",dclinecost["cost"])
-                warn("added zeros to make dcline cost ($(dclinecost["index"])) a quadratic function: $(cost_3)")
+                warn(LOGGER, "added zeros to make dcline cost ($(dclinecost["index"])) a quadratic function: $(cost_3)")
             end
         end
     end
@@ -499,7 +499,7 @@ end
 "adds dcline costs, if gen costs exist"
 function add_dcline_costs(data::Dict{String,Any})
     if length(data["gencost"]) > 0 && length(data["dclinecost"]) <= 0
-        warn("added zero cost function data for dclines")
+        warn(LOGGER, "added zero cost function data for dclines")
         model = data["gencost"][1]["model"]
         if model == 1
             for (i, dcline) in enumerate(data["dcline"])
@@ -587,7 +587,7 @@ function merge_generic_data(data::Dict{String,Any})
                         error("failed to extend the matpower matrix \"$(mp_name)\" with the matrix \"$(k)\" because they do not have the same number of rows, $(length(mp_matrix)) and $(length(v)) respectively.")
                     end
 
-                    info("extending matpower format by appending matrix \"$(k)\" in to \"$(mp_name)\"")
+                    info(LOGGER, "extending matpower format by appending matrix \"$(k)\" in to \"$(mp_name)\"")
 
                     for (i, row) in enumerate(mp_matrix)
                         merge_row = v[i]

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,8 +1,6 @@
 julia 0.5
 
-Ipopt 
+Ipopt
 SCS
 GLPKMathProgInterface
 Pajarito 0.4.0
-
-Logging 0.2.0

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,7 +1,8 @@
 using PowerModels
-using Logging
-# suppress warnings during testing
-Logging.configure(level=ERROR)
+using Memento
+
+# Suppress warnings during testing.
+setlevel!(getlogger(PowerModels), "error")
 
 using Ipopt
 using Pajarito


### PR DESCRIPTION
Updates to log message to a package level Memento logger. Closes #218.

- Required updating the minimum julia version as Memento dropped 0.5 support a while ago. While we could use an older version of Memento on 0.5 we'd get a lot of deprecation message on 0.6.
- Updated the minimum Compat version to support `@__MODULE__` on 0.6/0.7.
- We define a global `LOGGER` constant for the package and pass it as the first argument to all the existing logging calls.
- The package level logger can be set to `"error"` (via `setlevel!(getlogger(PowerModels), "error")`) to suppress warning messages without conflicting with warning messages from other libraries.

NOTES:

- Might want to convert a lot of the print statements in the code to `debug` calls.
- Seems like some of the regular warning messages could be `notice` messages.