### PR TITLE
FIX: Use of deprecated syntax

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,13 +3,11 @@ os:
   - linux
   - osx
 julia:
-  - 0.5
   - 0.6
   - nightly
 matrix:
   allow_failures:
     - julia: nightly
-    - julia: 0.5
 cache:
  directories:
    - /home/travis/.julia

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,5 +1,4 @@
-julia 0.5
+julia 0.6
 JSON 0.6.0
 MathProgBase 0.5.4
 JuMP 0.17 0.19-
-Compat 0.17

--- a/src/PowerModels.jl
+++ b/src/PowerModels.jl
@@ -5,7 +5,6 @@ module PowerModels
 using JSON
 using MathProgBase
 using JuMP
-using Compat
 
 include("io/matlab.jl")
 include("io/matpower.jl")

--- a/src/core/base.jl
+++ b/src/core/base.jl
@@ -7,10 +7,10 @@ export
     ids, ref, var, ext
 
 ""
-@compat abstract type AbstractPowerFormulation end
+abstract type AbstractPowerFormulation end
 
 ""
-@compat abstract type AbstractConicPowerFormulation <: AbstractPowerFormulation end
+abstract type AbstractConicPowerFormulation <: AbstractPowerFormulation end
 
 """
 ```

--- a/src/core/base.jl
+++ b/src/core/base.jl
@@ -38,7 +38,7 @@ Methods on `GenericPowerModel` for defining variables and adding constraints sho
 * add them to `model::JuMP.Model`, and
 * follow the conventions for variable and constraint names.
 """
-type GenericPowerModel{T<:AbstractPowerFormulation}
+mutable struct GenericPowerModel{T<:AbstractPowerFormulation}
     model::Model
 
     data::Dict{String,Any}

