### PR TITLE
UPD: updates network checks for multiphase networks

### DIFF
--- a/src/core/data.jl
+++ b/src/core/data.jl
@@ -386,7 +386,7 @@ function _rescale_cost_model(comp::Dict{String,Any}, scale::Real, multiphase::Bo
         else
             phases = length(comp["model"])
             for ph in 1:phases
-                ph_str = phases > 1 ? " on phase $(ph)" : ""
+                ph_str = isa(comp["model"], PowerModels.MultiPhaseValue) ? " on phase $(ph)" : ""
                 if comp["model"][ph] == 1
                     for i in 1:2:length(comp["cost"][ph])
                         comp["cost"][ph][i] = comp["cost"][ph][i]/scale
@@ -434,7 +434,7 @@ function check_voltage_angle_differences(data::Dict{String,Any}, default_pad = 1
     assert("per_unit" in keys(data) && data["per_unit"])
 
     for ph in 1:get(data, "phases", 1)
-        ph_str = get(data, "phases", 1) > 1 ? ", phase $(ph)" : ""
+        ph_str = haskey(data, "phases") ? ", phase $(ph)" : ""
         for (i, branch) in data["branch"]
             angmin = branch["angmin"][ph]
             angmax = branch["angmax"][ph]
@@ -484,7 +484,7 @@ function check_thermal_limits(data::Dict{String,Any})
 
     for (i, branch) in data["branch"]
         for ph in 1:get(data, "phases", 1)
-            ph_str = get(data, "phases", 1) > 1 ? ", phase $(ph)" : ""
+            ph_str = haskey(data, "phases") ? ", phase $(ph)" : ""
             if branch["rate_a"][ph] <= 0.0
                 theta_max = max(abs(branch["angmin"][ph]), abs(branch["angmax"][ph]))
 
@@ -630,7 +630,7 @@ function check_transformer_parameters(data::Dict{String,Any})
             end
         else
             for ph in 1:get(data, "phases", 1)
-                ph_str = get(data, "phases", 1) > 1 ? " on phase $(ph)" : ""
+                ph_str = haskey(data, "phases") ? " on phase $(ph)" : ""
                 if branch["tap"][ph] <= 0.0
                     warn(LOGGER, "branch found with non-positive tap value of $(branch["tap"][ph]), setting a tap to 1.0$(ph_str)")
                     if haskey(data, "phases")
@@ -697,7 +697,7 @@ function check_dcline_limits(data::Dict{String,Any})
     mva_base = data["baseMVA"]
 
     for ph in 1:get(data, "phases", 1)
-        ph_str = get(data, "phases", 1) > 1 ? ", phase $(ph)" : ""
+        ph_str = haskey(data, "phases") ? ", phase $(ph)" : ""
         for (i, dcline) in data["dcline"]
             if dcline["loss0"][ph] < 0.0
                 new_rate = 0.0
@@ -756,7 +756,7 @@ function check_voltage_setpoints(data::Dict{String,Any})
     end
 
     for ph in 1:get(data, "phases", 1)
-        ph_str = get(data, "phases", 1) > 1 ? "phase $(ph) " : ""
+        ph_str = haskey(data, "phases") ? "phase $(ph) " : ""
         for (i,gen) in data["gen"]
             bus_id = gen["gen_bus"]
             bus = data["bus"]["$(bus_id)"]

--- a/src/core/data.jl
+++ b/src/core/data.jl
@@ -386,6 +386,7 @@ function _rescale_cost_model(comp::Dict{String,Any}, scale::Real, multiphase::Bo
         else
             phases = length(comp["model"])
             for ph in 1:phases
+                ph_str = phases > 1 ? " on phase $(ph)" : ""
                 if comp["model"][ph] == 1
                     for i in 1:2:length(comp["cost"][ph])
                         comp["cost"][ph][i] = comp["cost"][ph][i]/scale
@@ -396,7 +397,7 @@ function _rescale_cost_model(comp::Dict{String,Any}, scale::Real, multiphase::Bo
                         comp["cost"][ph][i] = item*(scale^(degree-i))
                     end
                 else
-                    warn(LOGGER, "Skipping cost model of type $(comp["model"][ph]) on phase $(ph) in per unit transformation")
+                    warn(LOGGER, "Skipping cost model of type $(comp["model"][ph])$(ph_str) in per unit transformation")
                 end
             end
         end
@@ -432,48 +433,40 @@ function check_voltage_angle_differences(data::Dict{String,Any}, default_pad = 1
 
     assert("per_unit" in keys(data) && data["per_unit"])
 
-    if haskey(data, "phases")
-        for h in 1:data["phases"]
-            for (i, branch) in data["branch"]
-                angmin = branch["angmin"][h]
-                angmax = branch["angmax"][h]
-
-                if angmin <= -pi/2
-                    warn(LOGGER, "this code only supports angmin values in -90 deg. to 90 deg., tightening the value on branch $i, phase $h from $(rad2deg(angmin)) to -$(rad2deg(default_pad)) deg.")
-                    branch["angmin"][h] = -default_pad
-                end
-
-                if angmax >= pi/2
-                    warn(LOGGER, "this code only supports angmax values in -90 deg. to 90 deg., tightening the value on branch $i, phase $h from $(rad2deg(angmax)) to $(rad2deg(default_pad)) deg.")
-                    branch["angmax"][h] = default_pad
-                end
-
-                if angmin == 0.0 && angmax == 0.0
-                    warn(LOGGER, "angmin and angmax values are 0, widening these values on branch $i, phase $h to +/- $(rad2deg(default_pad)) deg.")
-                    branch["angmin"][h] = -default_pad
-                    branch["angmax"][h] = default_pad
-                end
-            end
-        end
-    else
+    for ph in 1:get(data, "phases", 1)
+        ph_str = get(data, "phases", 1) > 1 ? ", phase $(ph)" : ""
         for (i, branch) in data["branch"]
-            angmin = branch["angmin"]
-            angmax = branch["angmax"]
+            angmin = branch["angmin"][ph]
+            angmax = branch["angmax"][ph]
 
             if angmin <= -pi/2
-                warn(LOGGER, "this code only supports angmin values in -90 deg. to 90 deg., tightening the value on branch $i from $(rad2deg(angmin)) to -$(rad2deg(default_pad)) deg.")
-                branch["angmin"] = -default_pad
+                warn(LOGGER, "this code only supports angmin values in -90 deg. to 90 deg., tightening the value on branch $i$(ph_str) from $(rad2deg(angmin)) to -$(rad2deg(default_pad)) deg.")
+                if haskey(data, "phases")
+                    branch["angmin"][ph] = -default_pad
+                else
+                    branch["angmin"] = -default_pad
+                end
             end
 
             if angmax >= pi/2
-                warn(LOGGER, "this code only supports angmax values in -90 deg. to 90 deg., tightening the value on branch $i from $(rad2deg(angmax)) to $(rad2deg(default_pad)) deg.")
-                branch["angmax"] = default_pad
+                warn(LOGGER, "this code only supports angmax values in -90 deg. to 90 deg., tightening the value on branch $i$(ph_str) from $(rad2deg(angmax)) to $(rad2deg(default_pad)) deg.")
+                if haskey(data, "phases")
+                    branch["angmax"][ph] = default_pad
+                else
+                    branch["angmax"] = default_pad
+                end
+
             end
 
             if angmin == 0.0 && angmax == 0.0
-                warn(LOGGER, "angmin and angmax values are 0, widening these values on branch $i to +/- $(rad2deg(default_pad)) deg.")
-                branch["angmin"] =  -default_pad
-                branch["angmax"] = default_pad
+                warn(LOGGER, "angmin and angmax values are 0, widening these values on branch $i$(ph_str) to +/- $(rad2deg(default_pad)) deg.")
+                if haskey(data, "phases")
+                    branch["angmin"][ph] = -default_pad
+                    branch["angmax"][ph] =  default_pad
+                else
+                    branch["angmin"] = -default_pad
+                    branch["angmax"] =  default_pad
+                end
             end
         end
     end
@@ -491,6 +484,7 @@ function check_thermal_limits(data::Dict{String,Any})
 
     for (i, branch) in data["branch"]
         for ph in 1:get(data, "phases", 1)
+            ph_str = get(data, "phases", 1) > 1 ? ", phase $(ph)" : ""
             if branch["rate_a"][ph] <= 0.0
                 theta_max = max(abs(branch["angmin"][ph]), abs(branch["angmax"][ph]))
 
@@ -509,7 +503,7 @@ function check_thermal_limits(data::Dict{String,Any})
 
                 new_rate = y_mag*m_vmax*c_max
 
-                warn(LOGGER, "this code only supports positive rate_a values, changing the value on branch $(branch["index"]) from $(mva_base*branch["rate_a"][ph]) to $(mva_base*new_rate)")
+                warn(LOGGER, "this code only supports positive rate_a values, changing the value on branch $(branch["index"])$(ph_str) from $(mva_base*branch["rate_a"][ph]) to $(mva_base*new_rate)")
                 if haskey(data, "phases")
                     branch["rate_a"][ph] = new_rate
                 else
@@ -636,8 +630,9 @@ function check_transformer_parameters(data::Dict{String,Any})
             end
         else
             for ph in 1:get(data, "phases", 1)
+                ph_str = get(data, "phases", 1) > 1 ? " on phase $(ph)" : ""
                 if branch["tap"][ph] <= 0.0
-                    warn(LOGGER, "branch found with non-positive tap value of $(branch["tap"][ph]), setting a tap to 1.0")
+                    warn(LOGGER, "branch found with non-positive tap value of $(branch["tap"][ph]), setting a tap to 1.0$(ph_str)")
                     if haskey(data, "phases")
                         branch["tap"][ph] = 1.0
                     else
@@ -702,10 +697,11 @@ function check_dcline_limits(data::Dict{String,Any})
     mva_base = data["baseMVA"]
 
     for ph in 1:get(data, "phases", 1)
+        ph_str = get(data, "phases", 1) > 1 ? ", phase $(ph)" : ""
         for (i, dcline) in data["dcline"]
             if dcline["loss0"][ph] < 0.0
                 new_rate = 0.0
-                warn(LOGGER, "this code only supports positive loss0 values, changing the value on dcline $(dcline["index"]) from $(mva_base*dcline["loss0"][ph]) to $(mva_base*new_rate)")
+                warn(LOGGER, "this code only supports positive loss0 values, changing the value on dcline $(dcline["index"])$(ph_str) from $(mva_base*dcline["loss0"][ph]) to $(mva_base*new_rate)")
                 if haskey(data, "phases")
                     dcline["loss0"][ph] = new_rate
                 else
@@ -715,7 +711,7 @@ function check_dcline_limits(data::Dict{String,Any})
 
             if dcline["loss0"][ph] >= dcline["pmaxf"][ph]*(1-dcline["loss1"][ph] )+ dcline["pmaxt"][ph]
                 new_rate = 0.0
-                warn(LOGGER, "this code only supports loss0 values which are consistent with the line flow bounds, changing the value on dcline $(dcline["index"]) from $(mva_base*dcline["loss0"][ph]) to $(mva_base*new_rate)")
+                warn(LOGGER, "this code only supports loss0 values which are consistent with the line flow bounds, changing the value on dcline $(dcline["index"])$(ph_str) from $(mva_base*dcline["loss0"][ph]) to $(mva_base*new_rate)")
                 if haskey(data, "phases")
                     dcline["loss0"][ph] = new_rate
                 else
@@ -725,7 +721,7 @@ function check_dcline_limits(data::Dict{String,Any})
 
             if dcline["loss1"][ph] < 0.0
                 new_rate = 0.0
-                warn(LOGGER, "this code only supports positive loss1 values, changing the value on dcline $(dcline["index"]) from $(dcline["loss1"][ph]) to $(new_rate)")
+                warn(LOGGER, "this code only supports positive loss1 values, changing the value on dcline $(dcline["index"])$(ph_str) from $(dcline["loss1"][ph]) to $(new_rate)")
                 if haskey(data, "phases")
                     dcline["loss1"][ph] = new_rate
                 else
@@ -735,7 +731,7 @@ function check_dcline_limits(data::Dict{String,Any})
 
             if dcline["loss1"][ph] >= 1.0
                 new_rate = 0.0
-                warn(LOGGER, "this code only supports loss1 values < 1, changing the value on dcline $(dcline["index"]) from $(dcline["loss1"][ph]) to $(new_rate)")
+                warn(LOGGER, "this code only supports loss1 values < 1, changing the value on dcline $(dcline["index"])$(ph_str) from $(dcline["loss1"][ph]) to $(new_rate)")
                 if haskey(data, "phases")
                     dcline["loss1"][ph] = new_rate
                 else
@@ -760,11 +756,12 @@ function check_voltage_setpoints(data::Dict{String,Any})
     end
 
     for ph in 1:get(data, "phases", 1)
+        ph_str = get(data, "phases", 1) > 1 ? "phase $(ph) " : ""
         for (i,gen) in data["gen"]
             bus_id = gen["gen_bus"]
             bus = data["bus"]["$(bus_id)"]
             if gen["vg"][ph] != bus["vm"][ph]
-                warn(LOGGER, "the phase $(ph) voltage setpoint on generator $(i) does not match the value at bus $(bus_id)")
+                warn(LOGGER, "the $(ph_str)voltage setpoint on generator $(i) does not match the value at bus $(bus_id)")
             end
         end
 
@@ -776,11 +773,11 @@ function check_voltage_setpoints(data::Dict{String,Any})
             bus_to = data["bus"]["$(bus_to_id)"]
 
             if dcline["vf"][ph] != bus_fr["vm"][ph]
-                warn(LOGGER, "the phase $(ph) from bus voltage setpoint on dc line $(i) does not match the value at bus $(bus_fr_id)")
+                warn(LOGGER, "the $(ph_str)from bus voltage setpoint on dc line $(i) does not match the value at bus $(bus_fr_id)")
             end
 
             if dcline["vt"][ph] != bus_to["vm"][ph]
-                warn(LOGGER, "the phase $(ph) to bus voltage setpoint on dc line $(i) does not match the value at bus $(bus_to_id)")
+                warn(LOGGER, "the $(ph_str)to bus voltage setpoint on dc line $(i) does not match the value at bus $(bus_to_id)")
             end
         end
     end
@@ -807,16 +804,17 @@ end
 function _check_cost_functions(id, comp)
     if "model" in keys(comp) && "cost" in keys(comp)
         for ph in 1:length(comp["ncost"])
+            ph_str = length(comp["ncost"]) > 1 ? "phase $(ph) " : ""
             if comp["model"][ph] == 1
                 if length(PowerModels.getmpv(comp["cost"], ph)) != 2*comp["ncost"][ph]
-                    error("ncost of $(comp["ncost"][ph]) not consistent with $(length(PowerModels.getmpv(comp["cost"], ph))) cost values")
+                    error("$(ph_str)ncost of $(comp["ncost"][ph]) not consistent with $(length(PowerModels.getmpv(comp["cost"], ph))) cost values")
                 end
                 if length(PowerModels.getmpv(comp["cost"], ph)) < 4
-                    error("cost includes $(comp["ncost"]) points, but at least two points are required")
+                    error("$(ph_str)cost includes $(comp["ncost"][ph]) points, but at least two points are required")
                 end
                 for i in 3:2:length(PowerModels.getmpv(comp["cost"], ph))
                     if PowerModels.getmpv(comp["cost"], ph)[i-2] >= PowerModels.getmpv(comp["cost"], ph)[i]
-                        error("non-increasing x values in pwl cost model")
+                        error("non-increasing x values in $(ph_str)pwl cost model")
                     end
                 end
                 if "pmin" in keys(comp) && "pmax" in keys(comp)
@@ -824,16 +822,16 @@ function _check_cost_functions(id, comp)
                     pmax = comp["pmax"][ph]
                     for i in 3:2:length(PowerModels.getmpv(comp["cost"], ph))
                         if PowerModels.getmpv(comp["cost"], ph)[i] < pmin || PowerModels.getmpv(comp["cost"], ph)[i] > pmax
-                            warn(LOGGER, "pwl x value $(PowerModels.getmpv(comp["cost"], ph)[i]) is outside the generator bounds $(pmin)-$(pmax)")
+                            warn(LOGGER, "$(ph_str)pwl x value $(PowerModels.getmpv(comp["cost"], ph)[i]) is outside the generator bounds $(pmin)-$(pmax)")
                         end
                     end
                 end
             elseif comp["model"][ph] == 2
                 if length(PowerModels.getmpv(comp["cost"], ph)) != comp["ncost"][ph]
-                    error("ncost of $(comp["ncost"][ph]) not consistent with $(length(PowerModels.getmpv(comp["cost"], ph))) cost values")
+                    error("$(ph_str)ncost of $(comp["ncost"][ph]) not consistent with $(length(PowerModels.getmpv(comp["cost"], ph))) cost values")
                 end
             else
-                warn(LOGGER, "Unknown generator cost model of type $(comp["model"][ph])")
+                warn(LOGGER, "Unknown $(ph_str)generator cost model of type $(comp["model"][ph])")
             end
         end
     end

--- a/src/core/multiphase.jl
+++ b/src/core/multiphase.jl
@@ -51,14 +51,16 @@ Base.getindex(mpv::MultiPhaseValue, args...) = mpv.values[args...]
 
 Base.show(io::IO, mpv::MultiPhaseValue) = Base.show(io, mpv.values)
 
-Base.broadcast(f, a::MultiPhaseValue, b::MultiPhaseValue) = broadcast(f, a.values, b.values)
-Base.broadcast(f, a, b::MultiPhaseValue) = broadcast(f, a, b.values)
-Base.broadcast(f, a::MultiPhaseValue, b) = broadcast(f, a.values, b)
+Base.broadcast(f::Any, a, b::MultiPhaseValue) = broadcast(f, a, b.values)
+Base.broadcast(f::Any, a::MultiPhaseValue, b) = broadcast(f, a.values, b)
+Base.broadcast(f::Any, a::MultiPhaseValue, b::MultiPhaseValue) = broadcast(f, a.values, b.values)
 
 Base.:+(a::MultiPhaseVector{T}, b...) where T = MultiPhaseVector{T}(+(a.values, (isa(i, MultiPhaseValue) ? i.values : i for i in [b...])...))
 Base.:-(a::MultiPhaseVector{T}, b...) where T = MultiPhaseVector{T}(-(a.values, (isa(i, MultiPhaseValue) ? i.values : i for i in [b...])...))
 Base.:*(a::MultiPhaseVector{T}, b...) where T = MultiPhaseVector{T}(*(a.values, (isa(i, MultiPhaseValue) ? i.values : i for i in [b...])...))
 Base.:/(a::MultiPhaseVector{T}, b...) where T = MultiPhaseVector{T}(/(a.values, (isa(i, MultiPhaseValue) ? i.values : i for i in [b...])...))
+Base.:*(a::Real, b::MultiPhaseVector{T}) where T = MultiPhaseVector{T}(Base.broadcast(*, a, b.values))
+Base.:/(a::Real, b::MultiPhaseVector{T}) where T = MultiPhaseVector{T}(Base.broadcast(/, a, b.values))
 
 Base.:+(a::MultiPhaseMatrix{T}, b...) where T = MultiPhaseMatrix{T}(+(a.values, (isa(i, MultiPhaseValue) ? i.values : i for i in [b...])...))
 Base.:-(a::MultiPhaseMatrix{T}, b...) where T = MultiPhaseMatrix{T}(-(a.values, (isa(i, MultiPhaseValue) ? i.values : i for i in [b...])...))

--- a/test/data.jl
+++ b/test/data.jl
@@ -340,23 +340,25 @@ end
     setlevel!(TESTLOG, "warn")
 
     data["gen"]["1"]["model"] = 3
+    @test_warn(TESTLOG, "Skipping cost model of type 3 in per unit transformation", PowerModels.make_mixed_units(data))
+    @test_warn(TESTLOG, "Skipping cost model of type 3 in per unit transformation", PowerModels.make_per_unit(data))
     @test_warn(TESTLOG, "Unknown generator cost model of type 3", PowerModels.check_cost_functions(data))
     data["gen"]["1"]["model"] = 1
 
     data["gen"]["1"]["cost"][3] = 3000
     @test_warn(TESTLOG, "pwl x value 3000 is outside the generator bounds 0.0-20.0", PowerModels.check_cost_functions(data))
 
-    data["dcline"]["1"]["loss0"] = -1
+    data["dcline"]["1"]["loss0"] = -1.0
     @test_warn(TESTLOG, "this code only supports positive loss0 values, changing the value on dcline 1 from -100.0 to 0.0", PowerModels.check_dcline_limits(data))
 
-    data["dcline"]["1"]["loss1"] = -1
-    @test_warn(TESTLOG, "this code only supports positive loss1 values, changing the value on dcline 1 from -1 to 0.0", PowerModels.check_dcline_limits(data))
+    data["dcline"]["1"]["loss1"] = -1.0
+    @test_warn(TESTLOG, "this code only supports positive loss1 values, changing the value on dcline 1 from -1.0 to 0.0", PowerModels.check_dcline_limits(data))
 
     @test data["dcline"]["1"]["loss0"] == 0.0
     @test data["dcline"]["1"]["loss1"] == 0.0
 
-    data["dcline"]["1"]["loss1"] = 100
-    @test_warn(TESTLOG, "this code only supports loss1 values < 1, changing the value on dcline 1 from 100 to 0.0", PowerModels.check_dcline_limits(data))
+    data["dcline"]["1"]["loss1"] = 100.0
+    @test_warn(TESTLOG, "this code only supports loss1 values < 1, changing the value on dcline 1 from 100.0 to 0.0", PowerModels.check_dcline_limits(data))
 
     delete!(data["branch"]["1"], "tap")
     @test_warn(TESTLOG, "branch found without tap value, setting a tap to 1.0", PowerModels.check_transformer_parameters(data))
@@ -364,8 +366,8 @@ end
     delete!(data["branch"]["1"], "shift")
     @test_warn(TESTLOG, "branch found without shift value, setting a shift to 0.0", PowerModels.check_transformer_parameters(data))
 
-    data["branch"]["1"]["tap"] = -1
-    @test_warn(TESTLOG, "branch found with non-positive tap value of -1, setting a tap to 1.0", PowerModels.check_transformer_parameters(data))
+    data["branch"]["1"]["tap"] = -1.0
+    @test_warn(TESTLOG, "branch found with non-positive tap value of -1.0, setting a tap to 1.0", PowerModels.check_transformer_parameters(data))
 
     setlevel!(TESTLOG, "error")
 end

--- a/test/multiphase.jl
+++ b/test/multiphase.jl
@@ -260,7 +260,7 @@ end
         mp_data_3p["gen"]["1"]["model"][2] = 3
         @test_warn(TESTLOG, "Skipping cost model of type 3 on phase 2 in per unit transformation", PowerModels.make_mixed_units(mp_data_3p))
         @test_warn(TESTLOG, "Skipping cost model of type 3 on phase 2 in per unit transformation", PowerModels.make_per_unit(mp_data_3p))
-        @test_warn(TESTLOG, "Unknown generator cost model of type 3", PowerModels.check_cost_functions(mp_data_3p))
+        @test_warn(TESTLOG, "Unknown phase 2 generator cost model of type 3", PowerModels.check_cost_functions(mp_data_3p))
 
         mp_data_3p["gen"]["1"]["model"][2] = 1
         mp_data_3p["gen"]["1"]["cost"][2][3] = 3000
@@ -296,16 +296,16 @@ end
         @test mp_data_3p["shunt"]["1"]["status"] == 0
 
         mp_data_3p["dcline"]["1"]["loss0"][2] = -1.0
-        @test_warn(TESTLOG, "this code only supports positive loss0 values, changing the value on dcline 1 from -100.0 to 0.0", PowerModels.check_dcline_limits(mp_data_3p))
+        @test_warn(TESTLOG, "this code only supports positive loss0 values, changing the value on dcline 1, phase 2 from -100.0 to 0.0", PowerModels.check_dcline_limits(mp_data_3p))
 
         mp_data_3p["dcline"]["1"]["loss1"][2] = -1.0
-        @test_warn(TESTLOG, "this code only supports positive loss1 values, changing the value on dcline 1 from -1.0 to 0.0", PowerModels.check_dcline_limits(mp_data_3p))
+        @test_warn(TESTLOG, "this code only supports positive loss1 values, changing the value on dcline 1, phase 2 from -1.0 to 0.0", PowerModels.check_dcline_limits(mp_data_3p))
 
         @test mp_data_3p["dcline"]["1"]["loss0"][2] == 0.0
         @test mp_data_3p["dcline"]["1"]["loss1"][2] == 0.0
 
         mp_data_3p["dcline"]["1"]["loss1"][2] = 100.0
-        @test_warn(TESTLOG, "this code only supports loss1 values < 1, changing the value on dcline 1 from 100.0 to 0.0", PowerModels.check_dcline_limits(mp_data_3p))
+        @test_warn(TESTLOG, "this code only supports loss1 values < 1, changing the value on dcline 1, phase 2 from 100.0 to 0.0", PowerModels.check_dcline_limits(mp_data_3p))
 
         delete!(mp_data_3p["branch"]["1"], "tap")
         @test_warn(TESTLOG, "branch found without tap value, setting a tap to 1.0", PowerModels.check_transformer_parameters(mp_data_3p))
@@ -317,7 +317,7 @@ end
         @test_warn(TESTLOG, "branch found with non-positive tap value of -1.0, setting a tap to 1.0", PowerModels.check_transformer_parameters(mp_data_3p))
 
         mp_data_3p["branch"]["1"]["rate_a"][2] = -1.0
-        @test_warn(TESTLOG, "this code only supports positive rate_a values, changing the value on branch 1 from -100.0 to 100.47227335656343", PowerModels.check_thermal_limits(mp_data_3p))
+        @test_warn(TESTLOG, "this code only supports positive rate_a values, changing the value on branch 1, phase 2 from -100.0 to 100.47227335656343", PowerModels.check_thermal_limits(mp_data_3p))
         @test isapprox(mp_data_3p["branch"]["1"]["rate_a"][2], 1.0047227335; atol=1e-6)
 
         mp_data_3p["branch"]["4"] = deepcopy(mp_data_3p["branch"]["1"])


### PR DESCRIPTION
Updates the following functions to be compatible with multiphase networks

* `check_thermal_limits`
* `check_branch_directions`
* `check_transformer_parameters`
* `check_dcline_limits`
* `check_voltage_setpoints`
* `check_cost_functions`

These updates only handle diagonal cases, off-diagonal cases should be handled
in ThreePhasePowerModels (e.g. in `check_thermal_limits`).

Other checks that were not updated were confirmed to work on Multiphase networks.

Added `Base.:*` and `Base.:/` extensions for MultiPhaseVectors (handles
special broadcast cases).

Fixed issue with `Base.broadcast` extensions.

Added unit tests for new features.