### PR TITLE
FIX: Load/Shunt "status" value Type

### DIFF
--- a/src/core/data.jl
+++ b/src/core/data.jl
@@ -670,13 +670,13 @@ function _propagate_topology_status(data::Dict{String,Any})
     incident_load = bus_load_lookup(data["load"], data["bus"])
     incident_active_load = Dict()
     for (i, load_list) in incident_load
-        incident_active_load[i] = filter(load -> load["status"], load_list)
+        incident_active_load[i] = filter(load -> load["status"] != 0, load_list)
     end
 
     incident_shunt = bus_shunt_lookup(data["shunt"], data["bus"])
     incident_active_shunt = Dict()
     for (i, shunt_list) in incident_shunt
-        incident_active_shunt[i] = filter(shunt -> shunt["status"], shunt_list)
+        incident_active_shunt[i] = filter(shunt -> shunt["status"] != 0, shunt_list)
     end
 
     incident_gen = bus_gen_lookup(data["gen"], data["bus"])
@@ -754,17 +754,17 @@ function _propagate_topology_status(data::Dict{String,Any})
 
                 else # bus type == 4
                     for load in incident_active_load[i]
-                        if load["status"]
+                        if load["status"] != 0
                             info(LOGGER, "deactivating load $(load["index"]) due to inactive bus $(i)")
-                            load["status"] = false
+                            load["status"] = 0
                             updated = true
                         end
                     end
 
                     for shunt in incident_active_shunt[i]
-                        if shunt["status"]
+                        if shunt["status"] != 0
                             info(LOGGER, "deactivating shunt $(shunt["index"]) due to inactive bus $(i)")
-                            shunt["status"] = false
+                            shunt["status"] = 0
                             updated = true
                         end
                     end
@@ -789,10 +789,10 @@ function _propagate_topology_status(data::Dict{String,Any})
             cc_active_loads = [0]
             cc_active_shunts = [0]
             cc_active_gens = [0]
-            
+
             for i in cc
                 cc_active_loads = push!(cc_active_loads, length(incident_active_load[i]))
-                cc_active_shunts = push!(cc_active_shunts, length(incident_active_shunt[i])) 
+                cc_active_shunts = push!(cc_active_shunts, length(incident_active_shunt[i]))
                 cc_active_gens = push!(cc_active_gens, length(incident_active_gen[i]))
             end
 

--- a/src/io/matpower.jl
+++ b/src/io/matpower.jl
@@ -383,12 +383,20 @@ function split_loads_shunts(data::Dict{String,Any})
     shunt_num = 1
     for (i,bus) in enumerate(data["bus"])
         if bus["pd"] != 0.0 || bus["qd"] != 0.0
-            append!(data["load"], [Dict{String,Any}("pd" => bus["pd"], "qd" => bus["qd"], "load_bus" => bus["bus_i"], "status" => bus["bus_type"] != 4, "index" => load_num)])
+            append!(data["load"], [Dict{String,Any}("pd" => bus["pd"],
+                                                    "qd" => bus["qd"],
+                                                    "load_bus" => bus["bus_i"],
+                                                    "status" => convert(Int8, bus["bus_type"] != 4),
+                                                    "index" => load_num)])
             load_num += 1
         end
 
         if bus["gs"] != 0.0 || bus["bs"] != 0.0
-            append!(data["shunt"], [Dict{String,Any}("gs" => bus["gs"], "bs" => bus["bs"], "shunt_bus" => bus["bus_i"], "status" => bus["bus_type"] != 4, "index" => shunt_num)])
+            append!(data["shunt"], [Dict{String,Any}("gs" => bus["gs"],
+                                                     "bs" => bus["bs"],
+                                                     "shunt_bus" => bus["bus_i"],
+                                                     "status" => convert(Int8, bus["bus_type"] != 4),
+                                                     "index" => shunt_num)])
             shunt_num += 1
         end
 


### PR DESCRIPTION
Changes the "status" value of Loads and Shunts to `1` or `0` instead of
`true` or `false`, by using `convert(Int8, value)` during the
construction in `split_loads_shunts()`.

Refactors relevant lines to make lines more readable.

Closes #234