--- a/src/core/constraint.jl
+++ b/src/core/constraint.jl
@@ -20,14 +20,14 @@ function constraint_thermal_limit_to(pm::GenericPowerModel, n::Int, t_idx, rate_
 end
 
 "`norm([p[f_idx]; q[f_idx]]) <= rate_a`"
-function constraint_thermal_limit_from{T <: AbstractConicPowerFormulation}(pm::GenericPowerModel{T}, n::Int, f_idx, rate_a)
+function constraint_thermal_limit_from(pm::GenericPowerModel{T}, n::Int, f_idx, rate_a) where T<:AbstractConicPowerFormulation
     p_fr = pm.var[:nw][n][:p][f_idx]
     q_fr = pm.var[:nw][n][:q][f_idx]
     @constraint(pm.model, norm([p_fr; q_fr]) <= rate_a)
 end
 
 "`norm([p[t_idx]; q[t_idx]]) <= rate_a`"
-function constraint_thermal_limit_to{T <: AbstractConicPowerFormulation}(pm::GenericPowerModel{T}, n::Int, t_idx, rate_a)
+function constraint_thermal_limit_to(pm::GenericPowerModel{T}, n::Int, t_idx, rate_a) where T<:AbstractConicPowerFormulation
     p_to = pm.var[:nw][n][:p][t_idx]
     q_to = pm.var[:nw][n][:q][t_idx]
     @constraint(pm.model, norm([p_to; q_to]) <= rate_a)
@@ -86,7 +86,7 @@ Creates Line Flow constraint for DC Lines (Matpower Formulation)
 p_fr + p_to == loss0 + p_fr * loss1
 ```
 """
-function constraint_dcline{T}(pm::GenericPowerModel{T}, n::Int, f_bus, t_bus, f_idx, t_idx, loss0, loss1)
+function constraint_dcline(pm::GenericPowerModel{T}, n::Int, f_bus, t_bus, f_idx, t_idx, loss0, loss1) where T
     p_fr = pm.var[:nw][n][:p_dc][f_idx]
     p_to = pm.var[:nw][n][:p_dc][t_idx]
 

--- a/src/core/objective.jl
+++ b/src/core/objective.jl
@@ -104,7 +104,7 @@ function objective_min_polynomial_fuel_cost(pm::GenericPowerModel, nws=[pm.cnw])
 end
 
 ""
-function objective_min_polynomial_fuel_cost{T <: AbstractConicPowerFormulation}(pm::GenericPowerModel{T}, nws=[pm.cnw])
+function objective_min_polynomial_fuel_cost(pm::GenericPowerModel{T}, nws=[pm.cnw]) where T <: AbstractConicPowerFormulation
     check_polynomial_cost_models(pm, nws)
 
     pg = Dict(n => pm.var[:nw][n][:pg] for n in nws)
@@ -152,7 +152,7 @@ end
 """
 compute m and b from points pwl points
 """
-function slope_intercepts{T <: Real}(points::Array{T,1})
+function slope_intercepts(points::Array{T,1}) where T <: Real
     line_data = []
 
     for i in 3:2:length(points)

--- a/src/form/acp.jl
+++ b/src/form/acp.jl
@@ -17,26 +17,26 @@ ACPPowerModel(data::Dict{String,Any}; kwargs...) =
     GenericPowerModel(data, StandardACPForm; kwargs...)
 
 ""
-function variable_voltage{T <: AbstractACPForm}(pm::GenericPowerModel{T}, n::Int=pm.cnw; kwargs...)
+function variable_voltage(pm::GenericPowerModel{T}, n::Int=pm.cnw; kwargs...) where T <: AbstractACPForm
     variable_voltage_angle(pm, n; kwargs...)
     variable_voltage_magnitude(pm, n; kwargs...)
 end
 
 ""
-function variable_voltage_ne{T <: AbstractACPForm}(pm::GenericPowerModel{T}, n::Int=pm.cnw; kwargs...)
+function variable_voltage_ne(pm::GenericPowerModel{T}, n::Int=pm.cnw; kwargs...) where T <: AbstractACPForm
 end
 
 "do nothing, this model does not have complex voltage constraints"
-function constraint_voltage{T <: AbstractACPForm}(pm::GenericPowerModel{T}, n::Int)
+function constraint_voltage(pm::GenericPowerModel{T}, n::Int) where T <: AbstractACPForm
 end
 
 "do nothing, this model does not have complex voltage constraints"
-function constraint_voltage_ne{T <: AbstractACPForm}(pm::GenericPowerModel{T}, n::Int)
+function constraint_voltage_ne(pm::GenericPowerModel{T}, n::Int) where T <: AbstractACPForm
 end
 
 
 "`v[i] == vm`"
-function constraint_voltage_magnitude_setpoint{T <: AbstractACPForm}(pm::GenericPowerModel{T}, n::Int, i, vm)
+function constraint_voltage_magnitude_setpoint(pm::GenericPowerModel{T}, n::Int, i, vm) where T <: AbstractACPForm
     v = pm.var[:nw][n][:vm][i]
 
     @constraint(pm.model, v == vm)
@@ -49,7 +49,7 @@ sum(p[a] for a in bus_arcs) + sum(p_dc[a_dc] for a_dc in bus_arcs_dc) == sum(pg[
 sum(q[a] for a in bus_arcs) + sum(q_dc[a_dc] for a_dc in bus_arcs_dc) == sum(qg[g] for g in bus_gens) - qd + bs*v^2
 ```
 """
-function constraint_kcl_shunt{T <: AbstractACPForm}(pm::GenericPowerModel{T}, n::Int, i::Int, bus_arcs, bus_arcs_dc, bus_gens, pd, qd, gs, bs)
+function constraint_kcl_shunt(pm::GenericPowerModel{T}, n::Int, i::Int, bus_arcs, bus_arcs_dc, bus_gens, pd, qd, gs, bs) where T <: AbstractACPForm
     vm = pm.var[:nw][n][:vm][i]
     p = pm.var[:nw][n][:p]
     q = pm.var[:nw][n][:q]
@@ -68,7 +68,7 @@ sum(p[a] for a in bus_arcs) + sum(p_dc[a_dc] for a_dc in bus_arcs_dc) + sum(p_ne
 sum(q[a] for a in bus_arcs) + sum(p_dc[a_dc] for a_dc in bus_arcs_dc) + sum(q_ne[a] for a in bus_arcs_ne) == sum(qg[g] for g in bus_gens) - qd + bs*v^2
 ```
 """
-function constraint_kcl_shunt_ne{T <: AbstractACPForm}(pm::GenericPowerModel{T}, n::Int, i, bus_arcs, bus_arcs_dc, bus_arcs_ne, bus_gens, pd, qd, gs, bs)
+function constraint_kcl_shunt_ne(pm::GenericPowerModel{T}, n::Int, i, bus_arcs, bus_arcs_dc, bus_arcs_ne, bus_gens, pd, qd, gs, bs) where T <: AbstractACPForm
     vm = pm.var[:nw][n][:vm][i]
     p = pm.var[:nw][n][:p]
     q = pm.var[:nw][n][:q]
@@ -91,7 +91,7 @@ p[f_idx] == g/tm*v[f_bus]^2 + (-g*tr+b*ti)/tm*(v[f_bus]*v[t_bus]*cos(t[f_bus]-t[
 q[f_idx] == -(b+c/2)/tm*v[f_bus]^2 - (-b*tr-g*ti)/tm*(v[f_bus]*v[t_bus]*cos(t[f_bus]-t[t_bus])) + (-g*tr+b*ti)/tm*(v[f_bus]*v[t_bus]*sin(t[f_bus]-t[t_bus]))
 ```
 """
-function constraint_ohms_yt_from{T <: AbstractACPForm}(pm::GenericPowerModel{T}, n::Int, f_bus, t_bus, f_idx, t_idx, g, b, c, tr, ti, tm)
+function constraint_ohms_yt_from(pm::GenericPowerModel{T}, n::Int, f_bus, t_bus, f_idx, t_idx, g, b, c, tr, ti, tm) where T <: AbstractACPForm
     p_fr = pm.var[:nw][n][:p][f_idx]
     q_fr = pm.var[:nw][n][:q][f_idx]
     vm_fr = pm.var[:nw][n][:vm][f_bus]
@@ -111,7 +111,7 @@ p[t_idx] == g*v[t_bus]^2 + (-g*tr-b*ti)/tm*(v[t_bus]*v[f_bus]*cos(t[t_bus]-t[f_b
 q[t_idx] == -(b+c/2)*v[t_bus]^2 - (-b*tr+g*ti)/tm*(v[t_bus]*v[f_bus]*cos(t[f_bus]-t[t_bus])) + (-g*tr-b*ti)/tm*(v[t_bus]*v[f_bus]*sin(t[t_bus]-t[f_bus]))
 ```
 """
-function constraint_ohms_yt_to{T <: AbstractACPForm}(pm::GenericPowerModel{T}, n::Int, f_bus, t_bus, f_idx, t_idx, g, b, c, tr, ti, tm)
+function constraint_ohms_yt_to(pm::GenericPowerModel{T}, n::Int, f_bus, t_bus, f_idx, t_idx, g, b, c, tr, ti, tm) where T <: AbstractACPForm
     p_to = pm.var[:nw][n][:p][t_idx]
     q_to = pm.var[:nw][n][:q][t_idx]
     vm_fr = pm.var[:nw][n][:vm][f_bus]
@@ -131,7 +131,7 @@ p[f_idx] == g*(v[f_bus]/tr)^2 + -g*v[f_bus]/tr*v[t_bus]*cos(t[f_bus]-t[t_bus]-as
 q[f_idx] == -(b+c/2)*(v[f_bus]/tr)^2 + b*v[f_bus]/tr*v[t_bus]*cos(t[f_bus]-t[t_bus]-as) + -g*v[f_bus]/tr*v[t_bus]*sin(t[f_bus]-t[t_bus]-as)
 ```
 """
-function constraint_ohms_y_from{T <: AbstractACPForm}(pm::GenericPowerModel{T}, n::Int, f_bus, t_bus, f_idx, t_idx, g, b, c, tr, as)
+function constraint_ohms_y_from(pm::GenericPowerModel{T}, n::Int, f_bus, t_bus, f_idx, t_idx, g, b, c, tr, as) where T <: AbstractACPForm
     p_fr = pm.var[:nw][n][:p][f_idx]
     q_fr = pm.var[:nw][n][:q][f_idx]
     vm_fr = pm.var[:nw][n][:vm][f_bus]
@@ -151,7 +151,7 @@ p[t_idx] == g*v[t_bus]^2 + -g*v[t_bus]*v[f_bus]/tr*cos(t[t_bus]-t[f_bus]+as) + -
 q_to == -(b+c/2)*v[t_bus]^2 + b*v[t_bus]*v[f_bus]/tr*cos(t[f_bus]-t[t_bus]+as) + -g*v[t_bus]*v[f_bus]/tr*sin(t[t_bus]-t[f_bus]+as)
 ```
 """
-function constraint_ohms_y_to{T <: AbstractACPForm}(pm::GenericPowerModel{T}, n::Int, f_bus, t_bus, f_idx, t_idx, g, b, c, tr, as)
+function constraint_ohms_y_to(pm::GenericPowerModel{T}, n::Int, f_bus, t_bus, f_idx, t_idx, g, b, c, tr, as) where T <: AbstractACPForm
     p_to = pm.var[:nw][n][:p][t_idx]
     q_to = pm.var[:nw][n][:q][t_idx]
     vm_fr = pm.var[:nw][n][:vm][f_bus]
@@ -165,13 +165,13 @@ end
 
 
 ""
-function variable_voltage_on_off{T <: AbstractACPForm}(pm::GenericPowerModel{T}, n::Int=pm.cnw; kwargs...)
+function variable_voltage_on_off(pm::GenericPowerModel{T}, n::Int=pm.cnw; kwargs...) where T <: AbstractACPForm
     variable_voltage_angle(pm, n; kwargs...)
     variable_voltage_magnitude(pm, n; kwargs...)
 end
 
 "do nothing, this model does not have complex voltage constraints"
-function constraint_voltage_on_off{T <: AbstractACPForm}(pm::GenericPowerModel{T}, n::Int=pm.cnw)
+function constraint_voltage_on_off(pm::GenericPowerModel{T}, n::Int=pm.cnw) where T <: AbstractACPForm
 end
 
 """
@@ -180,7 +180,7 @@ p[f_idx] == z*(g/tm*v[f_bus]^2 + (-g*tr+b*ti)/tm*(v[f_bus]*v[t_bus]*cos(t[f_bus]
 q[f_idx] == z*(-(b+c/2)/tm*v[f_bus]^2 - (-b*tr-g*ti)/tm*(v[f_bus]*v[t_bus]*cos(t[f_bus]-t[t_bus])) + (-g*tr+b*ti)/tm*(v[f_bus]*v[t_bus]*sin(t[f_bus]-t[t_bus])))
 ```
 """
-function constraint_ohms_yt_from_on_off{T <: AbstractACPForm}(pm::GenericPowerModel{T}, n::Int, i, f_bus, t_bus, f_idx, t_idx, g, b, c, tr, ti, tm, t_min, t_max)
+function constraint_ohms_yt_from_on_off(pm::GenericPowerModel{T}, n::Int, i, f_bus, t_bus, f_idx, t_idx, g, b, c, tr, ti, tm, t_min, t_max) where T <: AbstractACPForm
     p_fr = pm.var[:nw][n][:p][f_idx]
     q_fr = pm.var[:nw][n][:q][f_idx]
     vm_fr = pm.var[:nw][n][:vm][f_bus]
@@ -199,7 +199,7 @@ p[t_idx] == z*(g*v[t_bus]^2 + (-g*tr-b*ti)/tm*(v[t_bus]*v[f_bus]*cos(t[t_bus]-t[
 q[t_idx] == z*(-(b+c/2)*v[t_bus]^2 - (-b*tr+g*ti)/tm*(v[t_bus]*v[f_bus]*cos(t[f_bus]-t[t_bus])) + (-g*tr-b*ti)/tm*(v[t_bus]*v[f_bus]*sin(t[t_bus]-t[f_bus])))
 ```
 """
-function constraint_ohms_yt_to_on_off{T <: AbstractACPForm}(pm::GenericPowerModel{T}, n::Int, i, f_bus, t_bus, f_idx, t_idx, g, b, c, tr, ti, tm, t_min, t_max)
+function constraint_ohms_yt_to_on_off(pm::GenericPowerModel{T}, n::Int, i, f_bus, t_bus, f_idx, t_idx, g, b, c, tr, ti, tm, t_min, t_max) where T <: AbstractACPForm
     p_to = pm.var[:nw][n][:p][t_idx]
     q_to = pm.var[:nw][n][:q][t_idx]
     vm_fr = pm.var[:nw][n][:vm][f_bus]
@@ -218,7 +218,7 @@ p_ne[f_idx] == z*(g/tm*v[f_bus]^2 + (-g*tr+b*ti)/tm*(v[f_bus]*v[t_bus]*cos(t[f_b
 q_ne[f_idx] == z*(-(b+c/2)/tm*v[f_bus]^2 - (-b*tr-g*ti)/tm*(v[f_bus]*v[t_bus]*cos(t[f_bus]-t[t_bus])) + (-g*tr+b*ti)/tm*(v[f_bus]*v[t_bus]*sin(t[f_bus]-t[t_bus])))
 ```
 """
-function constraint_ohms_yt_from_ne{T <: AbstractACPForm}(pm::GenericPowerModel{T}, n::Int, i, f_bus, t_bus, f_idx, t_idx, g, b, c, tr, ti, tm, t_min, t_max)
+function constraint_ohms_yt_from_ne(pm::GenericPowerModel{T}, n::Int, i, f_bus, t_bus, f_idx, t_idx, g, b, c, tr, ti, tm, t_min, t_max) where T <: AbstractACPForm
     p_fr = pm.var[:nw][n][:p_ne][f_idx]
     q_fr = pm.var[:nw][n][:q_ne][f_idx]
     vm_fr = pm.var[:nw][n][:vm][f_bus]
@@ -237,7 +237,7 @@ p_ne[t_idx] == z*(g*v[t_bus]^2 + (-g*tr-b*ti)/tm*(v[t_bus]*v[f_bus]*cos(t[t_bus]
 q_ne[t_idx] == z*(-(b+c/2)*v[t_bus]^2 - (-b*tr+g*ti)/tm*(v[t_bus]*v[f_bus]*cos(t[f_bus]-t[t_bus])) + (-g*tr-b*ti)/tm*(v[t_bus]*v[f_bus]*sin(t[t_bus]-t[f_bus])))
 ```
 """
-function constraint_ohms_yt_to_ne{T <: AbstractACPForm}(pm::GenericPowerModel{T}, n::Int, i, f_bus, t_bus, f_idx, t_idx, g, b, c, tr, ti, tm, t_min, t_max)
+function constraint_ohms_yt_to_ne(pm::GenericPowerModel{T}, n::Int, i, f_bus, t_bus, f_idx, t_idx, g, b, c, tr, ti, tm, t_min, t_max) where T <: AbstractACPForm
     p_to = pm.var[:nw][n][:p_ne][t_idx]
     q_to = pm.var[:nw][n][:q_ne][t_idx]
     vm_fr = pm.var[:nw][n][:vm][f_bus]
@@ -251,7 +251,7 @@ function constraint_ohms_yt_to_ne{T <: AbstractACPForm}(pm::GenericPowerModel{T}
 end
 
 "`angmin <= branch_z[i]*(t[f_bus] - t[t_bus]) <= angmax`"
-function constraint_voltage_angle_difference_on_off{T <: AbstractACPForm}(pm::GenericPowerModel{T}, n::Int, i, f_bus, t_bus, angmin, angmax, t_min, t_max)
+function constraint_voltage_angle_difference_on_off(pm::GenericPowerModel{T}, n::Int, i, f_bus, t_bus, angmin, angmax, t_min, t_max) where T <: AbstractACPForm
     va_fr = pm.var[:nw][n][:va][f_bus]
     va_to = pm.var[:nw][n][:va][t_bus]
     z = pm.var[:nw][n][:branch_z][i]
@@ -261,7 +261,7 @@ function constraint_voltage_angle_difference_on_off{T <: AbstractACPForm}(pm::Ge
 end
 
 "`angmin <= branch_ne[i]*(t[f_bus] - t[t_bus]) <= angmax`"
-function constraint_voltage_angle_difference_ne{T <: AbstractACPForm}(pm::GenericPowerModel{T}, n::Int, i, f_bus, t_bus, angmin, angmax, t_min, t_max)
+function constraint_voltage_angle_difference_ne(pm::GenericPowerModel{T}, n::Int, i, f_bus, t_bus, angmin, angmax, t_min, t_max) where T <: AbstractACPForm
     va_fr = pm.var[:nw][n][:va][f_bus]
     va_to = pm.var[:nw][n][:va][t_bus]
     z = pm.var[:nw][n][:branch_ne][i]
@@ -276,7 +276,7 @@ p[f_idx] + p[t_idx] >= 0
 q[f_idx] + q[t_idx] >= -c/2*(v[f_bus]^2/tr^2 + v[t_bus]^2)
 ```
 """
-function constraint_loss_lb{T <: AbstractACPForm}(pm::GenericPowerModel{T}, n::Int, f_bus, t_bus, f_idx, t_idx, c, tr)
+function constraint_loss_lb(pm::GenericPowerModel{T}, n::Int, f_bus, t_bus, f_idx, t_idx, c, tr) where T <: AbstractACPForm
     vm_fr = pm.var[:nw][n][:vm][f_bus]
     vm_to = pm.var[:nw][n][:vm][t_bus]
     p_fr = pm.var[:nw][n][:p][f_idx]

--- a/src/form/acp.jl
+++ b/src/form/acp.jl
@@ -4,10 +4,10 @@ export
     ACPPowerModel, StandardACPForm
 
 ""
-@compat abstract type AbstractACPForm <: AbstractPowerFormulation end
+abstract type AbstractACPForm <: AbstractPowerFormulation end
 
 ""
-@compat abstract type StandardACPForm <: AbstractACPForm end
+abstract type StandardACPForm <: AbstractACPForm end
 
 ""
 const ACPPowerModel = GenericPowerModel{StandardACPForm}

--- a/src/form/acr.jl
+++ b/src/form/acr.jl
@@ -4,10 +4,10 @@ export
     ACRPowerModel, StandardACRForm
 
 ""
-@compat abstract type AbstractACRForm <: AbstractPowerFormulation end
+abstract type AbstractACRForm <: AbstractPowerFormulation end
 
 ""
-@compat abstract type StandardACRForm <: AbstractACRForm end
+abstract type StandardACRForm <: AbstractACRForm end
 
 ""
 const ACRPowerModel = GenericPowerModel{StandardACRForm}

--- a/src/form/act.jl
+++ b/src/form/act.jl
@@ -17,18 +17,18 @@ ACTPowerModel(data::Dict{String,Any}; kwargs...) =
     GenericPowerModel(data, StandardACTForm; kwargs...)
 
 "`t[ref_bus] == 0`"
-function constraint_theta_ref{T <: AbstractACTForm}(pm::GenericPowerModel{T}, n::Int, i::Int)
+function constraint_theta_ref(pm::GenericPowerModel{T}, n::Int, i::Int) where T <: AbstractACTForm
     @constraint(pm.model, pm.var[:nw][n][:va][i] == 0)
 end
 
 ""
-function variable_voltage{T <: AbstractACTForm}(pm::GenericPowerModel{T}, n::Int=pm.cnw; kwargs...)
+function variable_voltage(pm::GenericPowerModel{T}, n::Int=pm.cnw; kwargs...) where T <: AbstractACTForm
     variable_voltage_angle(pm, n; kwargs...)
     variable_voltage_magnitude_sqr(pm, n; kwargs...)
     variable_voltage_product(pm, n; kwargs...)
 end
 
-function constraint_voltage{T <: StandardACTForm}(pm::GenericPowerModel{T}, n::Int)
+function constraint_voltage(pm::GenericPowerModel{T}, n::Int) where T <: StandardACTForm
     t = pm.var[:nw][n][:va]
     w = pm.var[:nw][n][:w]
     wr = pm.var[:nw][n][:wr]
@@ -47,7 +47,7 @@ t[f_bus] - t[t_bus] <= angmax
 t[f_bus] - t[t_bus] >= angmin
 ```
 """
-function constraint_voltage_angle_difference{T <: StandardACTForm}(pm::GenericPowerModel{T}, n::Int, f_bus, t_bus, angmin, angmax)
+function constraint_voltage_angle_difference(pm::GenericPowerModel{T}, n::Int, f_bus, t_bus, angmin, angmax) where T <: StandardACTForm
     va_fr = pm.var[:nw][n][:va][f_bus]
     va_to = pm.var[:nw][n][:va][t_bus]
 
@@ -57,7 +57,7 @@ end
 
 
 ""
-function add_bus_voltage_setpoint{T <: AbstractACTForm}(sol, pm::GenericPowerModel{T})
+function add_bus_voltage_setpoint(sol, pm::GenericPowerModel{T}) where T <: AbstractACTForm
     add_setpoint(sol, pm, "bus", "vm", :w; scale = (x,item) -> sqrt(x))
     add_setpoint(sol, pm, "bus", "va", :va)
 end

--- a/src/form/act.jl
+++ b/src/form/act.jl
@@ -4,10 +4,10 @@ export
     ACTPowerModel, StandardACTForm
 
 ""
-@compat abstract type AbstractACTForm <: AbstractPowerFormulation end
+abstract type AbstractACTForm <: AbstractPowerFormulation end
 
 ""
-@compat abstract type StandardACTForm <: AbstractACTForm end
+abstract type StandardACTForm <: AbstractACTForm end
 
 ""
 const ACTPowerModel = GenericPowerModel{StandardACTForm}

--- a/src/form/dcp.jl
+++ b/src/form/dcp.jl
@@ -3,10 +3,10 @@ export
     DCPLLPowerModel, StandardDCPLLForm
 
 ""
-@compat abstract type AbstractDCPForm <: AbstractPowerFormulation end
+abstract type AbstractDCPForm <: AbstractPowerFormulation end
 
 ""
-@compat abstract type StandardDCPForm <: AbstractDCPForm end
+abstract type StandardDCPForm <: AbstractDCPForm end
 
 ""
 const DCPPowerModel = GenericPowerModel{StandardDCPForm}
@@ -247,10 +247,10 @@ end
 
 
 ""
-@compat abstract type AbstractDCPLLForm <: AbstractDCPForm end
+abstract type AbstractDCPLLForm <: AbstractDCPForm end
 
 ""
-@compat abstract type StandardDCPLLForm <: AbstractDCPLLForm end
+abstract type StandardDCPLLForm <: AbstractDCPLLForm end
 
 ""
 const DCPLLPowerModel = GenericPowerModel{StandardDCPLLForm}

--- a/src/form/dcp.jl
+++ b/src/form/dcp.jl
@@ -16,30 +16,30 @@ DCPPowerModel(data::Dict{String,Any}; kwargs...) =
     GenericPowerModel(data, StandardDCPForm; kwargs...)
 
 ""
-function variable_voltage{T <: AbstractDCPForm}(pm::GenericPowerModel{T}, n::Int=pm.cnw; kwargs...)
+function variable_voltage(pm::GenericPowerModel{T}, n::Int=pm.cnw; kwargs...) where T <: AbstractDCPForm
     variable_voltage_angle(pm, n; kwargs...)
 end
 
 
 "nothing to add, there are no voltage variables on branches"
-function variable_voltage_ne{T <: AbstractDCPForm}(pm::GenericPowerModel{T}, n::Int=pm.cnw; kwargs...)
+function variable_voltage_ne(pm::GenericPowerModel{T}, n::Int=pm.cnw; kwargs...) where T <: AbstractDCPForm
 end
 
 "dc models ignore reactive power flows"
-function variable_reactive_generation{T <: AbstractDCPForm}(pm::GenericPowerModel{T}, n::Int=pm.cnw; bounded = true)
+function variable_reactive_generation(pm::GenericPowerModel{T}, n::Int=pm.cnw; bounded = true) where T <: AbstractDCPForm
 end
 
 "dc models ignore reactive power flows"
-function variable_reactive_branch_flow{T <: AbstractDCPForm}(pm::GenericPowerModel{T}, n::Int=pm.cnw; bounded = true)
+function variable_reactive_branch_flow(pm::GenericPowerModel{T}, n::Int=pm.cnw; bounded = true) where T <: AbstractDCPForm
 end
 
 "dc models ignore reactive power flows"
-function variable_reactive_branch_flow_ne{T <: AbstractDCPForm}(pm::GenericPowerModel{T}, n::Int=pm.cnw)
+function variable_reactive_branch_flow_ne(pm::GenericPowerModel{T}, n::Int=pm.cnw) where T <: AbstractDCPForm
 end
 
 
 ""
-function variable_active_branch_flow{T <: StandardDCPForm}(pm::GenericPowerModel{T}, n::Int=pm.cnw; bounded = true)
+function variable_active_branch_flow(pm::GenericPowerModel{T}, n::Int=pm.cnw; bounded = true) where T <: StandardDCPForm
     if bounded
         pm.var[:nw][n][:p] = @variable(pm.model,
             [(l,i,j) in pm.ref[:nw][n][:arcs_from]], basename="$(n)_p",
@@ -61,7 +61,7 @@ function variable_active_branch_flow{T <: StandardDCPForm}(pm::GenericPowerModel
 end
 
 ""
-function variable_active_branch_flow_ne{T <: StandardDCPForm}(pm::GenericPowerModel{T}, n::Int=pm.cnw)
+function variable_active_branch_flow_ne(pm::GenericPowerModel{T}, n::Int=pm.cnw) where T <: StandardDCPForm
     pm.var[:nw][n][:p_ne] = @variable(pm.model,
         [(l,i,j) in pm.ref[:nw][n][:ne_arcs_from]], basename="$(n)_p_ne",
         lowerbound = -pm.ref[:nw][n][:ne_branch][l]["rate_a"],
@@ -76,23 +76,23 @@ function variable_active_branch_flow_ne{T <: StandardDCPForm}(pm::GenericPowerMo
 end
 
 "do nothing, this model does not have complex voltage variables"
-function constraint_voltage{T <: AbstractDCPForm}(pm::GenericPowerModel{T}, n::Int)
+function constraint_voltage(pm::GenericPowerModel{T}, n::Int) where T <: AbstractDCPForm
 end
 
 "do nothing, this model does not have complex voltage variables"
-function constraint_voltage_ne{T <: AbstractDCPForm}(pm::GenericPowerModel{T}, n::Int)
+function constraint_voltage_ne(pm::GenericPowerModel{T}, n::Int) where T <: AbstractDCPForm
 end
 
 "do nothing, this model does not have voltage variables"
-function constraint_voltage_magnitude_setpoint{T <: AbstractDCPForm}(pm::GenericPowerModel{T}, n::Int, i, vm)
+function constraint_voltage_magnitude_setpoint(pm::GenericPowerModel{T}, n::Int, i, vm) where T <: AbstractDCPForm
 end
 
 "do nothing, this model does not have reactive variables"
-function constraint_reactive_gen_setpoint{T <: AbstractDCPForm}(pm::GenericPowerModel{T}, n::Int, i, qg)
+function constraint_reactive_gen_setpoint(pm::GenericPowerModel{T}, n::Int, i, qg) where T <: AbstractDCPForm
 end
 
 ""
-function constraint_kcl_shunt{T <: AbstractDCPForm}(pm::GenericPowerModel{T}, n::Int, i, bus_arcs, bus_arcs_dc, bus_gens, pd, qd, gs, bs)
+function constraint_kcl_shunt(pm::GenericPowerModel{T}, n::Int, i, bus_arcs, bus_arcs_dc, bus_gens, pd, qd, gs, bs) where T <: AbstractDCPForm
     pg = pm.var[:nw][n][:pg]
     p = pm.var[:nw][n][:p]
     p_dc = pm.var[:nw][n][:p_dc]
@@ -102,7 +102,7 @@ function constraint_kcl_shunt{T <: AbstractDCPForm}(pm::GenericPowerModel{T}, n:
 end
 
 ""
-function constraint_kcl_shunt_ne{T <: AbstractDCPForm}(pm::GenericPowerModel{T}, n::Int, i, bus_arcs, bus_arcs_dc, bus_arcs_ne, bus_gens, pd, qd, gs, bs)
+function constraint_kcl_shunt_ne(pm::GenericPowerModel{T}, n::Int, i, bus_arcs, bus_arcs_dc, bus_arcs_ne, bus_gens, pd, qd, gs, bs) where T <: AbstractDCPForm
     pg = pm.var[:nw][n][:pg]
     p = pm.var[:nw][n][:p]
     p_ne = pm.var[:nw][n][:p_ne]
@@ -118,7 +118,7 @@ Creates Ohms constraints (yt post fix indicates that Y and T values are in recta
 p[f_idx] == -b*(t[f_bus] - t[t_bus])
 ```
 """
-function constraint_ohms_yt_from{T <: AbstractDCPForm}(pm::GenericPowerModel{T}, n::Int, f_bus, t_bus, f_idx, t_idx, g, b, c, tr, ti, tm)
+function constraint_ohms_yt_from(pm::GenericPowerModel{T}, n::Int, f_bus, t_bus, f_idx, t_idx, g, b, c, tr, ti, tm) where T <: AbstractDCPForm
     p_fr = pm.var[:nw][n][:p][f_idx]
     va_fr = pm.var[:nw][n][:va][f_bus]
     va_to = pm.var[:nw][n][:va][t_bus]
@@ -128,10 +128,10 @@ function constraint_ohms_yt_from{T <: AbstractDCPForm}(pm::GenericPowerModel{T},
 end
 
 "Do nothing, this model is symmetric"
-function constraint_ohms_yt_to{T <: AbstractDCPForm}(pm::GenericPowerModel{T}, n::Int, f_bus, t_bus, f_idx, t_idx, g, b, c, tr, ti, tm)
+function constraint_ohms_yt_to(pm::GenericPowerModel{T}, n::Int, f_bus, t_bus, f_idx, t_idx, g, b, c, tr, ti, tm) where T <: AbstractDCPForm
 end
 
-function constraint_ohms_yt_from_ne{T <: AbstractDCPForm}(pm::GenericPowerModel{T}, n::Int, i, f_bus, t_bus, f_idx, t_idx, g, b, c, tr, ti, tm, t_min, t_max)
+function constraint_ohms_yt_from_ne(pm::GenericPowerModel{T}, n::Int, i, f_bus, t_bus, f_idx, t_idx, g, b, c, tr, ti, tm, t_min, t_max) where T <: AbstractDCPForm
     p_fr = pm.var[:nw][n][:p_ne][f_idx]
     va_fr = pm.var[:nw][n][:va][f_bus]
     va_to = pm.var[:nw][n][:va][t_bus]
@@ -142,37 +142,37 @@ function constraint_ohms_yt_from_ne{T <: AbstractDCPForm}(pm::GenericPowerModel{
 end
 
 "Do nothing, this model is symmetric"
-function constraint_ohms_yt_to_ne{T <: AbstractDCPForm}(pm::GenericPowerModel{T}, n::Int, i, f_bus, t_bus, f_idx, t_idx, g, b, c, tr, ti, tm, t_min, t_max)
+function constraint_ohms_yt_to_ne(pm::GenericPowerModel{T}, n::Int, i, f_bus, t_bus, f_idx, t_idx, g, b, c, tr, ti, tm, t_min, t_max) where T <: AbstractDCPForm
 end
 
 "`-rate_a <= p[f_idx] <= rate_a`"
-function constraint_thermal_limit_from{T <: AbstractDCPForm}(pm::GenericPowerModel{T}, n::Int, f_idx, rate_a)
+function constraint_thermal_limit_from(pm::GenericPowerModel{T}, n::Int, f_idx, rate_a) where T <: AbstractDCPForm
     p_fr = pm.con[:nw][n][:sm_fr][f_idx[1]] = pm.var[:nw][n][:p][f_idx]
     getlowerbound(p_fr) < -rate_a && setlowerbound(p_fr, -rate_a)
     getupperbound(p_fr) > rate_a && setupperbound(p_fr, rate_a)
 end
 
 "Do nothing, this model is symmetric"
-function constraint_thermal_limit_to{T <: AbstractDCPForm}(pm::GenericPowerModel{T}, n::Int, t_idx, rate_a)
+function constraint_thermal_limit_to(pm::GenericPowerModel{T}, n::Int, t_idx, rate_a) where T <: AbstractDCPForm
 end
 
 ""
-function add_bus_voltage_setpoint{T <: AbstractDCPForm}(sol, pm::GenericPowerModel{T})
+function add_bus_voltage_setpoint(sol, pm::GenericPowerModel{T}) where T <: AbstractDCPForm
     add_setpoint(sol, pm, "bus", "vm", :vm; default_value = (item) -> 1)
     add_setpoint(sol, pm, "bus", "va", :va)
 end
 
 ""
-function variable_voltage_on_off{T <: AbstractDCPForm}(pm::GenericPowerModel{T}, n::Int=pm.cnw; kwargs...)
+function variable_voltage_on_off(pm::GenericPowerModel{T}, n::Int=pm.cnw; kwargs...) where T <: AbstractDCPForm
     variable_voltage_angle(pm, n; kwargs...)
 end
 
 "do nothing, this model does not have complex voltage variables"
-function constraint_voltage_on_off{T <: AbstractDCPForm}(pm::GenericPowerModel{T}, n::Int)
+function constraint_voltage_on_off(pm::GenericPowerModel{T}, n::Int) where T <: AbstractDCPForm
 end
 
 "`-b*(t[f_bus] - t[t_bus] + t_min*(1-branch_z[i])) <= p[f_idx] <= -b*(t[f_bus] - t[t_bus] + t_max*(1-branch_z[i]))`"
-function constraint_ohms_yt_from_on_off{T <: AbstractDCPForm}(pm::GenericPowerModel{T}, n::Int, i, f_bus, t_bus, f_idx, t_idx, g, b, c, tr, ti, tm, t_min, t_max)
+function constraint_ohms_yt_from_on_off(pm::GenericPowerModel{T}, n::Int, i, f_bus, t_bus, f_idx, t_idx, g, b, c, tr, ti, tm, t_min, t_max) where T <: AbstractDCPForm
     p_fr = pm.var[:nw][n][:p][f_idx]
     va_fr = pm.var[:nw][n][:va][f_bus]
     va_to = pm.var[:nw][n][:va][t_bus]
@@ -183,7 +183,7 @@ function constraint_ohms_yt_from_on_off{T <: AbstractDCPForm}(pm::GenericPowerMo
 end
 
 "Do nothing, this model is symmetric"
-function constraint_ohms_yt_to_on_off{T <: AbstractDCPForm}(pm::GenericPowerModel{T}, n::Int, i, f_bus, t_bus, f_idx, t_idx, g, b, c, tr, ti, tm, t_min, t_max)
+function constraint_ohms_yt_to_on_off(pm::GenericPowerModel{T}, n::Int, i, f_bus, t_bus, f_idx, t_idx, g, b, c, tr, ti, tm, t_min, t_max) where T <: AbstractDCPForm
 end
 
 """
@@ -193,7 +193,7 @@ Generic on/off thermal limit constraint
 -rate_a*branch_z[i] <= p[f_idx] <=  rate_a*branch_z[i]
 ```
 """
-function constraint_thermal_limit_from_on_off{T <: AbstractDCPForm}(pm::GenericPowerModel{T}, n::Int, i, f_idx, rate_a)
+function constraint_thermal_limit_from_on_off(pm::GenericPowerModel{T}, n::Int, i, f_idx, rate_a) where T <: AbstractDCPForm
     p_fr = pm.var[:nw][n][:p][f_idx]
     z = pm.var[:nw][n][:branch_z][i]
 
@@ -208,7 +208,7 @@ Generic on/off thermal limit constraint
 -rate_a*branch_ne[i] <= p_ne[f_idx] <=  rate_a*branch_ne[i]
 ```
 """
-function constraint_thermal_limit_from_ne{T <: AbstractDCPForm}(pm::GenericPowerModel{T}, n::Int, i, f_idx, rate_a)
+function constraint_thermal_limit_from_ne(pm::GenericPowerModel{T}, n::Int, i, f_idx, rate_a) where T <: AbstractDCPForm
     p_fr = pm.var[:nw][n][:p_ne][f_idx]
     z = pm.var[:nw][n][:branch_ne][i]
 
@@ -217,15 +217,15 @@ function constraint_thermal_limit_from_ne{T <: AbstractDCPForm}(pm::GenericPower
 end
 
 "nothing to do, from handles both sides"
-function constraint_thermal_limit_to_on_off{T <: AbstractDCPForm}(pm::GenericPowerModel{T}, n::Int, i, t_idx, rate_a)
+function constraint_thermal_limit_to_on_off(pm::GenericPowerModel{T}, n::Int, i, t_idx, rate_a) where T <: AbstractDCPForm
 end
 
 "nothing to do, from handles both sides"
-function constraint_thermal_limit_to_ne{T <: AbstractDCPForm}(pm::GenericPowerModel{T}, n::Int, i, t_idx, rate_a)
+function constraint_thermal_limit_to_ne(pm::GenericPowerModel{T}, n::Int, i, t_idx, rate_a) where T <: AbstractDCPForm
 end
 
 "`angmin*branch_z[i] + t_min*(1-branch_z[i]) <= t[f_bus] - t[t_bus] <= angmax*branch_z[i] + t_max*(1-branch_z[i])`"
-function constraint_voltage_angle_difference_on_off{T <: AbstractDCPForm}(pm::GenericPowerModel{T}, n::Int, i, f_bus, t_bus, angmin, angmax, t_min, t_max)
+function constraint_voltage_angle_difference_on_off(pm::GenericPowerModel{T}, n::Int, i, f_bus, t_bus, angmin, angmax, t_min, t_max) where T <: AbstractDCPForm
     va_fr = pm.var[:nw][n][:va][f_bus]
     va_to = pm.var[:nw][n][:va][t_bus]
     z = pm.var[:nw][n][:branch_z][i]
@@ -235,7 +235,7 @@ function constraint_voltage_angle_difference_on_off{T <: AbstractDCPForm}(pm::Ge
 end
 
 "`angmin*branch_ne[i] + t_min*(1-branch_ne[i]) <= t[f_bus] - t[t_bus] <= angmax*branch_ne[i] + t_max*(1-branch_ne[i])`"
-function constraint_voltage_angle_difference_ne{T <: AbstractDCPForm}(pm::GenericPowerModel{T}, n::Int, i, f_bus, t_bus, angmin, angmax, t_min, t_max)
+function constraint_voltage_angle_difference_ne(pm::GenericPowerModel{T}, n::Int, i, f_bus, t_bus, angmin, angmax, t_min, t_max) where T <: AbstractDCPForm
     va_fr = pm.var[:nw][n][:va][f_bus]
     va_to = pm.var[:nw][n][:va][t_bus]
     z = pm.var[:nw][n][:branch_ne][i]
@@ -259,19 +259,19 @@ const DCPLLPowerModel = GenericPowerModel{StandardDCPLLForm}
 DCPLLPowerModel(data::Dict{String,Any}; kwargs...) = GenericPowerModel(data, StandardDCPLLForm; kwargs...)
 
 "`sum(p[a] for a in bus_arcs) + sum(p_dc[a_dc] for a_dc in bus_arcs_dc)== sum(pg[g] for g in bus_gens) - pd - gs*1.0^2`"
-function constraint_kcl_shunt{T <: AbstractDCPLLForm}(pm::GenericPowerModel{T}, n::Int, i, bus_arcs, bus_arcs_dc, bus_gens, pd, qd, gs, bs)
+function constraint_kcl_shunt(pm::GenericPowerModel{T}, n::Int, i, bus_arcs, bus_arcs_dc, bus_gens, pd, qd, gs, bs) where T <: AbstractDCPLLForm
     pg = pm.var[:nw][n][:pg]
     p = pm.var[:nw][n][:p]
     p_dc = pm.var[:nw][n][:p_dc]
 
-    @constraint(pm.model, sum(p[a] for a in bus_arcs) + sum(p_dc[a_dc] for a_dc in bus_arcs_dc) == sum(pg[g] for g in bus_gens) - pd - gs*1.0^2)
+    @constraint(pm.model, sum(p[a] for a in bus_arcs) + sum(p_dc[a_dc] for a_dc in bus_arcs_dc) == sum(pg[g] for g in bus_gens) - pd - gs*1.0^2i)
 end
 
 
 """
 Creates Ohms constraints (yt post fix indicates that Y and T values are in rectangular form)
 """
-function constraint_ohms_yt_from{T <: AbstractDCPLLForm}(pm::GenericPowerModel{T}, n::Int, f_bus, t_bus, f_idx, t_idx, g, b, c, tr, ti, tm)
+function constraint_ohms_yt_from(pm::GenericPowerModel{T}, n::Int, f_bus, t_bus, f_idx, t_idx, g, b, c, tr, ti, tm) where T <: AbstractDCPLLForm
     p_fr = pm.var[:nw][n][:p][f_idx]
     p_to = pm.var[:nw][n][:p][t_idx]
     va_fr = pm.var[:nw][n][:va][f_bus]
@@ -283,7 +283,7 @@ end
 """
 Creates Ohms constraints (yt post fix indicates that Y and T values are in rectangular form)
 """
-function constraint_ohms_yt_to{T <: AbstractDCPLLForm}(pm::GenericPowerModel{T}, n::Int, f_bus, t_bus, f_idx, t_idx, g, b, c, tr, ti, tm)
+function constraint_ohms_yt_to(pm::GenericPowerModel{T}, n::Int, f_bus, t_bus, f_idx, t_idx, g, b, c, tr, ti, tm) where T <: AbstractDCPLLForm
     p_fr = pm.var[:nw][n][:p][f_idx]
     p_to = pm.var[:nw][n][:p][t_idx]
     va_fr = pm.var[:nw][n][:va][f_bus]
@@ -295,7 +295,7 @@ end
 
 """
 """
-function constraint_ohms_yt_from_on_off{T <: AbstractDCPLLForm}(pm::GenericPowerModel{T}, n::Int, i, f_bus, t_bus, f_idx, t_idx, g, b, c, tr, ti, tm, t_min, t_max)
+function constraint_ohms_yt_from_on_off(pm::GenericPowerModel{T}, n::Int, i, f_bus, t_bus, f_idx, t_idx, g, b, c, tr, ti, tm, t_min, t_max) where T <: AbstractDCPLLForm
     p_fr = pm.var[:nw][n][:p][f_idx]
     p_to = pm.var[:nw][n][:p][t_idx]
     va_fr = pm.var[:nw][n][:va][f_bus]
@@ -308,7 +308,7 @@ end
 
 """
 """
-function constraint_ohms_yt_to_on_off{T <: AbstractDCPLLForm}(pm::GenericPowerModel{T}, n::Int, i, f_bus, t_bus, f_idx, t_idx, g, b, c, tr, ti, tm, t_min, t_max)
+function constraint_ohms_yt_to_on_off(pm::GenericPowerModel{T}, n::Int, i, f_bus, t_bus, f_idx, t_idx, g, b, c, tr, ti, tm, t_min, t_max) where T <: AbstractDCPLLForm
     p_fr = pm.var[:nw][n][:p][f_idx]
     p_to = pm.var[:nw][n][:p][t_idx]
     va_fr = pm.var[:nw][n][:va][f_bus]
@@ -324,7 +324,7 @@ end
 
 """
 """
-function constraint_ohms_yt_from_ne{T <: AbstractDCPLLForm}(pm::GenericPowerModel{T}, n::Int, i, f_bus, t_bus, f_idx, t_idx, g, b, c, tr, ti, tm, t_min, t_max)
+function constraint_ohms_yt_from_ne(pm::GenericPowerModel{T}, n::Int, i, f_bus, t_bus, f_idx, t_idx, g, b, c, tr, ti, tm, t_min, t_max) where T <: AbstractDCPLLForm
     p_fr = pm.var[:nw][n][:p_ne][f_idx]
     p_to = pm.var[:nw][n][:p_ne][t_idx]
     va_fr = pm.var[:nw][n][:va][f_bus]
@@ -337,7 +337,7 @@ end
 
 """
 """
-function constraint_ohms_yt_to_ne{T <: AbstractDCPLLForm}(pm::GenericPowerModel{T}, n::Int, i, f_bus, t_bus, f_idx, t_idx, g, b, c, tr, ti, tm, t_min, t_max)
+function constraint_ohms_yt_to_ne(pm::GenericPowerModel{T}, n::Int, i, f_bus, t_bus, f_idx, t_idx, g, b, c, tr, ti, tm, t_min, t_max) where T <: AbstractDCPLLForm
     p_fr = pm.var[:nw][n][:p_ne][f_idx]
     p_to = pm.var[:nw][n][:p_ne][t_idx]
     va_fr = pm.var[:nw][n][:va][f_bus]
@@ -352,7 +352,7 @@ end
 
 
 "`-rate_a*branch_z[i] <= p[t_idx] <= rate_a*branch_z[i]`"
-function constraint_thermal_limit_to_on_off{T <: AbstractDCPLLForm}(pm::GenericPowerModel{T}, n::Int, i, t_idx, rate_a)
+function constraint_thermal_limit_to_on_off(pm::GenericPowerModel{T}, n::Int, i, t_idx, rate_a) where T <: AbstractDCPLLForm
     p_to = pm.var[:nw][n][:p][t_idx]
     z = pm.var[:nw][n][:branch_z][i]
 

--- a/src/form/shared.jl
+++ b/src/form/shared.jl
@@ -22,7 +22,7 @@ AbstractWRForms = Union{AbstractACTForm, AbstractWRForm, AbstractWRMForm}
 AbstractPForms = Union{AbstractACPForm, AbstractACTForm, AbstractDCPForm}
 
 "`t[ref_bus] == 0`"
-function constraint_theta_ref{T <: AbstractPForms}(pm::GenericPowerModel{T}, n::Int, i::Int)
+function constraint_theta_ref(pm::GenericPowerModel{T}, n::Int, i::Int) where T <: AbstractPForms
     @constraint(pm.model, pm.var[:nw][n][:va][i] == 0)
 end
 
@@ -32,7 +32,7 @@ t[f_bus] - t[t_bus] <= angmax
 t[f_bus] - t[t_bus] >= angmin
 ```
 """
-function constraint_voltage_angle_difference{T <: AbstractPForms}(pm::GenericPowerModel{T}, n::Int, f_bus, t_bus, angmin, angmax)
+function constraint_voltage_angle_difference(pm::GenericPowerModel{T}, n::Int, f_bus, t_bus, angmin, angmax) where T <: AbstractPForms
     va_fr = pm.var[:nw][n][:va][f_bus]
     va_to = pm.var[:nw][n][:va][t_bus]
 
@@ -41,14 +41,14 @@ function constraint_voltage_angle_difference{T <: AbstractPForms}(pm::GenericPow
 end
 
 
-function constraint_voltage_magnitude_setpoint{T <: AbstractWRForms}(pm::GenericPowerModel{T}, n::Int, i, vm)
+function constraint_voltage_magnitude_setpoint(pm::GenericPowerModel{T}, n::Int, i, vm) where T <: AbstractWRForms
     w = pm.var[:nw][n][:w][i]
 
     @constraint(pm.model, w == vm^2)
 end
 
 "Do nothing, no way to represent this in these variables"
-function constraint_theta_ref{T <: AbstractWRForms}(pm::GenericPowerModel{T}, n::Int, ref_bus::Int)
+function constraint_theta_ref(pm::GenericPowerModel{T}, n::Int, ref_bus::Int) where T <: AbstractWRForms
 end
 
 
@@ -58,7 +58,7 @@ sum(p[a] for a in bus_arcs) + sum(p_dc[a_dc] for a_dc in bus_arcs_dc) == sum(pg[
 sum(q[a] for a in bus_arcs) + sum(q_dc[a_dc] for a_dc in bus_arcs_dc) == sum(qg[g] for g in bus_gens) - qd + bs*w[i]
 ```
 """
-function constraint_kcl_shunt{T <: AbstractWRForms}(pm::GenericPowerModel{T}, n::Int, i, bus_arcs, bus_arcs_dc, bus_gens, pd, qd, gs, bs)
+function constraint_kcl_shunt(pm::GenericPowerModel{T}, n::Int, i, bus_arcs, bus_arcs_dc, bus_gens, pd, qd, gs, bs) where T <: AbstractWRForms
     w = pm.var[:nw][n][:w][i]
     pg = pm.var[:nw][n][:pg]
     qg = pm.var[:nw][n][:qg]
@@ -78,7 +78,7 @@ sum(p[a] for a in bus_arcs) + sum(p_ne[a] for a in bus_arcs_ne) + sum(p_dc[a_dc]
 sum(q[a] for a in bus_arcs) + sum(q_ne[a] for a in bus_arcs_ne) + sum(q_dc[a_dc] for a_dc in bus_arcs_dc) == sum(qg[g] for g in bus_gens) - qd + bs*w[i]
 ```
 """
-function constraint_kcl_shunt_ne{T <: AbstractWRForms}(pm::GenericPowerModel{T}, n::Int, i, bus_arcs, bus_arcs_dc, bus_arcs_ne, bus_gens, pd, qd, gs, bs)
+function constraint_kcl_shunt_ne(pm::GenericPowerModel{T}, n::Int, i, bus_arcs, bus_arcs_dc, bus_arcs_ne, bus_gens, pd, qd, gs, bs) where T <: AbstractWRForms
     w = pm.var[:nw][n][:w][i]
     pg = pm.var[:nw][n][:pg]
     qg = pm.var[:nw][n][:qg]
@@ -97,7 +97,7 @@ end
 """
 Creates Ohms constraints (yt post fix indicates that Y and T values are in rectangular form)
 """
-function constraint_ohms_yt_from{T <: AbstractWRForms}(pm::GenericPowerModel{T}, n::Int, f_bus, t_bus, f_idx, t_idx, g, b, c, tr, ti, tm)
+function constraint_ohms_yt_from(pm::GenericPowerModel{T}, n::Int, f_bus, t_bus, f_idx, t_idx, g, b, c, tr, ti, tm) where T <: AbstractWRForms
     p_fr = pm.var[:nw][n][:p][f_idx]
     q_fr = pm.var[:nw][n][:q][f_idx]
     w_fr = pm.var[:nw][n][:w][f_bus]
@@ -112,7 +112,7 @@ end
 """
 Creates Ohms constraints (yt post fix indicates that Y and T values are in rectangular form)
 """
-function constraint_ohms_yt_to{T <: AbstractWRForms}(pm::GenericPowerModel{T}, n::Int, f_bus, t_bus, f_idx, t_idx, g, b, c, tr, ti, tm)
+function constraint_ohms_yt_to(pm::GenericPowerModel{T}, n::Int, f_bus, t_bus, f_idx, t_idx, g, b, c, tr, ti, tm) where T <: AbstractWRForms
     q_to = pm.var[:nw][n][:q][t_idx]
     p_to = pm.var[:nw][n][:p][t_idx]
     w_to = pm.var[:nw][n][:w][t_bus]
@@ -125,7 +125,7 @@ end
 
 
 ""
-function constraint_voltage_angle_difference{T <: AbstractWRForms}(pm::GenericPowerModel{T}, n::Int, f_bus, t_bus, angmin, angmax)
+function constraint_voltage_angle_difference(pm::GenericPowerModel{T}, n::Int, f_bus, t_bus, angmin, angmax) where T <: AbstractWRForms
     w_fr = pm.var[:nw][n][:w][f_bus]
     w_to = pm.var[:nw][n][:w][t_bus]
     wr = pm.var[:nw][n][:wr][(f_bus, t_bus)]
@@ -138,7 +138,7 @@ end
 
 
 ""
-function add_bus_voltage_setpoint{T <: AbstractWRForms}(sol, pm::GenericPowerModel{T})
+function add_bus_voltage_setpoint(sol, pm::GenericPowerModel{T}) where T <: AbstractWRForms
     add_setpoint(sol, pm, "bus", "vm", :w; scale = (x,item) -> sqrt(x))
     # What should the default value be?
     #add_setpoint(sol, pm, "bus", "va", :va; default_value = 0)

--- a/src/form/wr.jl
+++ b/src/form/wr.jl
@@ -4,10 +4,10 @@ export
     QCWRTriPowerModel, QCWRTriForm
 
 ""
-@compat abstract type AbstractWRForm <: AbstractPowerFormulation end
+abstract type AbstractWRForm <: AbstractPowerFormulation end
 
 ""
-@compat abstract type SOCWRForm <: AbstractWRForm end
+abstract type SOCWRForm <: AbstractWRForm end
 
 ""
 const SOCWRPowerModel = GenericPowerModel{SOCWRForm}
@@ -325,7 +325,7 @@ end
 
 
 ""
-@compat abstract type QCWRForm <: AbstractWRForm end
+abstract type QCWRForm <: AbstractWRForm end
 
 ""
 const QCWRPowerModel = GenericPowerModel{QCWRForm}
@@ -718,7 +718,7 @@ end
 
 
 ""
-@compat abstract type QCWRTriForm <: QCWRForm end
+abstract type QCWRTriForm <: QCWRForm end
 
 ""
 const QCWRTriPowerModel = GenericPowerModel{QCWRTriForm}

--- a/src/form/wr.jl
+++ b/src/form/wr.jl
@@ -16,13 +16,13 @@ const SOCWRPowerModel = GenericPowerModel{SOCWRForm}
 SOCWRPowerModel(data::Dict{String,Any}; kwargs...) = GenericPowerModel(data, SOCWRForm; kwargs...)
 
 ""
-function variable_voltage{T <: AbstractWRForm}(pm::GenericPowerModel{T}, n::Int=pm.cnw; kwargs...)
+function variable_voltage(pm::GenericPowerModel{T}, n::Int=pm.cnw; kwargs...) where T <: AbstractWRForm
     variable_voltage_magnitude_sqr(pm, n; kwargs...)
     variable_voltage_product(pm, n; kwargs...)
 end
 
 ""
-function constraint_voltage{T <: AbstractWRForm}(pm::GenericPowerModel{T}, n::Int)
+function constraint_voltage(pm::GenericPowerModel{T}, n::Int) where T <: AbstractWRForm
     w = pm.var[:nw][n][:w]
     wr = pm.var[:nw][n][:wr]
     wi = pm.var[:nw][n][:wi]
@@ -41,7 +41,7 @@ p[f_idx] == g/tm*w_fr_ne[i] + (-g*tr+b*ti)/tm*(wr_ne[i]) + (-b*tr-g*ti)/tm*(wi_n
 q[f_idx] == -(b+c/2)/tm*w_fr_ne[i] - (-b*tr-g*ti)/tm*(wr_ne[i]) + (-g*tr+b*ti)/tm*(wi_ne[i])
 ```
 """
-function constraint_ohms_yt_from_ne{T <: AbstractWRForm}(pm::GenericPowerModel{T}, n::Int, i, f_bus, t_bus, f_idx, t_idx, g, b, c, tr, ti, tm, t_min, t_max)
+function constraint_ohms_yt_from_ne(pm::GenericPowerModel{T}, n::Int, i, f_bus, t_bus, f_idx, t_idx, g, b, c, tr, ti, tm, t_min, t_max) where T <: AbstractWRForm
     p_fr = pm.var[:nw][n][:p_ne][f_idx]
     q_fr = pm.var[:nw][n][:q_ne][f_idx]
     w_fr = pm.var[:nw][n][:w_fr_ne][i]
@@ -60,7 +60,7 @@ p[t_idx] == g*w_to_ne[i] + (-g*tr-b*ti)/tm*(wr_ne[i]) + (-b*tr+g*ti)/tm*(-wi_ne[
 q[t_idx] == -(b+c/2)*w_to_ne[i] - (-b*tr+g*ti)/tm*(wr_ne[i]) + (-g*tr-b*ti)/tm*(-wi_ne[i])
 ```
 """
-function constraint_ohms_yt_to_ne{T <: AbstractWRForm}(pm::GenericPowerModel{T}, n::Int, i, f_bus, t_bus, f_idx, t_idx, g, b, c, tr, ti, tm, t_min, t_max)
+function constraint_ohms_yt_to_ne(pm::GenericPowerModel{T}, n::Int, i, f_bus, t_bus, f_idx, t_idx, g, b, c, tr, ti, tm, t_min, t_max) where T <: AbstractWRForm
     p_to = pm.var[:nw][n][:p_ne][t_idx]
     q_to = pm.var[:nw][n][:q_ne][t_idx]
     w_to = pm.var[:nw][n][:w_to_ne][i]
@@ -72,7 +72,7 @@ function constraint_ohms_yt_to_ne{T <: AbstractWRForm}(pm::GenericPowerModel{T},
 end
 
 ""
-function variable_voltage_on_off{T <: AbstractWRForm}(pm::GenericPowerModel{T}, n::Int=pm.cnw; kwargs...)
+function variable_voltage_on_off(pm::GenericPowerModel{T}, n::Int=pm.cnw; kwargs...) where T <: AbstractWRForm
     variable_voltage_magnitude_sqr(pm, n; kwargs...)
     variable_voltage_magnitude_sqr_from_on_off(pm, n; kwargs...)
     variable_voltage_magnitude_sqr_to_on_off(pm, n; kwargs...)
@@ -81,7 +81,7 @@ function variable_voltage_on_off{T <: AbstractWRForm}(pm::GenericPowerModel{T}, 
 end
 
 ""
-function constraint_voltage_on_off{T <: AbstractWRForm}(pm::GenericPowerModel{T}, n::Int)
+function constraint_voltage_on_off(pm::GenericPowerModel{T}, n::Int) where T <: AbstractWRForm
     w = pm.var[:nw][n][:w]
     wr = pm.var[:nw][n][:wr]
     wi = pm.var[:nw][n][:wi]
@@ -102,7 +102,7 @@ function constraint_voltage_on_off{T <: AbstractWRForm}(pm::GenericPowerModel{T}
 end
 
 ""
-function constraint_voltage_ne{T <: AbstractWRForm}(pm::GenericPowerModel{T}, n::Int)
+function constraint_voltage_ne(pm::GenericPowerModel{T}, n::Int) where T <: AbstractWRForm
     buses = pm.ref[:nw][n][:bus]
     branches = pm.ref[:nw][n][:ne_branch]
 
@@ -137,7 +137,7 @@ end
 
 
 ""
-function constraint_voltage_magnitude_from_on_off{T <: AbstractWRForm}(pm::GenericPowerModel{T}, n::Int)
+function constraint_voltage_magnitude_from_on_off(pm::GenericPowerModel{T}, n::Int) where T <: AbstractWRForm
     buses = pm.ref[:nw][n][:bus]
     branches = pm.ref[:nw][n][:branch]
 
@@ -151,7 +151,7 @@ function constraint_voltage_magnitude_from_on_off{T <: AbstractWRForm}(pm::Gener
 end
 
 ""
-function constraint_voltage_magnitude_to_on_off{T <: AbstractWRForm}(pm::GenericPowerModel{T}, n::Int)
+function constraint_voltage_magnitude_to_on_off(pm::GenericPowerModel{T}, n::Int) where T <: AbstractWRForm
     buses = pm.ref[:nw][n][:bus]
     branches = pm.ref[:nw][n][:branch]
 
@@ -166,7 +166,7 @@ end
 
 
 ""
-function constraint_voltage_magnitude_sqr_from_on_off{T <: AbstractWRForm}(pm::GenericPowerModel{T}, n::Int)
+function constraint_voltage_magnitude_sqr_from_on_off(pm::GenericPowerModel{T}, n::Int) where T <: AbstractWRForm
     buses = pm.ref[:nw][n][:bus]
     branches = pm.ref[:nw][n][:branch]
 
@@ -180,7 +180,7 @@ function constraint_voltage_magnitude_sqr_from_on_off{T <: AbstractWRForm}(pm::G
 end
 
 ""
-function constraint_voltage_magnitude_sqr_to_on_off{T <: AbstractWRForm}(pm::GenericPowerModel{T}, n::Int)
+function constraint_voltage_magnitude_sqr_to_on_off(pm::GenericPowerModel{T}, n::Int) where T <: AbstractWRForm
     buses = pm.ref[:nw][n][:bus]
     branches = pm.ref[:nw][n][:branch]
 
@@ -194,7 +194,7 @@ function constraint_voltage_magnitude_sqr_to_on_off{T <: AbstractWRForm}(pm::Gen
 end
 
 ""
-function constraint_voltage_product_on_off{T <: AbstractWRForm}(pm::GenericPowerModel{T}, n::Int)
+function constraint_voltage_product_on_off(pm::GenericPowerModel{T}, n::Int) where T <: AbstractWRForm
     wr_min, wr_max, wi_min, wi_max = calc_voltage_product_bounds(pm.ref[:nw][n][:buspairs])
 
     bi_bp = Dict([(i, (b["f_bus"], b["t_bus"])) for (i,b) in pm.ref[:nw][n][:branch]])
@@ -219,7 +219,7 @@ p[f_idx] ==        g/tm*w_fr[i] + (-g*tr+b*ti)/tm*(wr[i]) + (-b*tr-g*ti)/tm*(wi[
 q[f_idx] == -(b+c/2)/tm*w_fr[i] - (-b*tr-g*ti)/tm*(wr[i]) + (-g*tr+b*ti)/tm*(wi[i])
 ```
 """
-function constraint_ohms_yt_from_on_off{T <: AbstractWRForm}(pm::GenericPowerModel{T}, n::Int, i, f_bus, t_bus, f_idx, t_idx, g, b, c, tr, ti, tm, t_min, t_max)
+function constraint_ohms_yt_from_on_off(pm::GenericPowerModel{T}, n::Int, i, f_bus, t_bus, f_idx, t_idx, g, b, c, tr, ti, tm, t_min, t_max) where T <: AbstractWRForm
     p_fr = pm.var[:nw][n][:p][f_idx]
     q_fr = pm.var[:nw][n][:q][f_idx]
     w_fr = pm.var[:nw][n][:w_fr][i]
@@ -238,7 +238,7 @@ p[t_idx] ==        g*w_to[i] + (-g*tr-b*ti)/tm*(wr[i]) + (-b*tr+g*ti)/tm*(-wi[i]
 q[t_idx] == -(b+c/2)*w_to[i] - (-b*tr+g*ti)/tm*(wr[i]) + (-g*tr-b*ti)/tm*(-wi[i])
 ```
 """
-function constraint_ohms_yt_to_on_off{T <: AbstractWRForm}(pm::GenericPowerModel{T}, n::Int, i, f_bus, t_bus, f_idx, t_idx, g, b, c, tr, ti, tm, t_min, t_max)
+function constraint_ohms_yt_to_on_off(pm::GenericPowerModel{T}, n::Int, i, f_bus, t_bus, f_idx, t_idx, g, b, c, tr, ti, tm, t_min, t_max) where T <: AbstractWRForm
     p_to = pm.var[:nw][n][:p][t_idx]
     q_to = pm.var[:nw][n][:q][t_idx]
     w_to = pm.var[:nw][n][:w_to][i]
@@ -250,7 +250,7 @@ function constraint_ohms_yt_to_on_off{T <: AbstractWRForm}(pm::GenericPowerModel
 end
 
 "`angmin*wr[i] <= wi[i] <= angmax*wr[i]`"
-function constraint_voltage_angle_difference_on_off{T <: AbstractWRForm}(pm::GenericPowerModel{T}, n::Int, i, f_bus, t_bus, angmin, angmax, t_min, t_max)
+function constraint_voltage_angle_difference_on_off(pm::GenericPowerModel{T}, n::Int, i, f_bus, t_bus, angmin, angmax, t_min, t_max) where T <: AbstractWRForm
     wr = pm.var[:nw][n][:wr][i]
     wi = pm.var[:nw][n][:wi][i]
 
@@ -259,7 +259,7 @@ function constraint_voltage_angle_difference_on_off{T <: AbstractWRForm}(pm::Gen
 end
 
 "`angmin*wr_ne[i] <= wi_ne[i] <= angmax*wr_ne[i]`"
-function constraint_voltage_angle_difference_ne{T <: AbstractWRForm}(pm::GenericPowerModel{T}, n::Int, i, f_bus, t_bus, angmin, angmax, t_min, t_max)
+function constraint_voltage_angle_difference_ne(pm::GenericPowerModel{T}, n::Int, i, f_bus, t_bus, angmin, angmax, t_min, t_max) where T <: AbstractWRForm
     wr = pm.var[:nw][n][:wr_ne][i]
     wi = pm.var[:nw][n][:wi_ne][i]
 
@@ -268,14 +268,14 @@ function constraint_voltage_angle_difference_ne{T <: AbstractWRForm}(pm::Generic
 end
 
 ""
-function variable_voltage_ne{T <: AbstractWRForm}(pm::GenericPowerModel{T}, n::Int=pm.cnw; kwargs...)
+function variable_voltage_ne(pm::GenericPowerModel{T}, n::Int=pm.cnw; kwargs...) where T <: AbstractWRForm
     variable_voltage_magnitude_sqr_from_ne(pm, n; kwargs...)
     variable_voltage_magnitude_sqr_to_ne(pm, n; kwargs...)
     variable_voltage_product_ne(pm, n; kwargs...)
 end
 
 ""
-function variable_voltage_magnitude_sqr_from_ne{T <: AbstractWRForm}(pm::GenericPowerModel{T}, n::Int=pm.cnw)
+function variable_voltage_magnitude_sqr_from_ne(pm::GenericPowerModel{T}, n::Int=pm.cnw) where T <: AbstractWRForm
     buses = pm.ref[:nw][n][:bus]
     branches = pm.ref[:nw][n][:ne_branch]
 
@@ -288,10 +288,10 @@ function variable_voltage_magnitude_sqr_from_ne{T <: AbstractWRForm}(pm::Generic
 end
 
 ""
-function variable_voltage_magnitude_sqr_to_ne{T <: AbstractWRForm}(pm::GenericPowerModel{T}, n::Int=pm.cnw)
+function variable_voltage_magnitude_sqr_to_ne(pm::GenericPowerModel{T}, n::Int=pm.cnw) where T <: AbstractWRForm
     buses = pm.ref[:nw][n][:bus]
     branches = pm.ref[:nw][n][:ne_branch]
-    
+
     pm.var[:nw][n][:w_to_ne] = @variable(pm.model,
         [i in keys(pm.ref[:nw][n][:ne_branch])], basename="$(n)_w_to_ne",
         lowerbound = 0,
@@ -301,21 +301,21 @@ function variable_voltage_magnitude_sqr_to_ne{T <: AbstractWRForm}(pm::GenericPo
 end
 
 ""
-function variable_voltage_product_ne{T <: AbstractWRForm}(pm::GenericPowerModel{T}, n::Int=pm.cnw)
+function variable_voltage_product_ne(pm::GenericPowerModel{T}, n::Int=pm.cnw) where T <: AbstractWRForm
     wr_min, wr_max, wi_min, wi_max = calc_voltage_product_bounds(pm.ref[:nw][n][:ne_buspairs])
     bi_bp = Dict([(i, (b["f_bus"], b["t_bus"])) for (i,b) in pm.ref[:nw][n][:ne_branch]])
-    
+
     pm.var[:nw][n][:wr_ne] = @variable(pm.model,
         [b in keys(pm.ref[:nw][n][:ne_branch])], basename="$(n)_wr_ne",
-        lowerbound = min(0, wr_min[bi_bp[b]]), 
+        lowerbound = min(0, wr_min[bi_bp[b]]),
         upperbound = max(0, wr_max[bi_bp[b]]),
         start = getstart(pm.ref[:nw][n][:ne_buspairs], bi_bp[b], "wr_start", 1.0)
     )
-    
+
     pm.var[:nw][n][:wi_ne] = @variable(pm.model,
         [b in keys(pm.ref[:nw][n][:ne_branch])], basename="$(n)_wi_ne",
         lowerbound = min(0, wi_min[bi_bp[b]]),
-        upperbound = max(0, wi_max[bi_bp[b]]), 
+        upperbound = max(0, wi_max[bi_bp[b]]),
         start = getstart(pm.ref[:nw][n][:ne_buspairs], bi_bp[b], "wi_start")
     )
 end
@@ -337,19 +337,19 @@ end
 
 
 "Creates variables associated with differences in phase angles"
-function variable_voltage_angle_difference{T}(pm::GenericPowerModel{T}, n::Int=pm.cnw)
+function variable_voltage_angle_difference(pm::GenericPowerModel{T}, n::Int=pm.cnw) where T
     pm.var[:nw][n][:td] = @variable(pm.model,
         [bp in keys(pm.ref[:nw][n][:buspairs])], basename="$(n)_td",
         lowerbound = pm.ref[:nw][n][:buspairs][bp]["angmin"],
-        upperbound = pm.ref[:nw][n][:buspairs][bp]["angmax"], 
+        upperbound = pm.ref[:nw][n][:buspairs][bp]["angmax"],
         start = getstart(pm.ref[:nw][n][:buspairs], bp, "td_start")
     )
 end
 
 "Creates the voltage magnitude product variables"
-function variable_voltage_magnitude_product{T}(pm::GenericPowerModel{T}, n::Int=pm.cnw)
+function variable_voltage_magnitude_product(pm::GenericPowerModel{T}, n::Int=pm.cnw) where T
     buspairs = pm.ref[:nw][n][:buspairs]
-    pm.var[:nw][n][:vv] = @variable(pm.model, 
+    pm.var[:nw][n][:vv] = @variable(pm.model,
         [bp in keys(pm.ref[:nw][n][:buspairs])], basename="$(n)_vv",
         lowerbound = buspairs[bp]["vm_fr_min"]*buspairs[bp]["vm_to_min"],
         upperbound = buspairs[bp]["vm_fr_max"]*buspairs[bp]["vm_to_max"],
@@ -358,7 +358,7 @@ function variable_voltage_magnitude_product{T}(pm::GenericPowerModel{T}, n::Int=
 end
 
 ""
-function variable_cosine{T}(pm::GenericPowerModel{T}, n::Int=pm.cnw)
+function variable_cosine(pm::GenericPowerModel{T}, n::Int=pm.cnw) where T
     cos_min = Dict([(bp, -Inf) for bp in keys(pm.ref[:nw][n][:buspairs])])
     cos_max = Dict([(bp,  Inf) for bp in keys(pm.ref[:nw][n][:buspairs])])
 
@@ -387,16 +387,16 @@ end
 
 ""
 function variable_sine(pm::GenericPowerModel, n::Int=pm.cnw)
-    pm.var[:nw][n][:si] = @variable(pm.model, 
+    pm.var[:nw][n][:si] = @variable(pm.model,
         [bp in keys(pm.ref[:nw][n][:buspairs])], basename="$(n)_si",
         lowerbound = sin(pm.ref[:nw][n][:buspairs][bp]["angmin"]),
-        upperbound = sin(pm.ref[:nw][n][:buspairs][bp]["angmax"]), 
+        upperbound = sin(pm.ref[:nw][n][:buspairs][bp]["angmax"]),
         start = getstart(pm.ref[:nw][n][:buspairs], bp, "si_start")
     )
 end
 
 ""
-function variable_current_magnitude_sqr{T}(pm::GenericPowerModel{T}, n::Int=pm.cnw)
+function variable_current_magnitude_sqr(pm::GenericPowerModel{T}, n::Int=pm.cnw) where T
     buspairs = pm.ref[:nw][n][:buspairs]
     pm.var[:nw][n][:cm] = @variable(pm.model,
         cm[bp in keys(pm.ref[:nw][n][:buspairs])], basename="$(n)_cm",
@@ -407,7 +407,7 @@ function variable_current_magnitude_sqr{T}(pm::GenericPowerModel{T}, n::Int=pm.c
 end
 
 ""
-function variable_voltage{T <: QCWRForm}(pm::GenericPowerModel{T}, n::Int=pm.cnw; kwargs...)
+function variable_voltage(pm::GenericPowerModel{T}, n::Int=pm.cnw; kwargs...) where T <: QCWRForm
     variable_voltage_angle(pm, n; kwargs...)
     variable_voltage_magnitude(pm, n; kwargs...)
 
@@ -422,7 +422,7 @@ function variable_voltage{T <: QCWRForm}(pm::GenericPowerModel{T}, n::Int=pm.cnw
 end
 
 ""
-function constraint_voltage{T <: QCWRForm}(pm::GenericPowerModel{T}, n::Int)
+function constraint_voltage(pm::GenericPowerModel{T}, n::Int) where T <: QCWRForm
     v = pm.var[:nw][n][:vm]
     t = pm.var[:nw][n][:va]
 
@@ -467,7 +467,7 @@ function constraint_voltage{T <: QCWRForm}(pm::GenericPowerModel{T}, n::Int)
 end
 
 "`p[f_idx]^2 + q[f_idx]^2 <= w[f_bus]/tm*cm[f_bus,t_bus]`"
-function constraint_power_magnitude_sqr{T <: QCWRForm}(pm::GenericPowerModel{T}, n::Int, f_bus, t_bus, arc_from, tm)
+function constraint_power_magnitude_sqr(pm::GenericPowerModel{T}, n::Int, f_bus, t_bus, arc_from, tm) where T <: QCWRForm
     w_i = pm.var[:nw][n][:w][f_bus]
     p_fr = pm.var[:nw][n][:p][arc_from]
     q_fr = pm.var[:nw][n][:q][arc_from]
@@ -477,7 +477,7 @@ function constraint_power_magnitude_sqr{T <: QCWRForm}(pm::GenericPowerModel{T},
 end
 
 "`cm[f_bus,t_bus] == (g^2 + b^2)*(w[f_bus]/tm + w[t_bus] - 2*(tr*wr[f_bus,t_bus] + ti*wi[f_bus,t_bus])/tm) - c*q[f_idx] - ((c/2)/tm)^2*w[f_bus]`"
-function constraint_power_magnitude_link{T <: QCWRForm}(pm::GenericPowerModel{T}, n::Int, f_bus, t_bus, arc_from, g, b, c, tr, ti, tm)
+function constraint_power_magnitude_link(pm::GenericPowerModel{T}, n::Int, f_bus, t_bus, arc_from, g, b, c, tr, ti, tm) where T <: QCWRForm
     w_fr = pm.var[:nw][n][:w][f_bus]
     w_to = pm.var[:nw][n][:w][t_bus]
     q_fr = pm.var[:nw][n][:q][arc_from]
@@ -489,12 +489,12 @@ function constraint_power_magnitude_link{T <: QCWRForm}(pm::GenericPowerModel{T}
 end
 
 "`t[ref_bus] == 0`"
-function constraint_theta_ref{T <: QCWRForm}(pm::GenericPowerModel{T}, n::Int, i::Int)
+function constraint_theta_ref(pm::GenericPowerModel{T}, n::Int, i::Int) where T <: QCWRForm
     @constraint(pm.model, pm.var[:nw][n][:va][i] == 0)
 end
 
 ""
-function constraint_voltage_angle_difference{T <: QCWRForm}(pm::GenericPowerModel{T}, n::Int, f_bus, t_bus, angmin, angmax)
+function constraint_voltage_angle_difference(pm::GenericPowerModel{T}, n::Int, f_bus, t_bus, angmin, angmax) where T <: QCWRForm
     td = pm.var[:nw][n][:td][(f_bus, t_bus)]
 
     if getlowerbound(td) < angmin
@@ -517,7 +517,7 @@ function constraint_voltage_angle_difference{T <: QCWRForm}(pm::GenericPowerMode
 end
 
 ""
-function add_bus_voltage_setpoint{T <: QCWRForm}(sol, pm::GenericPowerModel{T})
+function add_bus_voltage_setpoint(sol, pm::GenericPowerModel{T}) where T <: QCWRForm
     add_setpoint(sol, pm, "bus", "vm", :vm)
     add_setpoint(sol, pm, "bus", "va", :va)
 end
@@ -525,7 +525,7 @@ end
 
 
 ""
-function variable_voltage_on_off{T <: QCWRForm}(pm::GenericPowerModel{T}, n::Int=pm.cnw; kwargs...)
+function variable_voltage_on_off(pm::GenericPowerModel{T}, n::Int=pm.cnw; kwargs...) where T <: QCWRForm
     variable_voltage_angle(pm, n; kwargs...)
     variable_voltage_magnitude(pm, n; kwargs...)
     variable_voltage_magnitude_from_on_off(pm, n; kwargs...)
@@ -545,7 +545,7 @@ function variable_voltage_on_off{T <: QCWRForm}(pm::GenericPowerModel{T}, n::Int
 end
 
 ""
-function variable_voltage_angle_difference_on_off{T}(pm::GenericPowerModel{T}, n::Int=pm.cnw)
+function variable_voltage_angle_difference_on_off(pm::GenericPowerModel{T}, n::Int=pm.cnw) where T
     pm.var[:nw][n][:td] = @variable(pm.model,
         [l in keys(pm.ref[:nw][n][:branch])], basename="$(n)_td",
         lowerbound = min(0, pm.ref[:nw][n][:branch][l]["angmin"]),
@@ -555,7 +555,7 @@ function variable_voltage_angle_difference_on_off{T}(pm::GenericPowerModel{T}, n
 end
 
 ""
-function variable_voltage_magnitude_product_on_off{T}(pm::GenericPowerModel{T}, n::Int=pm.cnw)
+function variable_voltage_magnitude_product_on_off(pm::GenericPowerModel{T}, n::Int=pm.cnw) where T
     vv_min = Dict([(l, pm.ref[:nw][n][:bus][branch["f_bus"]]["vmin"]*pm.ref[:nw][n][:bus][branch["t_bus"]]["vmin"]) for (l, branch) in pm.ref[:nw][n][:branch]])
     vv_max = Dict([(l, pm.ref[:nw][n][:bus][branch["f_bus"]]["vmax"]*pm.ref[:nw][n][:bus][branch["t_bus"]]["vmax"]) for (l, branch) in pm.ref[:nw][n][:branch]])
 
@@ -569,7 +569,7 @@ end
 
 
 ""
-function variable_cosine_on_off{T}(pm::GenericPowerModel{T}, n::Int=pm.cnw)
+function variable_cosine_on_off(pm::GenericPowerModel{T}, n::Int=pm.cnw) where T
     cos_min = Dict([(l, -Inf) for l in keys(pm.ref[:nw][n][:branch])])
     cos_max = Dict([(l,  Inf) for l in keys(pm.ref[:nw][n][:branch])])
 
@@ -588,17 +588,17 @@ function variable_cosine_on_off{T}(pm::GenericPowerModel{T}, n::Int=pm.cnw)
         end
     end
 
-    pm.var[:nw][n][:cs] = @variable(pm.model, 
+    pm.var[:nw][n][:cs] = @variable(pm.model,
         [l in keys(pm.ref[:nw][n][:branch])], basename="$(n)_cs",
         lowerbound = min(0, cos_min[l]),
-        upperbound = max(0, cos_max[l]), 
+        upperbound = max(0, cos_max[l]),
         start = getstart(pm.ref[:nw][n][:branch], l, "cs_start", 1.0)
     )
 end
 
 ""
 function variable_sine_on_off(pm::GenericPowerModel, n::Int=pm.cnw)
-    pm.var[:nw][n][:si] = @variable(pm.model, 
+    pm.var[:nw][n][:si] = @variable(pm.model,
         [l in keys(pm.ref[:nw][n][:branch])], basename="$(n)_si",
         lowerbound = min(0, sin(pm.ref[:nw][n][:branch][l]["angmin"])),
         upperbound = max(0, sin(pm.ref[:nw][n][:branch][l]["angmax"])),
@@ -608,7 +608,7 @@ end
 
 
 ""
-function variable_current_magnitude_sqr_on_off{T}(pm::GenericPowerModel{T}, n::Int=pm.cnw)
+function variable_current_magnitude_sqr_on_off(pm::GenericPowerModel{T}, n::Int=pm.cnw) where T
     cm_min = Dict([(l, 0) for l in keys(pm.ref[:nw][n][:branch])])
     cm_max = Dict([(l, (branch["rate_a"]*branch["tap"]/pm.ref[:nw][n][:bus][branch["f_bus"]]["vmin"])^2) for (l, branch) in pm.ref[:nw][n][:branch]])
 
@@ -622,7 +622,7 @@ end
 
 
 ""
-function constraint_voltage_on_off{T <: QCWRForm}(pm::GenericPowerModel{T}, n::Int)
+function constraint_voltage_on_off(pm::GenericPowerModel{T}, n::Int) where T <: QCWRForm
     v = pm.var[:nw][n][:vm]
     t = pm.var[:nw][n][:va]
     vm_fr = pm.var[:nw][n][:vm_fr]
@@ -687,7 +687,7 @@ end
 
 
 "`p[arc_from]^2 + q[arc_from]^2 <= w[f_bus]/tm*cm[i]`"
-function constraint_power_magnitude_sqr_on_off{T <: QCWRForm}(pm::GenericPowerModel{T}, n::Int, i, f_bus, arc_from, tm)
+function constraint_power_magnitude_sqr_on_off(pm::GenericPowerModel{T}, n::Int, i, f_bus, arc_from, tm) where T <: QCWRForm
     w = pm.var[:nw][n][:w][f_bus]
     p_fr = pm.var[:nw][n][:p][arc_from]
     q_fr = pm.var[:nw][n][:q][arc_from]
@@ -705,7 +705,7 @@ function constraint_power_magnitude_sqr_on_off{T <: QCWRForm}(pm::GenericPowerMo
 end
 
 "`cm[f_bus,t_bus] == (g^2 + b^2)*(w[f_bus]/tm + w[t_bus] - 2*(tr*wr[f_bus,t_bus] + ti*wi[f_bus,t_bus])/tm) - c*q[f_idx] - ((c/2)/tm)^2*w[f_bus]`"
-function constraint_power_magnitude_link_on_off{T <: QCWRForm}(pm::GenericPowerModel{T}, n::Int, i, arc_from, g, b, c, tr, ti, tm)
+function constraint_power_magnitude_link_on_off(pm::GenericPowerModel{T}, n::Int, i, arc_from, g, b, c, tr, ti, tm) where T <: QCWRForm
     w_fr = pm.var[:nw][n][:w_fr][i]
     w_to = pm.var[:nw][n][:w_to][i]
     q_fr = pm.var[:nw][n][:q][arc_from]
@@ -729,23 +729,23 @@ function QCWRTriPowerModel(data::Dict{String,Any}; kwargs...)
 end
 
 ""
-function variable_voltage_magnitude_product{T <: QCWRTriForm}(pm::GenericPowerModel{T}, n::Int=pm.cnw)
+function variable_voltage_magnitude_product(pm::GenericPowerModel{T}, n::Int=pm.cnw) where T <: QCWRTriForm
     # do nothing - no lifted variables required for voltage variable product
-end 
+end
 
-"creates lambda variables for convex combination model" 
-function variable_multipliers{T <: QCWRTriForm}(pm::GenericPowerModel{T}, n::Int=pm.cnw)
+"creates lambda variables for convex combination model"
+function variable_multipliers(pm::GenericPowerModel{T}, n::Int=pm.cnw) where T <: QCWRTriForm
     buspairs = pm.ref[:nw][n][:buspairs]
-    pm.var[:nw][n][:lambda_wr] = @variable(pm.model, 
+    pm.var[:nw][n][:lambda_wr] = @variable(pm.model,
         [bp in keys(pm.ref[:nw][n][:buspairs]), i=1:8], basename="$(n)_lambda",
         lowerbound = 0, upperbound = 1)
-    pm.var[:nw][n][:lambda_wi] = @variable(pm.model, 
+    pm.var[:nw][n][:lambda_wi] = @variable(pm.model,
         [bp in keys(pm.ref[:nw][n][:buspairs]), i=1:8], basename="$(n)_lambda",
         lowerbound = 0, upperbound = 1)
 end
 
 ""
-function variable_voltage{T <: QCWRTriForm}(pm::GenericPowerModel{T}, n::Int=pm.cnw; kwargs...)
+function variable_voltage(pm::GenericPowerModel{T}, n::Int=pm.cnw; kwargs...) where T <: QCWRTriForm
     variable_voltage_angle(pm, n; kwargs...)
     variable_voltage_magnitude(pm, n; kwargs...)
 
@@ -761,7 +761,7 @@ function variable_voltage{T <: QCWRTriForm}(pm::GenericPowerModel{T}, n::Int=pm.
 end
 
 ""
-function constraint_voltage{T <: QCWRTriForm}(pm::GenericPowerModel{T}, n::Int)
+function constraint_voltage(pm::GenericPowerModel{T}, n::Int) where T <: QCWRTriForm
     v = pm.var[:nw][n][:vm]
     t = pm.var[:nw][n][:va]
 

--- a/src/form/wrm.jl
+++ b/src/form/wrm.jl
@@ -15,7 +15,7 @@ SDPWRMPowerModel(data::Dict{String,Any}; kwargs...) = GenericPowerModel(data, SD
 
 
 ""
-function variable_voltage{T <: AbstractWRMForm}(pm::GenericPowerModel{T}, n::Int=pm.cnw; bounded = true)
+function variable_voltage(pm::GenericPowerModel{T}, n::Int=pm.cnw; bounded = true) where T <: AbstractWRMForm
     wr_min, wr_max, wi_min, wi_max = calc_voltage_product_bounds(pm.ref[:nw][n][:buspairs])
 
     w_index = 1:length(keys(pm.ref[:nw][n][:bus]))
@@ -80,7 +80,7 @@ end
 
 
 ""
-function constraint_voltage{T <: AbstractWRMForm}(pm::GenericPowerModel{T}, n::Int)
+function constraint_voltage(pm::GenericPowerModel{T}, n::Int) where T <: AbstractWRMForm
     WR = pm.var[:nw][n][:WR]
     WI = pm.var[:nw][n][:WI]
 

--- a/src/form/wrm.jl
+++ b/src/form/wrm.jl
@@ -2,10 +2,10 @@ export
     SDPWRMPowerModel, SDPWRMForm
 
 ""
-@compat abstract type AbstractWRMForm <: AbstractConicPowerFormulation end
+abstract type AbstractWRMForm <: AbstractConicPowerFormulation end
 
 ""
-@compat abstract type SDPWRMForm <: AbstractWRMForm end
+abstract type SDPWRMForm <: AbstractWRMForm end
 
 ""
 const SDPWRMPowerModel = GenericPowerModel{SDPWRMForm}

--- a/src/io/matlab.jl
+++ b/src/io/matlab.jl
@@ -97,7 +97,7 @@ function type_value(value_string::AbstractString)
 end
 
 "Attempts to determine the type of an array of strings extracted from a matlab file"
-function type_array{T <: AbstractString}(string_array::Vector{T})
+function type_array(string_array::Vector{T}) where T <: AbstractString
     value_string = [strip(value_string) for value_string in string_array]
 
     return if any(contains(value_string, "'") for value_string in string_array)


### PR DESCRIPTION
Requires complete drop of support for Julia v0.5, but prepares for eventual
Julia v0.7 update. Because v0.5 tests are currently allowed failures in travis, 
and will be removed if PR #219  is accepted, it has not been removed in this PR.

Addresses linter warning "Use of deprecated parameter syntax" by changing 
e.g. `function some_name{T}(var)` to `function some_name(var) where T`

Also addresses linter warning "Use of deprecated `type` syntax" which was 
deprecated in favor of `mutable struct`.