### PR TITLE
bugfix calc_branch_y TPPM#45

### DIFF
--- a/src/core/data.jl
+++ b/src/core/data.jl
@@ -64,14 +64,19 @@ end
 
 ""
 function calc_branch_y(branch::Dict{String,Any})
-    r = branch["br_r"]
-    x = branch["br_x"]
+    if(typeof(branch["br_r"]) <: MultiPhaseMatrix)
+        y = pinv(branch["br_r"].values + im*branch["br_x"].values)
+        g = PowerModels.MultiPhaseMatrix(real(y))
+        b = PowerModels.MultiPhaseMatrix(imag(y))
+    else
+        r = branch["br_r"]
+        x = branch["br_x"]
 
-    ym = map(+, map(*, r, r), map(*, x, x))
+        ym = map(+, map(*, r, r), map(*, x, x))
 
-    g = map(_div_zero, r, ym)
-    b = map(-, map(_div_zero, x, ym))
-
+        g = map(_div_zero, r, ym)
+        b = map(-, map(_div_zero, x, ym))
+    end
     return g, b
 end
 
@@ -1257,4 +1262,3 @@ function _make_multiphase(data::Dict{String,Any}, phases::Real)
         end
     end
 end
-

--- a/test/data.jl
+++ b/test/data.jl
@@ -388,3 +388,34 @@ end
         @test isapprox(result["objective"], 5907; atol = 1e0)
     end
 end
+
+@testset "test impedance to admittance" begin
+    branch = Dict{String, Any}()
+    branch["br_r"] = 1
+    branch["br_x"] = 2
+    g,b  = PowerModels.calc_branch_y(branch)
+    @test isapprox(g, 0.2)
+    @test isapprox(b, -0.4)
+
+    branch["br_r"] = 0
+    branch["br_x"] = 0
+    g,b  = PowerModels.calc_branch_y(branch)
+    @test isapprox(g, 0)
+    @test isapprox(b, 0)
+
+    branch["br_r"] = PowerModels.MultiPhaseMatrix([1 2;3 4])
+    branch["br_x"] = PowerModels.MultiPhaseMatrix([1 2;3 4])
+    g,b  = PowerModels.calc_branch_y(branch)
+
+    @test typeof(g) <: PowerModels.MultiPhaseMatrix
+    @test isapprox(g.values, [-1.0 0.5; 0.75 -0.25])
+    @test isapprox(b.values, [1.0 -0.5; -0.75 0.25])
+
+    branch["br_r"] = PowerModels.MultiPhaseMatrix([1 2 0;3 4 0; 0 0 0])
+    branch["br_x"] = PowerModels.MultiPhaseMatrix([1 2 0;3 4 0; 0 0 0])
+    g,b  = PowerModels.calc_branch_y(branch)
+
+    @test typeof(g) <: PowerModels.MultiPhaseMatrix
+    @test isapprox(g.values, [-1.0 0.5 0; 0.75 -0.25 0; 0 0 0])
+    @test isapprox(b.values, [1.0 -0.5 0; -0.75 0.25 0; 0 0 0])
+end


### PR DESCRIPTION
Would this be an acceptable fix for https://github.com/lanl-ansi/ThreePhasePowerModels.jl/issues/45 ?

Uses the pseudo-inverse to avoid issues when certain phases are absent in the impedance matrix. 

Added corresponding unit test