### PR TITLE
UPD: Separated Loads and Shunts from Buses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ PowerModels.jl Change Log
 - Fixed a mathematical bug when swapping the orientation of a transformer
 - Added support for parsing of PTI raw files into a Dict
 - Updated branch mathematical model and Matpower parser to support asymmetrical line charging
+- Updated KCL constraint models to account for multiple loads and shunts per bus
+- Separated loads and shunts from buses in PowerModels data structure
 
 ### v0.5.1
 - Added support for convex piecewise linear cost functions

--- a/docs/src/network-data.md
+++ b/docs/src/network-data.md
@@ -4,7 +4,7 @@
 
 Internally PowerModels utilizes a dictionary to store network data. The dictionary uses strings as key values so it can be serialized to JSON for algorithmic data exchange.
 
-The data dictionary organization and key names are designed to be consistent with the [Matpower](http://www.pserc.cornell.edu/matpower/) file format and should be familiar to power system researchers.
+The data dictionary organization and key names are designed to be consistent with the [Matpower](http://www.pserc.cornell.edu/matpower/) file format and should be familiar to power system researchers, with the exception that loads and shunts are now split into separate fields (see example below).
 
 The network data dictionary structure is roughly as follows:
 
@@ -17,8 +17,30 @@ The network data dictionary structure is roughly as follows:
     "1":{
         "index":<int>,
         "bus_type":<int>,
+        "va":<float>,
+        "vm":<float>,
+        ...
+    },
+    "2":{...},
+    ...
+},
+"load":{
+    "1":{
+        "index":<int>,
+        "load_bus":<int>,
         "pd":<float>,
         "qd":<float>,
+        ...
+    },
+    "2":{...},
+    ...
+},
+"shunt":{
+    "1":{
+        "index":<int>,
+        "shunt_bus":<int>,
+        "gs":<float>,
+        "bs":<float>,
         ...
     },
     "2":{...},
@@ -56,7 +78,7 @@ network_data = PowerModels.parse_file("nesta_case3_lmbd.m")
 display(network_data)
 ```
 
-For a detailed list of all possible parameters refer to the specification document provided with [Matpower](http://www.pserc.cornell.edu/matpower/).  
+For a detailed list of all possible parameters refer to the specification document provided with [Matpower](http://www.pserc.cornell.edu/matpower/). The exception to this is that `"load"` and `"shunt"`, containing `"pd"`, `"qd"` and `"gs"`, `"bs"`, respectively, have been added as additional fields. These values are contained in `"bus"` in the original specification.
 
 ### Noteworthy Differences from Matpower Data Files
 
@@ -93,9 +115,9 @@ opf_result = run_ac_opf(data, IpoptSolver())
 
 PowerModels.update_data(data, opf_result["solution"])
 pf_result = run_ac_pf(data, IpoptSolver())
-``` 
+```
 
-For details on all of the network data helper functions see, `src/core/data.jl`. 
+For details on all of the network data helper functions see, `src/core/data.jl`.
 
 
 ## Working with Matpower Data Files

--- a/docs/src/parser.md
+++ b/docs/src/parser.md
@@ -39,6 +39,7 @@ type_array
 build_typed_dict
 extend_case_data
 mp_data_to_pm_data
+split_loads_shunts
 ```
 
 ## PTI Data Files (PSS/E)

--- a/docs/src/quickguide.md
+++ b/docs/src/quickguide.md
@@ -58,15 +58,15 @@ run_opf("nesta_case3_lmbd.m", SOCWRPowerModel, IpoptSolver())
 ```
 
 ## Modifying Network Data
-The following example demonstrates one way to perform multiple PowerModels solves while modify the network data in Julia,
+The following example demonstrates one way to perform multiple PowerModels solves while modifing the network data in Julia,
 
 ```julia
 network_data = PowerModels.parse_file("nesta_case3_lmbd.m")
 
 run_opf(network_data, ACPPowerModel, IpoptSolver())
 
-network_data["bus"]["3"]["pd"] = 0.0
-network_data["bus"]["3"]["qd"] = 0.0
+network_data["load"]["3"]["pd"] = 0.0
+network_data["load"]["3"]["qd"] = 0.0
 
 run_opf(network_data, ACPPowerModel, IpoptSolver())
 ```

--- a/docs/src/result-data.md
+++ b/docs/src/result-data.md
@@ -22,7 +22,7 @@ At the top level the results data dictionary is structured as follows:
 
 ### Machine Data
 
-This object provides basic information about the hardware that was 
+This object provides basic information about the hardware that was
 used when the run command was called.
 
 ```json
@@ -34,7 +34,7 @@ used when the run command was called.
 
 ### Case Data
 
-This object provides basic information about the network cases that was 
+This object provides basic information about the network cases that was
 used when the run command was called.
 
 ```json
@@ -47,9 +47,9 @@ used when the run command was called.
 
 ### Solution Data
 
-The solution object provides detailed information about the solution 
-produced by the run command.  The solution is organized similarly to 
-[The Network Data Dictionary](@ref) with the same nested structure and 
+The solution object provides detailed information about the solution
+produced by the run command.  The solution is organized similarly to
+[The Network Data Dictionary](@ref) with the same nested structure and
 parameter names, when available.  A network solution most often only includes
 a small subset of the data included in the network data.
 
@@ -59,8 +59,6 @@ For example the data for a bus, `data["bus"]["1"]` is structured as follows,
 {
 "bus_i": 1,
 "bus_type": 3,
-"pd":1.0,
-"qd":0.37,
 "vm":1.0,
 "va":0.0,
 ...
@@ -76,8 +74,8 @@ A solution specifying a voltage magnitude and angle would for the same case, i.e
 }
 ```
 
-Because the data dictionary and the solution dictionary have the same structure 
-PowerModels provides an `update_data` helper function which can be used to 
+Because the data dictionary and the solution dictionary have the same structure
+PowerModels provides an `update_data` helper function which can be used to
 update a data diction with the values from a solution as follows,
 
 ```

--- a/src/core/constraint_template.jl
+++ b/src/core/constraint_template.jl
@@ -70,8 +70,16 @@ function constraint_kcl_shunt(pm::GenericPowerModel, n::Int, i::Int)
     bus_arcs = ref(pm, n, :bus_arcs, i)
     bus_arcs_dc = ref(pm, n, :bus_arcs_dc, i)
     bus_gens = ref(pm, n, :bus_gens, i)
+    bus_loads = ref(pm, n, :bus_loads, i)
+    bus_shunts = ref(pm, n, :bus_shunts, i)
 
-    constraint_kcl_shunt(pm, n, i, bus_arcs, bus_arcs_dc, bus_gens, bus["pd"], bus["qd"], bus["gs"], bus["bs"])
+    pd = Dict(k => v["pd"] for (k,v) in ref(pm, n, :load))
+    qd = Dict(k => v["qd"] for (k,v) in ref(pm, n, :load))
+
+    gs = Dict(k => v["gs"] for (k,v) in ref(pm, n, :shunt))
+    bs = Dict(k => v["bs"] for (k,v) in ref(pm, n, :shunt))
+
+    constraint_kcl_shunt(pm, n, i, bus_arcs, bus_arcs_dc, bus_gens, bus_loads, bus_shunts, pd, qd, gs, bs)
 end
 constraint_kcl_shunt(pm::GenericPowerModel, i::Int) = constraint_kcl_shunt(pm, pm.cnw, i::Int)
 
@@ -83,8 +91,16 @@ function constraint_kcl_shunt_ne(pm::GenericPowerModel, n::Int, i::Int)
     bus_arcs_dc = ref(pm, n, :bus_arcs_dc, i)
     bus_arcs_ne = ref(pm, n, :ne_bus_arcs, i)
     bus_gens = ref(pm, n, :bus_gens, i)
+    bus_loads = ref(pm, n, :bus_loads, i)
+    bus_shunts = ref(pm, n, :bus_shunts, i)
 
-    constraint_kcl_shunt_ne(pm, n, i, bus_arcs, bus_arcs_dc, bus_arcs_ne, bus_gens, bus["pd"], bus["qd"], bus["gs"], bus["bs"])
+    pd = Dict(k => v["pd"] for (k,v) in ref(pm, n, :load))
+    qd = Dict(k => v["qd"] for (k,v) in ref(pm, n, :load))
+
+    gs = Dict(k => v["gs"] for (k,v) in ref(pm, n, :shunt))
+    bs = Dict(k => v["bs"] for (k,v) in ref(pm, n, :shunt))
+
+    constraint_kcl_shunt_ne(pm, n, i, bus_arcs, bus_arcs_dc, bus_arcs_ne, bus_gens, bus_loads, bus_shunts, pd, qd, gs, bs)
 end
 constraint_kcl_shunt_ne(pm::GenericPowerModel, i::Int) = constraint_kcl_shunt_ne(pm, pm.cnw, i::Int)
 

--- a/src/core/data.jl
+++ b/src/core/data.jl
@@ -177,16 +177,24 @@ function _make_per_unit(data::Dict{String,Any}, mva_base::Real)
 
     if haskey(data, "bus")
         for (i, bus) in data["bus"]
-            apply_func(bus, "pd", rescale)
-            apply_func(bus, "qd", rescale)
-
-            apply_func(bus, "gs", rescale)
-            apply_func(bus, "bs", rescale)
-
             apply_func(bus, "va", deg2rad)
 
             apply_func(bus, "lam_kcl_r", rescale_dual)
             apply_func(bus, "lam_kcl_i", rescale_dual)
+        end
+    end
+
+    if haskey(data, "load")
+        for (i, load) in data["load"]
+            apply_func(load, "pd", rescale)
+            apply_func(load, "qd", rescale)
+        end
+    end
+
+    if haskey(data, "shunt")
+        for (i, shunt) in data["shunt"]
+            apply_func(shunt, "gs", rescale)
+            apply_func(shunt, "bs", rescale)
         end
     end
 
@@ -289,16 +297,24 @@ function _make_mixed_units(data::Dict{String,Any}, mva_base::Real)
 
     if haskey(data, "bus")
         for (i, bus) in data["bus"]
-            apply_func(bus, "pd", rescale)
-            apply_func(bus, "qd", rescale)
-
-            apply_func(bus, "gs", rescale)
-            apply_func(bus, "bs", rescale)
-
             apply_func(bus, "va", rad2deg)
 
             apply_func(bus, "lam_kcl_r", rescale_dual)
             apply_func(bus, "lam_kcl_i", rescale_dual)
+        end
+    end
+
+    if haskey(data, "load")
+        for (i, load) in data["load"]
+            apply_func(load, "pd", rescale)
+            apply_func(load, "qd", rescale)
+        end
+    end
+
+    if haskey(data, "shunt")
+        for (i, shunt) in data["shunt"]
+            apply_func(shunt, "gs", rescale)
+            apply_func(shunt, "bs", rescale)
         end
     end
 

--- a/src/form/acp.jl
+++ b/src/form/acp.jl
@@ -45,11 +45,11 @@ end
 
 """
 ```
-sum(p[a] for a in bus_arcs) + sum(p_dc[a_dc] for a_dc in bus_arcs_dc) == sum(pg[g] for g in bus_gens) - pd - gs*v^2
-sum(q[a] for a in bus_arcs) + sum(q_dc[a_dc] for a_dc in bus_arcs_dc) == sum(qg[g] for g in bus_gens) - qd + bs*v^2
+sum(p[a] for a in bus_arcs) + sum(p_dc[a_dc] for a_dc in bus_arcs_dc) == sum(pg[g] for g in bus_gens) - sum(pd[d] for d in bus_loads) - sum(gs[s] for s in bus_shunts)*v^2
+sum(q[a] for a in bus_arcs) + sum(q_dc[a_dc] for a_dc in bus_arcs_dc) == sum(qg[g] for g in bus_gens) - sum(qd[d] for d in bus_loads) + sum(bs[s] for s in bus_shunts)*v^2
 ```
 """
-function constraint_kcl_shunt(pm::GenericPowerModel{T}, n::Int, i::Int, bus_arcs, bus_arcs_dc, bus_gens, pd, qd, gs, bs) where T <: AbstractACPForm
+function constraint_kcl_shunt(pm::GenericPowerModel{T}, n::Int, i::Int, bus_arcs, bus_arcs_dc, bus_gens, bus_loads, bus_shunts, pd, qd, gs, bs) where T <: AbstractACPForm
     vm = pm.var[:nw][n][:vm][i]
     p = pm.var[:nw][n][:p]
     q = pm.var[:nw][n][:q]
@@ -58,17 +58,18 @@ function constraint_kcl_shunt(pm::GenericPowerModel{T}, n::Int, i::Int, bus_arcs
     p_dc = pm.var[:nw][n][:p_dc]
     q_dc = pm.var[:nw][n][:q_dc]
 
-    pm.con[:nw][n][:kcl_p][i] = @constraint(pm.model, sum(p[a] for a in bus_arcs) + sum(p_dc[a_dc] for a_dc in bus_arcs_dc) == sum(pg[g] for g in bus_gens) - pd - gs*vm^2)
-    pm.con[:nw][n][:kcl_q][i] = @constraint(pm.model, sum(q[a] for a in bus_arcs) + sum(q_dc[a_dc] for a_dc in bus_arcs_dc) == sum(qg[g] for g in bus_gens) - qd + bs*vm^2)
+    pm.con[:nw][n][:kcl_p][i] = @constraint(pm.model, sum(p[a] for a in bus_arcs) + sum(p_dc[a_dc] for a_dc in bus_arcs_dc) == sum(pg[g] for g in bus_gens) - sum(pd[d] for d in bus_loads) - sum(gs[s] for s in bus_shunts)*vm^2)
+    pm.con[:nw][n][:kcl_q][i] = @constraint(pm.model, sum(q[a] for a in bus_arcs) + sum(q_dc[a_dc] for a_dc in bus_arcs_dc) == sum(qg[g] for g in bus_gens) - sum(qd[d] for d in bus_loads) + sum(bs[s] for s in bus_shunts)*vm^2)
 end
+
 
 """
 ```
-sum(p[a] for a in bus_arcs) + sum(p_dc[a_dc] for a_dc in bus_arcs_dc) + sum(p_ne[a] for a in bus_arcs_ne) == sum(pg[g] for g in bus_gens) - pd - gs*v^2
-sum(q[a] for a in bus_arcs) + sum(p_dc[a_dc] for a_dc in bus_arcs_dc) + sum(q_ne[a] for a in bus_arcs_ne) == sum(qg[g] for g in bus_gens) - qd + bs*v^2
+sum(p[a] for a in bus_arcs) + sum(p_dc[a_dc] for a_dc in bus_arcs_dc) + sum(p_ne[a] for a in bus_arcs_ne) == sum(pg[g] for g in bus_gens) - sum(pd[d] for d in bus_loads) - sum(gs[s] for s in bus_shunts)*vm^2
+sum(q[a] for a in bus_arcs) + sum(p_dc[a_dc] for a_dc in bus_arcs_dc) + sum(q_ne[a] for a in bus_arcs_ne) == sum(qg[g] for g in bus_gens) - sum(qd[d] for d in bus_loads) + sum(bs[s] for s in bus_shunts)*vm^2
 ```
 """
-function constraint_kcl_shunt_ne(pm::GenericPowerModel{T}, n::Int, i, bus_arcs, bus_arcs_dc, bus_arcs_ne, bus_gens, pd, qd, gs, bs) where T <: AbstractACPForm
+function constraint_kcl_shunt_ne(pm::GenericPowerModel{T}, n::Int, i, bus_arcs, bus_arcs_dc, bus_arcs_ne, bus_gens, bus_loads, bus_shunts, pd, qd, gs, bs) where T <: AbstractACPForm
     vm = pm.var[:nw][n][:vm][i]
     p = pm.var[:nw][n][:p]
     q = pm.var[:nw][n][:q]
@@ -79,8 +80,8 @@ function constraint_kcl_shunt_ne(pm::GenericPowerModel{T}, n::Int, i, bus_arcs, 
     p_dc = pm.var[:nw][n][:p_dc]
     q_dc = pm.var[:nw][n][:q_dc]
 
-    @constraint(pm.model, sum(p[a] for a in bus_arcs) + sum(p_dc[a_dc] for a_dc in bus_arcs_dc)  + sum(p_ne[a] for a in bus_arcs_ne) == sum(pg[g] for g in bus_gens) - pd - gs*vm^2)
-    @constraint(pm.model, sum(q[a] for a in bus_arcs) + sum(q_dc[a_dc] for a_dc in bus_arcs_dc)  + sum(q_ne[a] for a in bus_arcs_ne) == sum(qg[g] for g in bus_gens) - qd + bs*vm^2)
+    @constraint(pm.model, sum(p[a] for a in bus_arcs) + sum(p_dc[a_dc] for a_dc in bus_arcs_dc)  + sum(p_ne[a] for a in bus_arcs_ne) == sum(pg[g] for g in bus_gens) - sum(pd[d] for d in bus_loads) - sum(gs[s] for s in bus_shunts)*vm^2)
+    @constraint(pm.model, sum(q[a] for a in bus_arcs) + sum(q_dc[a_dc] for a_dc in bus_arcs_dc)  + sum(q_ne[a] for a in bus_arcs_ne) == sum(qg[g] for g in bus_gens) - sum(qd[d] for d in bus_loads) + sum(gs[s] for s in bus_shunts)*vm^2)
 end
 
 """

--- a/src/form/acr.jl
+++ b/src/form/acr.jl
@@ -62,7 +62,7 @@ function constraint_theta_ref(pm::GenericPowerModel{T}, n::Int, i::Int) where T 
 end
 
 
-function constraint_kcl_shunt(pm::GenericPowerModel{T}, n::Int, i, bus_arcs, bus_arcs_dc, bus_gens, pd, qd, gs, bs) where T <: AbstractACRForm
+function constraint_kcl_shunt(pm::GenericPowerModel{T}, n::Int, i, bus_arcs, bus_arcs_dc, bus_gens, bus_loads, bus_shunts, pd, qd, gs, bs) where T <: AbstractACRForm
     vr = pm.var[:nw][n][:vr][i]
     vi = pm.var[:nw][n][:vi][i]
     p = pm.var[:nw][n][:p]
@@ -71,9 +71,11 @@ function constraint_kcl_shunt(pm::GenericPowerModel{T}, n::Int, i, bus_arcs, bus
     qg = pm.var[:nw][n][:qg]
     p_dc = pm.var[:nw][n][:p_dc]
     q_dc = pm.var[:nw][n][:q_dc]
+    load = pm.ref[:nw][n][:load]
+    shunt = pm.ref[:nw][n][:shunt]
 
-    @constraint(pm.model, sum(p[a] for a in bus_arcs) + sum(p_dc[a_dc] for a_dc in bus_arcs_dc) == sum(pg[g] for g in bus_gens) - pd - gs*(vr^2 + vi^2))
-    @constraint(pm.model, sum(q[a] for a in bus_arcs) + sum(q_dc[a_dc] for a_dc in bus_arcs_dc) == sum(qg[g] for g in bus_gens) - qd + bs*(vr^2 + vi^2))
+    @constraint(pm.model, sum(p[a] for a in bus_arcs) + sum(p_dc[a_dc] for a_dc in bus_arcs_dc) == sum(pg[g] for g in bus_gens) - sum(pd[d] for d in bus_loads) - sum(gs[s] for s in bus_shunts)*(vr^2 + vi^2))
+    @constraint(pm.model, sum(q[a] for a in bus_arcs) + sum(q_dc[a_dc] for a_dc in bus_arcs_dc) == sum(qg[g] for g in bus_gens) - sum(qd[d] for d in bus_loads) + sum(bs[s] for s in bus_shunts)*(vr^2 + vi^2))
 end
 
 

--- a/src/form/dcp.jl
+++ b/src/form/dcp.jl
@@ -91,24 +91,30 @@ end
 function constraint_reactive_gen_setpoint(pm::GenericPowerModel{T}, n::Int, i, qg) where T <: AbstractDCPForm
 end
 
+
 ""
-function constraint_kcl_shunt(pm::GenericPowerModel{T}, n::Int, i, bus_arcs, bus_arcs_dc, bus_gens, pd, qd, gs, bs) where T <: AbstractDCPForm
+function constraint_kcl_shunt(pm::GenericPowerModel{T}, n::Int, i, bus_arcs, bus_arcs_dc, bus_gens, bus_loads, bus_shunts, pd, qd, gs, bs) where T <: AbstractDCPForm
     pg = pm.var[:nw][n][:pg]
     p = pm.var[:nw][n][:p]
     p_dc = pm.var[:nw][n][:p_dc]
+    load = pm.ref[:nw][n][:load]
+    shunt = pm.ref[:nw][n][:shunt]
 
-    pm.con[:nw][n][:kcl_p][i] = @constraint(pm.model, sum(p[a] for a in bus_arcs) + sum(p_dc[a_dc] for a_dc in bus_arcs_dc) == sum(pg[g] for g in bus_gens) - pd - gs*1.0^2)
+    pm.con[:nw][n][:kcl_p][i] = @constraint(pm.model, sum(p[a] for a in bus_arcs) + sum(p_dc[a_dc] for a_dc in bus_arcs_dc) == sum(pg[g] for g in bus_gens) - sum(pd[d] for d in bus_loads) - sum(gs[s] for s in bus_shunts)*1.0^2)
     # omit reactive constraint
 end
 
+
 ""
-function constraint_kcl_shunt_ne(pm::GenericPowerModel{T}, n::Int, i, bus_arcs, bus_arcs_dc, bus_arcs_ne, bus_gens, pd, qd, gs, bs) where T <: AbstractDCPForm
+function constraint_kcl_shunt_ne(pm::GenericPowerModel{T}, n::Int, i, bus_arcs, bus_arcs_dc, bus_arcs_ne, bus_gens, bus_loads, bus_shunts, pd, qd, gs, bs) where T <: AbstractDCPForm
     pg = pm.var[:nw][n][:pg]
     p = pm.var[:nw][n][:p]
     p_ne = pm.var[:nw][n][:p_ne]
     p_dc = pm.var[:nw][n][:p_dc]
+    load = pm.ref[:nw][n][:load]
+    shunt = pm.ref[:nw][n][:shunt]
 
-    @constraint(pm.model, sum(p[a] for a in bus_arcs) + sum(p_ne[a] for a in bus_arcs_ne) + sum(p_dc[a_dc] for a_dc in bus_arcs_dc) == sum(pg[g] for g in bus_gens) - pd - gs*1.0^2)
+    @constraint(pm.model, sum(p[a] for a in bus_arcs) + sum(p_ne[a] for a in bus_arcs_ne) + sum(p_dc[a_dc] for a_dc in bus_arcs_dc) == sum(pg[g] for g in bus_gens) - sum(pd[d] for d in bus_loads) - sum(gs[s] for s in bus_shunts)*1.0^2)
 end
 
 """
@@ -258,13 +264,16 @@ const DCPLLPowerModel = GenericPowerModel{StandardDCPLLForm}
 "default DC constructor"
 DCPLLPowerModel(data::Dict{String,Any}; kwargs...) = GenericPowerModel(data, StandardDCPLLForm; kwargs...)
 
-"`sum(p[a] for a in bus_arcs) + sum(p_dc[a_dc] for a_dc in bus_arcs_dc)== sum(pg[g] for g in bus_gens) - pd - gs*1.0^2`"
-function constraint_kcl_shunt(pm::GenericPowerModel{T}, n::Int, i, bus_arcs, bus_arcs_dc, bus_gens, pd, qd, gs, bs) where T <: AbstractDCPLLForm
+
+"`sum(p[a] for a in bus_arcs) + sum(p_dc[a_dc] for a_dc in bus_arcs_dc)== sum(pg[g] for g in bus_gens) - sum(pd[d] for d in bus_loads) - sum(gs[s] for s in bus_shunts)*1.0^2`"
+function constraint_kcl_shunt(pm::GenericPowerModel{T}, n::Int, i, bus_arcs, bus_arcs_dc, bus_gens, bus_loads, bus_shunts, pd, qd, gs, bs) where T <: AbstractDCPLLForm
     pg = pm.var[:nw][n][:pg]
     p = pm.var[:nw][n][:p]
     p_dc = pm.var[:nw][n][:p_dc]
+    load = pm.ref[:nw][n][:load]
+    shunt = pm.ref[:nw][n][:shunt]
 
-    @constraint(pm.model, sum(p[a] for a in bus_arcs) + sum(p_dc[a_dc] for a_dc in bus_arcs_dc) == sum(pg[g] for g in bus_gens) - pd - gs*1.0^2i)
+    @constraint(pm.model, sum(p[a] for a in bus_arcs) + sum(p_dc[a_dc] for a_dc in bus_arcs_dc) == sum(pg[g] for g in bus_gens) - sum(pd[d] for d in bus_loads) - sum(gs[s] for s in bus_shunts)*1.0^2)
 end
 
 

--- a/src/form/shared.jl
+++ b/src/form/shared.jl
@@ -3,13 +3,13 @@
 #################################
 #
 # This is the home of functions that are shared across multiple branches
-# of the type hierarchy.  Hence all function in this file should be over 
+# of the type hierarchy.  Hence all function in this file should be over
 # union types.
 #
-# The types defined in this file should not be exported because they exist 
+# The types defined in this file should not be exported because they exist
 # only to prevent code replication
 #
-# Note that Union types are discouraged in Julia, 
+# Note that Union types are discouraged in Julia,
 # https://docs.julialang.org/en/release-0.6/manual/style-guide/#Avoid-strange-type-Unions-1
 # and should be used with discretion.
 #
@@ -54,11 +54,11 @@ end
 
 """
 ```
-sum(p[a] for a in bus_arcs) + sum(p_dc[a_dc] for a_dc in bus_arcs_dc) == sum(pg[g] for g in bus_gens) - pd - gs*w[i]
-sum(q[a] for a in bus_arcs) + sum(q_dc[a_dc] for a_dc in bus_arcs_dc) == sum(qg[g] for g in bus_gens) - qd + bs*w[i]
+sum(p[a] for a in bus_arcs) + sum(p_dc[a_dc] for a_dc in bus_arcs_dc) == sum(pg[g] for g in bus_gens) - sum(pd[d] for d in bus_loads) - sum(gs[s] for d in bus_shunts)*w[i]
+sum(q[a] for a in bus_arcs) + sum(q_dc[a_dc] for a_dc in bus_arcs_dc) == sum(qg[g] for g in bus_gens) - sum(qd[d] for d in bus_loads) + sum(bs[s] for d in bus_shunts)*w[i]
 ```
 """
-function constraint_kcl_shunt(pm::GenericPowerModel{T}, n::Int, i, bus_arcs, bus_arcs_dc, bus_gens, pd, qd, gs, bs) where T <: AbstractWRForms
+function constraint_kcl_shunt(pm::GenericPowerModel{T}, n::Int, i, bus_arcs, bus_arcs_dc, bus_gens, bus_loads, bus_shunts, pd, qd, gs, bs) where T <: AbstractWRForms
     w = pm.var[:nw][n][:w][i]
     pg = pm.var[:nw][n][:pg]
     qg = pm.var[:nw][n][:qg]
@@ -66,19 +66,21 @@ function constraint_kcl_shunt(pm::GenericPowerModel{T}, n::Int, i, bus_arcs, bus
     q = pm.var[:nw][n][:q]
     p_dc = pm.var[:nw][n][:p_dc]
     q_dc = pm.var[:nw][n][:q_dc]
+    load = pm.ref[:nw][n][:load]
+    shunt = pm.ref[:nw][n][:shunt]
 
-    @constraint(pm.model, sum(p[a] for a in bus_arcs) + sum(p_dc[a_dc] for a_dc in bus_arcs_dc) == sum(pg[g] for g in bus_gens) - pd - gs*w)
-    @constraint(pm.model, sum(q[a] for a in bus_arcs) + sum(q_dc[a_dc] for a_dc in bus_arcs_dc) == sum(qg[g] for g in bus_gens) - qd + bs*w)
+    @constraint(pm.model, sum(p[a] for a in bus_arcs) + sum(p_dc[a_dc] for a_dc in bus_arcs_dc) == sum(pg[g] for g in bus_gens) - sum(pd[d] for d in bus_loads) - sum(gs[s] for s in bus_shunts)*w)
+    @constraint(pm.model, sum(q[a] for a in bus_arcs) + sum(q_dc[a_dc] for a_dc in bus_arcs_dc) == sum(qg[g] for g in bus_gens) - sum(qd[d] for d in bus_loads) + sum(bs[s] for s in bus_shunts)*w)
 end
 
 
 """
 ```
-sum(p[a] for a in bus_arcs) + sum(p_ne[a] for a in bus_arcs_ne) + sum(p_dc[a_dc] for a_dc in bus_arcs_dc) == sum(pg[g] for g in bus_gens) - pd - gs*w[i]
-sum(q[a] for a in bus_arcs) + sum(q_ne[a] for a in bus_arcs_ne) + sum(q_dc[a_dc] for a_dc in bus_arcs_dc) == sum(qg[g] for g in bus_gens) - qd + bs*w[i]
+sum(p[a] for a in bus_arcs) + sum(p_ne[a] for a in bus_arcs_ne) + sum(p_dc[a_dc] for a_dc in bus_arcs_dc) == sum(pg[g] for g in bus_gens) - sum(pd[d] for d in bus_loads) - sum(gs[s] for s in bus_shunts)*w[i]
+sum(q[a] for a in bus_arcs) + sum(q_ne[a] for a in bus_arcs_ne) + sum(q_dc[a_dc] for a_dc in bus_arcs_dc) == sum(qg[g] for g in bus_gens) - sum(qd[d] for d in bus_loads) + sum(bs[s] for s in bus_shunts)*w[i]
 ```
 """
-function constraint_kcl_shunt_ne(pm::GenericPowerModel{T}, n::Int, i, bus_arcs, bus_arcs_dc, bus_arcs_ne, bus_gens, pd, qd, gs, bs) where T <: AbstractWRForms
+function constraint_kcl_shunt_ne(pm::GenericPowerModel{T}, n::Int, i, bus_arcs, bus_arcs_dc, bus_arcs_ne, bus_gens, bus_loads, bus_shunts, pd, qd, gs, bs) where T <: AbstractWRForms
     w = pm.var[:nw][n][:w][i]
     pg = pm.var[:nw][n][:pg]
     qg = pm.var[:nw][n][:qg]
@@ -88,9 +90,11 @@ function constraint_kcl_shunt_ne(pm::GenericPowerModel{T}, n::Int, i, bus_arcs, 
     q_ne = pm.var[:nw][n][:q_ne]
     p_dc = pm.var[:nw][n][:p_dc]
     q_dc = pm.var[:nw][n][:q_dc]
+    load = pm.ref[:nw][n][:load]
+    shunt = pm.ref[:nw][n][:shunt]
 
-    @constraint(pm.model, sum(p[a] for a in bus_arcs) + sum(p_ne[a] for a in bus_arcs_ne) + sum(p_dc[a_dc] for a_dc in bus_arcs_dc) == sum(pg[g] for g in bus_gens) - pd - gs*w)
-    @constraint(pm.model, sum(q[a] for a in bus_arcs) + sum(q_ne[a] for a in bus_arcs_ne) + sum(q_dc[a_dc] for a_dc in bus_arcs_dc) == sum(qg[g] for g in bus_gens) - qd + bs*w)
+    @constraint(pm.model, sum(p[a] for a in bus_arcs) + sum(p_ne[a] for a in bus_arcs_ne) + sum(p_dc[a_dc] for a_dc in bus_arcs_dc) == sum(pg[g] for g in bus_gens) - sum(pd[d] for d in bus_loads) - sum(gs[s] for s in bus_shunts)*w)
+    @constraint(pm.model, sum(q[a] for a in bus_arcs) + sum(q_ne[a] for a in bus_arcs_ne) + sum(q_dc[a_dc] for a_dc in bus_arcs_dc) == sum(qg[g] for g in bus_gens) - sum(qd[d] for d in bus_loads) + sum(bs[s] for s in bus_shunts)*w)
 end
 
 

--- a/test/docs.jl
+++ b/test/docs.jl
@@ -16,8 +16,8 @@
         @test result["status"] == :LocalOptimal
         @test isapprox(result["objective"], 5906.88; atol = 1e0)
 
-        network_data["bus"]["3"]["pd"] = 0.0
-        network_data["bus"]["3"]["qd"] = 0.0
+        network_data["load"]["3"]["pd"] = 0.0
+        network_data["load"]["3"]["qd"] = 0.0
 
         result = run_opf(network_data, ACPPowerModel, IpoptSolver(print_level=0))
 

--- a/test/modify.jl
+++ b/test/modify.jl
@@ -20,8 +20,8 @@
         @test result["status"] == :LocalOptimal
         @test isapprox(result["objective"], 195.896; atol = 1e-1)
 
-        data["bus"]["5"]["pd"] = 0
-        data["bus"]["5"]["qd"] = 0
+        data["load"]["4"]["pd"] = 0
+        data["load"]["4"]["qd"] = 0
 
         result = run_opf(data, ACPPowerModel, ipopt_solver)
         @test result["status"] == :LocalOptimal
@@ -43,8 +43,8 @@
                     \"gen_status\":0
                 }
             },
-            \"bus\":{
-                \"5\":{
+            \"load\":{
+                \"4\":{
                     \"pd\":0,
                     \"qd\":0
                 }


### PR DESCRIPTION
Matpower parser has been updated to separate out Loads and Shunts from
Buses, into `"load"` and `"shunt"`, respectively. This happens on
Matpower file loading. This change is in preparation for the upcoming
addition of PSS(R)E parser support.

KCL constraint equations have been updated to support multiple loads and
shunts per bus by changing the equations from e.g.
(from `src/form/acl.jl` line:48)

    sum(p[a] for a in bus_arcs) +
    sum(p_dc[a_dc] for a_dc in bus_arcs_dc)
    ==
    sum(pg[g] for g in bus_gens) - pd - gs*v^2

to

    sum(p[a] for a in bus_arcs) +
    sum(p_dc[a_dc] for a_dc in bus_arcs_dc)
    ==
    sum(pg[g] for g in bus_gens) -
    sum(load[d]["pd"] for d in bus_loads) -
    sum(shunt[s]["gs"] for s in bus_shunts)*v^2

`make_per_unit` and `make_mixed_unit` functions have been updated
to include the two new `"load"` and `"shunt"` sections.

Unit tests have been updated to account for the two new `"load"` and
`"shunt"` sections, but have otherwise remained unchanged.

Updated documentation to reflect changes to the PowerModels data
structure.

Updated changelog to include changes to PowerModels data structure
and changes to KCL constraint models.

Closes #209