### PR TITLE
ADD: Warning when fields are missing during PTI parse

### DIFF
--- a/src/io/pti.jl
+++ b/src/io/pti.jl
@@ -247,13 +247,15 @@ data types given by `section` and saved into `data::Dict`
 
 """
 function parse_line_element!(data::Dict, elements::Array, section::AbstractString)
+    missing = []
     for (field, dtype) in get_pti_dtypes(section)
         try
             element = shift!(elements)
         catch message
             if isa(message, ArgumentError)
                 debug(LOGGER, "Have run out of elements in $section at $field")
-                break
+                push!(missing, field)
+                continue
             end
         end
 
@@ -281,6 +283,11 @@ function parse_line_element!(data::Dict, elements::Array, section::AbstractStrin
                 error(LOGGER, message)
             end
         end
+    end
+
+    if length(missing) > 0
+        missing_str = join(missing, ", ")
+        warn(LOGGER, "The following fields in $section are missing: $missing_str")
     end
 end
 

--- a/test/psse.jl
+++ b/test/psse.jl
@@ -184,7 +184,10 @@ end
         @test_warn(TESTLOG, "Could not find bus 1, returning 0 for field vm",
                    PowerModels.get_bus_value(1, "vm", dummy_data))
 
-        @test_warn(getlogger(PowerModels), "PTI v33.0.0 does not contain vmin and vmax values, defaults of 0.9 and 1.1, respectively, assumed.",
+        @test_warn(TESTLOG, "PTI v33.0.0 does not contain vmin and vmax values, defaults of 0.9 and 1.1, respectively, assumed.",
+                   PowerModels.parse_file("../test/data/pti/parser_test_i.raw"))
+
+        @test_warn(TESTLOG, "The following fields in BUS are missing: NVHI, NVLO, EVHI, EVLO",
                    PowerModels.parse_file("../test/data/pti/parser_test_i.raw"))
 
         setlevel!(TESTLOG, "error")


### PR DESCRIPTION
Adds a warning enumerating the missing data fields when parsing a PTI
file.

Closes #292 