### PR TITLE
ADD: Unit tests for Multphase and Multinetwork

### DIFF
--- a/src/core/data.jl
+++ b/src/core/data.jl
@@ -396,7 +396,7 @@ function _rescale_cost_model(comp::Dict{String,Any}, scale::Real, multiphase::Bo
                         comp["cost"][ph][i] = item*(scale^(degree-i))
                     end
                 else
-                    warn(LOGGER, "Skipping cost model of type $(comp["model"]) on phase $(ph) in per unit transformation")
+                    warn(LOGGER, "Skipping cost model of type $(comp["model"][ph]) on phase $(ph) in per unit transformation")
                 end
             end
         end
@@ -844,14 +844,14 @@ function _propagate_topology_status(data::Dict{String,Any})
     buses = Dict(bus["bus_i"] => bus for (i,bus) in data["bus"])
 
     for (i,load) in data["load"]
-        if load["status"] != 0 && load["pd"] == 0.0 && load["qd"] == 0.0
+        if load["status"] != 0 && all(load["pd"] .== 0.0) && all(load["qd"] .== 0.0)
             info(LOGGER, "deactivating load $(load["index"]) due to zero pd and qd")
             load["status"] = 0
         end
     end
 
     for (i,shunt) in data["shunt"]
-        if shunt["status"] != 0 && shunt["gs"] == 0.0 && shunt["bs"] == 0.0
+        if shunt["status"] != 0 && all(shunt["gs"] .== 0.0) && all(shunt["bs"] .== 0.0)
             info(LOGGER, "deactivating shunt $(shunt["index"]) due to zero gs and bs")
             shunt["status"] = 0
         end
@@ -1004,7 +1004,7 @@ function _propagate_topology_status(data::Dict{String,Any})
 
     info(LOGGER, "topology status propagation fixpoint reached in $(iteration) rounds")
 
-    check_refrence_buses(data)
+    check_reference_buses(data)
 end
 
 
@@ -1039,26 +1039,26 @@ function _select_largest_component(data::Dict{String,Any})
         end
     end
 
-    check_refrence_buses(data)
+    check_reference_buses(data)
 end
 
 
 """
 checks that each connected components has a reference bus, if not, adds one
 """
-function check_refrence_buses(data::Dict{String,Any})
+function check_reference_buses(data::Dict{String,Any})
     if InfrastructureModels.ismultinetwork(data)
         for (i,nw_data) in data["nw"]
-            _check_refrence_buses(nw_data)
+            _check_reference_buses(nw_data)
         end
     else
-        _check_refrence_buses(data)
+        _check_reference_buses(data)
     end
 end
 
 
 ""
-function _check_refrence_buses(data::Dict{String,Any})
+function _check_reference_buses(data::Dict{String,Any})
     bus_lookup = Dict(bus["bus_i"] => bus for (i,bus) in data["bus"])
     bus_gen = bus_gen_lookup(data["gen"], data["bus"])
 

--- a/test/multinetwork.jl
+++ b/test/multinetwork.jl
@@ -1,5 +1,6 @@
 using JuMP
 PMs = PowerModels
+TESTLOG = getlogger(PowerModels)
 
 @testset "test multinetwork" begin
 
@@ -251,6 +252,27 @@ PMs = PowerModels
             end
         end
 
+    end
+
+    @testset "test errors and warnings" begin
+        mn_data = build_mn_data("../test/data/matpower/case5.m")
+
+        @test_throws(TESTLOG, ErrorException, PowerModels.check_voltage_angle_differences(mn_data))
+        @test_throws(TESTLOG, ErrorException, PowerModels.check_thermal_limits(mn_data))
+        @test_throws(TESTLOG, ErrorException, PowerModels.check_branch_directions(mn_data))
+        @test_throws(TESTLOG, ErrorException, PowerModels.check_branch_loops(mn_data))
+        @test_throws(TESTLOG, ErrorException, PowerModels.check_connectivity(mn_data))
+        @test_throws(TESTLOG, ErrorException, PowerModels.check_transformer_parameters(mn_data))
+        @test_throws(TESTLOG, ErrorException, PowerModels.check_bus_types(mn_data))
+        @test_throws(TESTLOG, ErrorException, PowerModels.check_dcline_limits(mn_data))
+        @test_throws(TESTLOG, ErrorException, PowerModels.check_voltage_setpoints(mn_data))
+        @test_throws(TESTLOG, ErrorException, PowerModels.check_cost_functions(mn_data))
+        @test_throws(TESTLOG, ErrorException, PowerModels.connected_components(mn_data))
+
+        @test_nowarn PowerModels.check_reference_buses(mn_data)
+        @test_nowarn PowerModels.make_multiphase(mn_data, 3)
+
+        @test_throws(TESTLOG, ErrorException, PowerModels.run_ac_opf(mn_data, ipopt_solver))
     end
 
 end

--- a/test/multiphase.jl
+++ b/test/multiphase.jl
@@ -244,13 +244,12 @@ end
         @test_throws(TESTLOG, ErrorException, PowerModels.update_data(mp_data_2p, mp_data_3p))
         @test_throws(TESTLOG, ErrorException, PowerModels.check_keys(mp_data_3p, ["load"]))
 
-        setlevel!(TESTLOG, "warn")
-        TESTLOG.propagate = false
+        setlevel!(TESTLOG, "info")
 
         @test_warn(TESTLOG, "Skipping cost model of type 3 in per unit transformation", PowerModels.make_mixed_units(data))
         @test_warn(TESTLOG, "Skipping cost model of type 3 on phase 1 in per unit transformation", PowerModels.make_mixed_units(mp_data_2p))
 
-        PowerModels.make_per_unit(mp_data_2p)
+        @test_warn(TESTLOG, "Skipping cost model of type 3 on phase 1 in per unit transformation", PowerModels.make_per_unit(mp_data_2p))
 
         @test_nowarn PowerModels.check_voltage_angle_differences(mp_data_3p)
 
@@ -277,13 +276,12 @@ end
         mp_data_3p["load"]["1"]["pd"] = mp_data_3p["load"]["1"]["qd"] = [0, 0, 0]
         mp_data_3p["shunt"]["1"] = Dict{String,Any}("gs"=>[0,0,0], "bs"=>[0,0,0], "status"=>1, "shunt_bus"=>1, "index"=>1)
 
-        PowerModels.propagate_topology_status(mp_data_3p)
+        Memento.Test.@test_log(TESTLOG, "info", "deactivating load 1 due to zero pd and qd", PowerModels.propagate_topology_status(mp_data_3p))
 
         @test mp_data_3p["load"]["1"]["status"] == 0
         @test mp_data_3p["shunt"]["1"]["status"] == 0
 
         setlevel!(TESTLOG, "error")
-        TESTLOG.propagate = true
 
         @test_throws(TESTLOG, ErrorException, PowerModels.check_thermal_limits(mp_data_3p))
         @test_throws(TESTLOG, ErrorException, PowerModels.check_branch_directions(mp_data_3p))

--- a/test/psse.jl
+++ b/test/psse.jl
@@ -179,7 +179,6 @@ end
         dummy_data = PowerModels.parse_file("../test/data/pti/frankenstein_70.raw")
 
         setlevel!(TESTLOG, "warn")
-        TESTLOG.propagate = false
 
         @test_warn(TESTLOG, "Could not find bus 1, returning 0 for field vm",
                    PowerModels.get_bus_value(1, "vm", dummy_data))
@@ -191,7 +190,6 @@ end
                    PowerModels.parse_file("../test/data/pti/parser_test_i.raw"))
 
         setlevel!(TESTLOG, "error")
