### PR TITLE
FIX: Guess section in PTI parser

### DIFF
--- a/src/io/pti.jl
+++ b/src/io/pti.jl
@@ -376,7 +376,7 @@ function parse_pti_data(data_string::String, sections::Array)
                 guess_section = ""
             end
 
-            if guess_section == section
+            if guess_section == section && length(sections) > 0
                 section = shift!(sections)
                 continue
             else


### PR DESCRIPTION
During the section guessing during the parsing of the PTI file,
there was not check to see if there were remaining sections.