### PR TITLE
ADD: Data extensions from PTI files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ PowerModels.jl Change Log
 - Changed test MIP solver from GLPK to CBC
 - Improved robustness of matpower data parsing and transformation
 - Minor issues closed #251
+- Added PowerModels data extensions from PTI files via the `import_all` kwarg in `parse_file`
 
 ### v0.6.1
 - Moved to Juniper for non-convex MINLP tests

--- a/docs/src/parser.md
+++ b/docs/src/parser.md
@@ -81,4 +81,5 @@ calc_2term_reactive_power
 get_bus_values
 find_max_bus_id
 create_starbus_from_transformer
+import_remaining!
 ```

--- a/src/io/common.jl
+++ b/src/io/common.jl
@@ -1,15 +1,16 @@
 """
-    parse_file(file)
+    parse_file(file; import_all)
 
 Parses a Matpower .m `file` or PTI (PSS(R)E-v33) .raw `file` into a
-PowerModels data structure.
+PowerModels data structure. All fields from PTI files will be imported if
+`import_all` is true (Default: false).
 """
-function parse_file(file::String)
+function parse_file(file::String; import_all=false)
     if endswith(file, ".m")
         pm_data = PowerModels.parse_matpower(file)
     elseif endswith(lowercase(file), ".raw")
         warn(LOGGER, "The PSS(R)E parser is partially implimented, and currently only supports buses, loads, shunts, generators, branches, and transformers")
-        pm_data = PowerModels.parse_psse(file)
+        pm_data = PowerModels.parse_psse(file; import_all=import_all)
     else
         pm_data = parse_json(file)
     end

--- a/src/io/psse.jl
+++ b/src/io/psse.jl
@@ -106,35 +106,49 @@ function create_starbus_from_transformer(pm_data::Dict, transformer::Dict)::Dict
 end
 
 
+"Imports remaining keys from `data_in` into `data_out`, excluding keys in `exclude`"
+function import_remaining!(data_out::Dict, data_in::Dict; exclude=[])
+    for (k, v) in data_in
+        if k ∉ exclude
+            data_out[lowercase(k)] = v
+        end
+    end
+end
+
+
 """
     psse2pm_branch!(pm_data, pti_data)
 
 Parses PSS(R)E-style Branch data into a PowerModels-style Dict.
 """
-function psse2pm_branch!(pm_data::Dict, pti_data::Dict)
+function psse2pm_branch!(pm_data::Dict, pti_data::Dict, import_all::Bool)
     pm_data["branch"] = []
     if haskey(pti_data, "BRANCH")
         for (i, branch) in enumerate(pti_data["BRANCH"])
             sub_data = Dict{String,Any}()
 
-            sub_data["f_bus"] = branch["I"]
-            sub_data["t_bus"] = branch["J"]
-            sub_data["br_r"] = branch["R"]
-            sub_data["br_x"] = branch["X"]
-            sub_data["g_fr"] = branch["GI"]
-            sub_data["b_fr"] = branch["BI"] == 0. && branch["B"] != 0. ? branch["B"] / 2 : branch["BI"]
-            sub_data["g_to"] = branch["GJ"]
-            sub_data["b_to"] = branch["BJ"] == 0. && branch["B"] != 0. ? branch["B"] / 2 : branch["BJ"]
-            sub_data["rate_a"] = branch["RATEA"]
-            sub_data["rate_b"] = branch["RATEB"]
-            sub_data["rate_c"] = branch["RATEC"]
+            sub_data["f_bus"] = pop!(branch, "I")
+            sub_data["t_bus"] = pop!(branch, "J")
+            sub_data["br_r"] = pop!(branch, "R")
+            sub_data["br_x"] = pop!(branch, "X")
+            sub_data["g_fr"] = pop!(branch, "GI")
+            sub_data["b_fr"] = branch["BI"] == 0. && branch["B"] != 0. ? branch["B"] / 2 : pop!(branch, "BI")
+            sub_data["g_to"] = pop!(branch, "GJ")
+            sub_data["b_to"] = branch["BJ"] == 0. && branch["B"] != 0. ? pop!(branch, "B") / 2 : pop!(branch, "BJ")
+            sub_data["rate_a"] = pop!(branch, "RATEA")
+            sub_data["rate_b"] = pop!(branch, "RATEB")
+            sub_data["rate_c"] = pop!(branch, "RATEC")
             sub_data["tap"] = 1.0
             sub_data["shift"] = 0.0
-            sub_data["br_status"] = branch["ST"]
+            sub_data["br_status"] = pop!(branch, "ST")
             sub_data["angmin"] = 0.0
             sub_data["angmax"] = 0.0
             sub_data["transformer"] = false
             sub_data["index"] = i
+
+            if import_all
+                import_remaining!(sub_data, branch)
+            end
 
             append!(pm_data["branch"], [deepcopy(sub_data)])
         end
@@ -147,7 +161,7 @@ end
 
 Parses PSS(R)E-style Generator data in a PowerModels-style Dict.
 """
-function psse2pm_generator!(pm_data::Dict, pti_data::Dict)
+function psse2pm_generator!(pm_data::Dict, pti_data::Dict, import_all::Bool)
     pm_data["gen"] = []
     if haskey(pti_data, "GENERATOR")
         for gen in pti_data["GENERATOR"]
@@ -158,21 +172,21 @@ function psse2pm_generator!(pm_data::Dict, pti_data::Dict)
             sub_data["shutdown"] = 0.0
             sub_data["ncost"] = 3
             sub_data["cost"] = [0.0, 1.0, 0.0]
-            sub_data["gen_bus"] = gen["I"]
-            sub_data["gen_status"] = gen["STAT"]
-            sub_data["pg"] = gen["PG"]
-            sub_data["qg"] = gen["QG"]
-            sub_data["vg"] = gen["VS"]
-            sub_data["mbase"] = gen["MBASE"]
+            sub_data["gen_bus"] = pop!(gen, "I")
+            sub_data["gen_status"] = pop!(gen, "STAT")
+            sub_data["pg"] = pop!(gen, "PG")
+            sub_data["qg"] = pop!(gen, "QG")
+            sub_data["vg"] = pop!(gen, "VS")
+            sub_data["mbase"] = pop!(gen, "MBASE")
             sub_data["ramp_agc"] = 0.0
             sub_data["ramp_q"] = 0.0
             sub_data["ramp_10"] = 0.0
             sub_data["ramp_30"] = 0.0
-            sub_data["pmin"] = gen["PB"]
-            sub_data["pmax"] = gen["PT"]
+            sub_data["pmin"] = pop!(gen, "PB")
+            sub_data["pmax"] = pop!(gen, "PT")
             sub_data["apf"] = 0.0
-            sub_data["qmin"] = gen["QB"]
-            sub_data["qmax"] = gen["QT"]
+            sub_data["qmin"] = pop!(gen, "QB")
+            sub_data["qmax"] = pop!(gen, "QT")
             sub_data["pc1"] = 0.0
             sub_data["pc2"] = 0.0
             sub_data["qc1min"] = 0.0
@@ -180,6 +194,10 @@ function psse2pm_generator!(pm_data::Dict, pti_data::Dict)
             sub_data["qc2min"] = 0.0
             sub_data["qc2max"] = 0.0
             sub_data["index"] = length(pm_data["gen"]) + 1
+
+            if import_all
+                import_remaining!(sub_data, gen)
+            end
 
             append!(pm_data["gen"], [deepcopy(sub_data)])
         end
@@ -192,31 +210,35 @@ end
 
 Parses PSS(R)E-style Bus data into a PowerModels-style Dict.
 """
-function psse2pm_bus!(pm_data::Dict, pti_data::Dict)
+function psse2pm_bus!(pm_data::Dict, pti_data::Dict, import_all::Bool)
     pm_data["bus"] = []
     if haskey(pti_data, "BUS")
         for bus in pti_data["BUS"]
             sub_data = Dict{String,Any}()
 
             sub_data["bus_i"] = bus["I"]
-            sub_data["bus_type"] = bus["IDE"]
-            sub_data["area"] = bus["AREA"]
-            sub_data["vm"] = bus["VM"]
-            sub_data["va"] = bus["VA"]
-            sub_data["base_kv"] = bus["BASKV"]
-            sub_data["zone"] = bus["ZONE"]
-            sub_data["name"] = bus["NAME"]
+            sub_data["bus_type"] = pop!(bus, "IDE")
+            sub_data["area"] = pop!(bus, "AREA")
+            sub_data["vm"] = pop!(bus, "VM")
+            sub_data["va"] = pop!(bus, "VA")
+            sub_data["base_kv"] = pop!(bus, "BASKV")
+            sub_data["zone"] = pop!(bus, "ZONE")
+            sub_data["name"] = pop!(bus, "NAME")
 
             if haskey(bus, "NVHI") && haskey(bus, "NVLO")
-                sub_data["vmax"] = bus["NVHI"]
-                sub_data["vmin"] = bus["NVLO"]
+                sub_data["vmax"] = pop!(bus, "NVHI")
+                sub_data["vmin"] = pop!(bus, "NVLO")
             else
                 warn(LOGGER, "PTI v$(pti_data["CASE IDENTIFICATION"][1]["REV"]) does not contain vmin and vmax values, defaults of 0.9 and 1.1, respectively, assumed.")
                 sub_data["vmax"] = 1.1
                 sub_data["vmin"] = 0.9
             end
 
-            sub_data["index"] = bus["I"]
+            sub_data["index"] = pop!(bus, "I")
+
+            if import_all
+                import_remaining!(sub_data, bus)
+            end
 
             append!(pm_data["bus"], [deepcopy(sub_data)])
         end
@@ -229,17 +251,21 @@ end
 
 Parses PSS(R)E-style Load data into a PowerModels-style Dict.
 """
-function psse2pm_load!(pm_data::Dict, pti_data::Dict)
+function psse2pm_load!(pm_data::Dict, pti_data::Dict, import_all::Bool)
     pm_data["load"] = []
     if haskey(pti_data, "LOAD")
         for load in pti_data["LOAD"]
             sub_data = Dict{String,Any}()
 
-            sub_data["load_bus"] = load["I"]
-            sub_data["pd"] = load["PL"]
-            sub_data["qd"] = load["QL"]
-            sub_data["status"] = load["STATUS"]
+            sub_data["load_bus"] = pop!(load, "I")
+            sub_data["pd"] = pop!(load, "PL")
+            sub_data["qd"] = pop!(load, "QL")
+            sub_data["status"] = pop!(load, "STATUS")
             sub_data["index"] = length(pm_data["load"]) + 1
+
+            if import_all
+                import_remaining!(sub_data, load)
+            end
 
             append!(pm_data["load"], [deepcopy(sub_data)])
         end
@@ -253,18 +279,22 @@ end
 Parses PSS(R)E-style Fixed and Switched Shunt data into a PowerModels-style
 Dict.
 """
-function psse2pm_shunt!(pm_data::Dict, pti_data::Dict)
+function psse2pm_shunt!(pm_data::Dict, pti_data::Dict, import_all::Bool)
     pm_data["shunt"] = []
 
     if haskey(pti_data, "FIXED SHUNT")
         for shunt in pti_data["FIXED SHUNT"]
             sub_data = Dict{String,Any}()
 
-            sub_data["shunt_bus"] = shunt["I"]
-            sub_data["gs"] = shunt["GL"]
-            sub_data["bs"] = shunt["BL"]
-            sub_data["status"] = shunt["STATUS"]
+            sub_data["shunt_bus"] = pop!(shunt, "I")
+            sub_data["gs"] = pop!(shunt, "GL")
+            sub_data["bs"] = pop!(shunt, "BL")
+            sub_data["status"] = pop!(shunt, "STATUS")
             sub_data["index"] = length(pm_data["shunt"]) + 1
+
+            if import_all
+                import_remaining!(sub_data, shunt)
+            end
 
             append!(pm_data["shunt"], [deepcopy(sub_data)])
         end
@@ -276,11 +306,15 @@ function psse2pm_shunt!(pm_data::Dict, pti_data::Dict)
         for shunt in pti_data["SWITCHED SHUNT"]
             sub_data = Dict{String,Any}()
 
-            sub_data["shunt_bus"] = shunt["I"]
+            sub_data["shunt_bus"] = pop!(shunt, "I")
             sub_data["gs"] = 0.0
-            sub_data["bs"] = shunt["BINIT"]
-            sub_data["status"] = shunt["STAT"]
+            sub_data["bs"] = pop!(shunt, "BINIT")
+            sub_data["status"] = pop!(shunt, "STAT")
             sub_data["index"] = length(pm_data["shunt"]) + 1
+
+            if import_all
+                import_remaining!(sub_data, shunt)
+            end
 
             append!(pm_data["shunt"], [deepcopy(sub_data)])
         end
@@ -293,7 +327,7 @@ end
 
 Parses PSS(R)E-style Transformer data into a PowerModels-style Dict.
 """
-function psse2pm_transformer!(pm_data::Dict, pti_data::Dict)
+function psse2pm_transformer!(pm_data::Dict, pti_data::Dict, import_all::Bool)
     if !haskey(pm_data, "branch")
         pm_data["branch"] = []
     end
@@ -323,17 +357,17 @@ function psse2pm_transformer!(pm_data::Dict, pti_data::Dict)
                 sub_data["br_r"] = br_r
                 sub_data["br_x"] = br_x
 
-                sub_data["g_fr"] = transformer["MAG1"]
-                sub_data["b_fr"] = transformer["MAG2"]
+                sub_data["g_fr"] = pop!(transformer, "MAG1")
+                sub_data["b_fr"] = pop!(transformer, "MAG2")
                 sub_data["g_to"] = 0.0
                 sub_data["b_to"] = 0.0
 
-                sub_data["rate_a"] = transformer["RATA1"]
-                sub_data["rate_b"] = transformer["RATB1"]
-                sub_data["rate_c"] = transformer["RATC1"]
+                sub_data["rate_a"] = pop!(transformer, "RATA1")
+                sub_data["rate_b"] = pop!(transformer, "RATB1")
+                sub_data["rate_c"] = pop!(transformer, "RATC1")
 
-                sub_data["tap"] = transformer["WINDV1"] / transformer["WINDV2"]
-                sub_data["shift"] = transformer["ANG1"]
+                sub_data["tap"] = pop!(transformer, "WINDV1") / pop!(transformer, "WINDV2")
+                sub_data["shift"] = pop!(transformer, "ANG1")
 
                 # Unit Transformations
                 if transformer["CW"] != 1  # NOT "for off-nominal turns ratio in pu of winding bus base voltage"
@@ -351,8 +385,13 @@ function psse2pm_transformer!(pm_data::Dict, pti_data::Dict)
                 sub_data["transformer"] = true
                 sub_data["index"] = length(pm_data["branch"]) + 1
 
-                append!(pm_data["branch"], [deepcopy(sub_data)])
+                if import_all
+                    import_remaining!(sub_data, transformer; exclude=["I", "J", "K", "CZ", "CW", "R1-2", "R2-3", "R3-1",
+                                                                      "X1-2", "X2-3", "X3-1", "SBASE1-2", "SBASE2-3",
+                                                                      "SBASE3-1", "MAG1", "MAG2", "STAT", "NOMV1", "NOMV2"])
+                end
 
+                append!(pm_data["branch"], [deepcopy(sub_data)])
             else  # Three-winding Transformers
                 bus_id1, bus_id2, bus_id3 = transformer["I"], transformer["J"], transformer["K"]
 
@@ -402,17 +441,17 @@ function psse2pm_transformer!(pm_data::Dict, pti_data::Dict)
                     sub_data["br_r"] = br_r
                     sub_data["br_x"] = br_x
 
-                    sub_data["g_fr"] = m == 1 ? transformer["MAG1"] : 0.0
-                    sub_data["b_fr"] = m == 1 ? transformer["MAG2"] : 0.0
+                    sub_data["g_fr"] = m == 1 ? pop!(transformer, "MAG1") : 0.0
+                    sub_data["b_fr"] = m == 1 ? pop!(transformer, "MAG2") : 0.0
                     sub_data["g_to"] = 0.0
                     sub_data["b_to"] = 0.0
 
-                    sub_data["rate_a"] = transformer["RATA$m"]
-                    sub_data["rate_b"] = transformer["RATB$m"]
-                    sub_data["rate_c"] = transformer["RATC$m"]
+                    sub_data["rate_a"] = pop!(transformer, "RATA$m")
+                    sub_data["rate_b"] = pop!(transformer, "RATB$m")
+                    sub_data["rate_c"] = pop!(transformer, "RATC$m")
 
-                    sub_data["tap"] = transformer["WINDV$m"]
-                    sub_data["shift"] = transformer["ANG$m"]
+                    sub_data["tap"] = pop!(transformer, "WINDV$m")
+                    sub_data["shift"] = pop!(transformer, "ANG$m")
 
                     # Unit Transformations
                     if transformer["CW"] != 1  # NOT "for off-nominal turns ratio in pu of winding bus base voltage"
@@ -422,6 +461,8 @@ function psse2pm_transformer!(pm_data::Dict, pti_data::Dict)
                         end
                     end
 
+                    delete!(transformer, "NOMV$m")
+
                     sub_data["br_status"] = transformer["STAT"]
 
                     sub_data["angmin"] = 0.0
@@ -429,6 +470,12 @@ function psse2pm_transformer!(pm_data::Dict, pti_data::Dict)
 
                     sub_data["transformer"] = true
                     sub_data["index"] = length(pm_data["branch"]) + 1
+
+                    if import_all
+                        import_remaining!(sub_data, transformer; exclude=["I", "J", "K", "CZ", "CW", "R1-2", "R2-3", "R3-1",
+                                                                          "X1-2", "X2-3", "X3-1", "SBASE1-2", "SBASE2-3",
+                                                                          "SBASE3-1", "MAG1", "MAG2", "STAT"])
+                    end
 
                     append!(pm_data["branch"], [deepcopy(sub_data)])
                 end
@@ -444,7 +491,7 @@ end
 Parses PSS(R)E-style Two-Terminal and VSC DC Lines data into a PowerModels
 compatible Dict structure by first converting them to a simple DC Line Model.
 """
-function psse2pm_dcline!(pm_data::Dict, pti_data::Dict)
+function psse2pm_dcline!(pm_data::Dict, pti_data::Dict, import_all::Bool)
     pm_data["dcline"] = []
 
     if haskey(pti_data, "TWO-TERMINAL DC")
@@ -452,10 +499,10 @@ function psse2pm_dcline!(pm_data::Dict, pti_data::Dict)
         for dcline in pti_data["TWO-TERMINAL DC"]
             sub_data = Dict{String,Any}()
 
-            power_demand = dcline["MDC"] == 1 ? abs(dcline["SETVL"]) : dcline["MDC"] == 2 ? abs(dcline["SETVL"] / dcline["VSCHD"] / 1000) : 0
+            power_demand = dcline["MDC"] == 1 ? abs(pop!(dcline, "SETVL")) : dcline["MDC"] == 2 ? abs(pop!(dcline, "SETVL") / pop!(dcline, "VSCHD") / 1000) : 0
 
-            sub_data["qminf"], sub_data["qmaxf"] = calc_2term_reactive_power(power_demand, dcline["ANMNR"], dcline["ANMXR"])
-            sub_data["qmint"], sub_data["qmaxt"] = calc_2term_reactive_power(power_demand, dcline["ANMNI"], dcline["ANMXI"])
+            sub_data["qminf"], sub_data["qmaxf"] = calc_2term_reactive_power(power_demand, pop!(dcline, "ANMNR"), pop!(dcline, "ANMXR"))
+            sub_data["qmint"], sub_data["qmaxt"] = calc_2term_reactive_power(power_demand, pop!(dcline, "ANMNI"), pop!(dcline, "ANMXI"))
 
             sub_data["f_bus"] = dcline["IPR"]
             sub_data["t_bus"] = dcline["IPI"]
@@ -464,13 +511,13 @@ function psse2pm_dcline!(pm_data::Dict, pti_data::Dict)
             sub_data["pt"] = power_demand
             sub_data["qf"] = 0
             sub_data["qt"] = 0
-            sub_data["vf"] = get_bus_value(dcline["IPR"], "vm", pm_data)
-            sub_data["vt"] = get_bus_value(dcline["IPI"], "vm", pm_data)
+            sub_data["vf"] = get_bus_value(pop!(dcline, "IPR"), "vm", pm_data)
+            sub_data["vt"] = get_bus_value(pop!(dcline, "IPI"), "vm", pm_data)
 
             sub_data["pminf"] = dcline["MDC"] > 0.0 ? 0.9 * power_demand : 0.0
             sub_data["pmaxf"] = dcline["MDC"] > 0.0 ? 1.1 * power_demand : 0.0
             sub_data["pmint"] = dcline["MDC"] < 0.0 ? 0.9 * power_demand : 0.0
-            sub_data["pmaxt"] = dcline["MDC"] < 0.0 ? 1.1 * power_demand : 0.0
+            sub_data["pmaxt"] = pop!(dcline, "MDC") < 0.0 ? 1.1 * power_demand : 0.0
 
             sub_data["loss0"] = 0
             sub_data["loss1"] = 0
@@ -482,6 +529,10 @@ function psse2pm_dcline!(pm_data::Dict, pti_data::Dict)
             sub_data["cost"] = [0.0, 1.0, 0.0]
             sub_data["model"] = 2
             sub_data["index"] = length(pm_data["dcline"]) + 1
+
+            if import_all
+                import_remaining!(sub_data, dcline)
+            end
 
             append!(pm_data["dcline"], [deepcopy(sub_data)])
         end
@@ -501,25 +552,30 @@ end
     parse_psse(pti_data)
 
 Converts PSS(R)E-style data parsed from a PTI raw file, passed by `pti_data`
-into a format suitable for use internally in PowerModels.
+into a format suitable for use internally in PowerModels. Imports all remaining
+data from the PTI file if `import_all` is true (Default: false).
 """
-function parse_psse(pti_data::Dict)::Dict
+function parse_psse(pti_data::Dict; import_all=false)::Dict
     pm_data = Dict{String,Any}()
 
     pm_data["multinetwork"] = false
     pm_data["per_unit"] = false
     pm_data["source_type"] = "pti"
     pm_data["source_version"] = VersionNumber("$(pti_data["CASE IDENTIFICATION"][1]["REV"])")
-    pm_data["baseMVA"] = pti_data["CASE IDENTIFICATION"][1]["SBASE"]
-    pm_data["name"] = pti_data["CASE IDENTIFICATION"][1]["NAME"]
+    pm_data["baseMVA"] = pop!(pti_data["CASE IDENTIFICATION"][1], "SBASE")
+    pm_data["name"] = pop!(pti_data["CASE IDENTIFICATION"][1], "NAME")
 
-    psse2pm_bus!(pm_data, pti_data)
-    psse2pm_load!(pm_data, pti_data)
-    psse2pm_shunt!(pm_data, pti_data)
-    psse2pm_generator!(pm_data, pti_data)
-    psse2pm_branch!(pm_data, pti_data)
-    psse2pm_transformer!(pm_data, pti_data)
-    psse2pm_dcline!(pm_data, pti_data)
+    if import_all
+        import_remaining!(pm_data, pti_data["CASE IDENTIFICATION"][1]; exclude=["REV"])
+    end
+
+    psse2pm_bus!(pm_data, pti_data, import_all)
+    psse2pm_load!(pm_data, pti_data, import_all)
+    psse2pm_shunt!(pm_data, pti_data, import_all)
+    psse2pm_generator!(pm_data, pti_data, import_all)
+    psse2pm_branch!(pm_data, pti_data, import_all)
+    psse2pm_transformer!(pm_data, pti_data, import_all)
+    psse2pm_dcline!(pm_data, pti_data, import_all)
 
     # update lookup structure
     for (k, v) in pm_data
@@ -539,8 +595,8 @@ end
 
 
 "Parses directly from file"
-function parse_psse(file::String)::Dict
+function parse_psse(file::String; import_all=false)::Dict
     pti_data = parse_pti(file)
 
-    return parse_psse(pti_data)
+    return parse_psse(pti_data; import_all=import_all)
 end

--- a/src/io/pti.jl
+++ b/src/io/pti.jl
@@ -399,7 +399,7 @@ function parse_pti_data(data_string::String, sections::Array)
             end
 
             debug(LOGGER, join(["Section:", section], " "))
-            if section ∉ ["CASE IDENTIFICATION","TRANSFORMER","VOLTAGE SOURCE CONVERTER","MULTI-TERMINAL DC","TWO-TERMINAL DC","GNE DEVICE"]
+            if !(section in ["CASE IDENTIFICATION","TRANSFORMER","VOLTAGE SOURCE CONVERTER","MULTI-TERMINAL DC","TWO-TERMINAL DC","GNE DEVICE"])
                 section_data = Dict{String,Any}()
                 parse_line_element!(section_data, elements, section)
 

--- a/test/psse.jl
+++ b/test/psse.jl
@@ -190,7 +190,7 @@ end
        @test_warn(getlogger(PowerModels), "Voltage Source Converter DC lines are not yet supported",
                    PowerModels.parse_file("../test/data/pti/frankenstein_70.raw"))
 
-        @test_warn(getlogger(PowerModels), "PTI v33 does not contain vmin and vmax values, defaults of 0.9 and 1.1, respectively, assumed.",
+        @test_warn(getlogger(PowerModels), "PTI v33.0.0 does not contain vmin and vmax values, defaults of 0.9 and 1.1, respectively, assumed.",
                    PowerModels.parse_file("../test/data/pti/parser_test_i.raw"))
 
 
@@ -324,8 +324,15 @@ end
         data = PowerModels.parse_file("../test/data/pti/case30.raw"; import_all=true)
 
         @test length(data) == 19
-        for (key, n) in zip(["bus", "load", "shunt", "gen", "branch", "dcline"], [30, 21, 2, 6, 41, 0])
-            @test length(data[key]) == n
+
+        for (key, n) in zip(["bus", "load", "shunt", "gen", "branch"], [14, 14, 14, 45, 29])
+            for item in values(data[key])
+                if key == "branch" && item["transformer"]
+                    @test length(item) == 42
+                else
+                    @test length(item) == n
+                end
+            end
         end
 
         result = PowerModels.run_opf(data, PowerModels.ACPPowerModel, ipopt_solver)

--- a/test/psse.jl
+++ b/test/psse.jl
@@ -319,4 +319,18 @@ end
             end
         end
     end
+
+    @testset "import all" begin
+        data = PowerModels.parse_file("../test/data/pti/case30.raw"; import_all=true)
+
+        @test length(data) == 19
+        for (key, n) in zip(["bus", "load", "shunt", "gen", "branch", "dcline"], [30, 21, 2, 6, 41, 0])
+            @test length(data[key]) == n
+        end
+
+        result = PowerModels.run_opf(data, PowerModels.ACPPowerModel, ipopt_solver)
+
+        @test result["status"] == :LocalOptimal
+        @test isapprox(result["objective"], 297.878089; atol=1e-4)
+    end
 end


### PR DESCRIPTION
Adds optional keyword argument `import_all` to `parse_file` (defaults to
false). If true, this option will indicate to the parser that all unused
fields from the PTI file should be passed to the final PowerModels data
structure. PTI keys will be converted to lowercase in the PM data
structure. Adds helper function `import_remaining!(data_out, data_in;
exclude)`.

Adds unit tests to ensure proper passing of additional parameters, and
to check that data structures with additional parameters are still
consistent with previous OPF results.

Updated documentation and changelog.

Addresses #242