### PR TITLE
Discrepancy BIM vs BFM

### DIFF
--- a/docs/src/quickguide.md
+++ b/docs/src/quickguide.md
@@ -86,15 +86,15 @@ This network data can be modified in the same way as the previous Matpower `.m` 
 ## Inspecting AC and DC branch flow results
 The flow AC and DC branch results are not written to the result by default. To inspect the flow results, pass a settings Dict
 ```julia
-result = run_opf("case3_dc.m", ACPPowerModel, IpoptSolver(), setting = Dict("output" => Dict("line_flows" => true)))
+result = run_opf("case3_dc.m", ACPPowerModel, IpoptSolver(), setting = Dict("output" => Dict("branch_flows" => true)))
 result["solution"]["dcline"]["1"]
 result["solution"]["branch"]["2"]
 ```
 
-The losses of a AC or DC branch can be derived:
+The losses of an AC or DC branch can be derived:
 ```julia
-loss_ac =  Dict(name => data["p_to"]+data["p_from"] for (name, data) in result["solution"]["branch"])
-loss_dc =  Dict(name => data["p_to"]+data["p_from"] for (name, data) in result["solution"]["dcline"])
+loss_ac =  Dict(name => data["pt"]+data["pf"] for (name, data) in result["solution"]["branch"])
+loss_dc =  Dict(name => data["pt"]+data["pf"] for (name, data) in result["solution"]["dcline"])
 ```
 
 

--- a/src/core/data.jl
+++ b/src/core/data.jl
@@ -44,8 +44,8 @@ function calc_series_current_magnitude_bound(branches, buses)
         g_sh_to = branch["g_to"]
         b_sh_fr = branch["b_fr"]
         b_sh_to = branch["b_to"]
-        zmag_fr = abs(g_sh_fr + im*b_sh_fr)
-        zmag_to = abs(g_sh_to + im*b_sh_to)
+        ymag_fr = abs(g_sh_fr + im*b_sh_fr)
+        ymag_to = abs(g_sh_to + im*b_sh_to)
 
         vmax_fr = bus_fr["vmax"]
         vmax_to = bus_fr["vmax"]
@@ -56,15 +56,47 @@ function calc_series_current_magnitude_bound(branches, buses)
         tap_to = 1 # no transformer on to side, keeps expressions symmetric.
         smax = branch["rate_a"]
 
-        cmax_tot_fr = smax*tap_fr/vmin_fr
-        cmax_tot_to = smax*tap_to/vmin_to
+        cmax_tot_fr = smax/(vmin_fr/tap_fr) #|I|=|S|/|U|
+        cmax_tot_to = smax/(vmin_to/tap_to)
 
-        cmax_sh_fr = zmag_fr * vmax_fr
-        cmax_sh_to = zmag_to * vmax_to
+        cmax_sh_fr = ymag_fr * (vmax_fr/tap_fr)
+        cmax_sh_to = ymag_to * (vmax_to/tap_to)
 
         cmax[key] = max(cmax_tot_fr + cmax_sh_fr, cmax_tot_to + cmax_sh_to)
     end
     return cmax
+end
+
+
+""
+function calc_series_active_power_bound(branches, buses)
+    pmax = Dict([(key, 0.0) for key in keys(branches)])
+    for (key, branch) in branches
+        bus_fr = buses[branch["f_bus"]]
+        g_sh_fr = branch["g_fr"]
+        vmax_fr = bus_fr["vmax"]
+        tap_fr = branch["tap"]
+        smax = branch["rate_a"]
+
+        pmax[key] = smax + abs(g_sh_fr) * (vmax_fr/tap_fr)^2
+    end
+    return pmax
+end
+
+
+""
+function calc_series_reactive_power_bound(branches, buses)
+    qmax = Dict([(key, 0.0) for key in keys(branches)])
+    for (key, branch) in branches
+        bus_fr = buses[branch["f_bus"]]
+        b_sh_fr = branch["g_fr"]
+        vmax_fr = bus_fr["vmax"]
+        tap_fr = branch["tap"]
+        smax = branch["rate_a"]
+
+        qmax[key] = smax + abs(b_sh_fr) * (vmax_fr/tap_fr)^2
+    end
+    return qmax
 end
 
 

--- a/test/data/matpower/case5_gap.m
+++ b/test/data/matpower/case5_gap.m
@@ -45,9 +45,3 @@ mpc.branch = [
 	3	 4	 0.00297	 0.0297	 0.00674	 426.0	 426.0	 426.0	 0.0	 0.0	 1	 -4.41979643164	 2.02540580579;
 	4	 5	 0.00297	 0.0297	 0.00674	 240.0	 240.0	 240.0	 0.0	 0.0	 1	 -5.06895761352	 -0.827924013964;
 ];
-
-%% dcline data
-%	fbus	tbus	status	Pf	Pt	Qf	Qt	Vf	Vt	Pmin	Pmax	QminF	QmaxF	QminT	QmaxT	loss0	loss1
-mpc.dcline = [
-	3	5	1	0 0	0	0	1.1	1.05555	0	0 	0	0	0 0	0	0;
-];

--- a/test/data/matpower/case5_gap.m
+++ b/test/data/matpower/case5_gap.m
@@ -45,3 +45,9 @@ mpc.branch = [
 	3	 4	 0.00297	 0.0297	 0.00674	 426.0	 426.0	 426.0	 0.0	 0.0	 1	 -4.41979643164	 2.02540580579;
 	4	 5	 0.00297	 0.0297	 0.00674	 240.0	 240.0	 240.0	 0.0	 0.0	 1	 -5.06895761352	 -0.827924013964;
 ];
+
+%% dcline data
+%	fbus	tbus	status	Pf	Pt	Qf	Qt	Vf	Vt	Pmin	Pmax	QminF	QmaxF	QminT	QmaxT	loss0	loss1
+mpc.dcline = [
+	3	5	1	0 0	0	0	1.1	1.05555	0	0 	0	0	0 0	0	0;
+];


### PR DESCRIPTION
Regarding #278 , I spent a bit of time going through the implementation. I've found one bug in the bounds of the series active and reactive power flow variables, but that wasn't the source of the discrepancy, as it occurs just as well with the line shunts ('b') set to zero. 

The actual reason is the lack of a current constraint in the SOC BIM formulation. 

In the case5_gap.m, the generator costs are negative. So the objective actually results in a *maximization* of the amount of power injected into the system. As expected, this leads to a significant gap between the exact model and the SOC model, as the slack introduced by the convexification can be used to generate artificial power losses on the lines. Assume the shunts are set to zero, then P_lij + P_lji = P^loss_l = r_l *|I_lij|^2 and (P_lij^2 + Q_lij^2)/|U_i|^2 <= |I_ij|^2. In the BFM, the constraint P_lij + P_lji  = r * ccm limits the amount of power that can be dumped into the branch as an artifical load, due to the bound on ccm (which is nevertheless less strict than the apparent power bound, after compensation for voltage deviations). You can see that all the ccm variables are at their upper bound in case5_gap.m. 

How do you want to go forward?