-        TESTLOG.propagate = true
     end
 
     @testset "three-winding transformer" begin

--- a/test/pti.jl
+++ b/test/pti.jl
@@ -5,17 +5,15 @@ TESTLOG = getlogger(PowerModels)
 @testset "test .raw file parser" begin
     @testset "Check PTI exception handling" begin
         setlevel!(TESTLOG, "warn")
-        TESTLOG.propagate = false
 
         @test_nowarn PowerModels.parse_pti("../test/data/pti/parser_test_a.raw")
         @test_throws(TESTLOG, ErrorException, PowerModels.parse_pti("../test/data/pti/parser_test_b.raw"))
-        @test_warn(TESTLOG, "Version 32 of PTI format is unsupported, parser may not function correctly.", 
+        @test_warn(TESTLOG, "Version 32 of PTI format is unsupported, parser may not function correctly.",
                    PowerModels.parse_pti("../test/data/pti/parser_test_c.raw"))
         @test_throws(TESTLOG, ErrorException, PowerModels.parse_pti("../test/data/pti/parser_test_d.raw"))
         @test_warn(TESTLOG, "GNE DEVICE parsing is not supported.", PowerModels.parse_pti("../test/data/pti/parser_test_h.raw"))
 
         setlevel!(TESTLOG, "error")
-        TESTLOG.propagate = true
     end
 
     @testset "4-bus frankenstein file" begin


### PR DESCRIPTION
Adds Unit tests to check for warnings, errors and check function
extensions (e.g. on `var`, `ref`, and `con`) for Multiphase features.

Adds Unit test to check for errors and warnings with Multinetwork
features.

Renames `check_refrence_buses` to `check_reference_buses`
(spelling error).

Corrects error message in `_rescale_cost_model` to handle phases.

Updates loads/shunts check in `propagate_topology_status` to handle
multiphase networks.