### PR TITLE
FIX: Vector and Matrix Operations on MultiPhaseValues

### DIFF
--- a/src/core/data.jl
+++ b/src/core/data.jl
@@ -64,30 +64,9 @@ end
 
 ""
 function calc_branch_y(branch::Dict{String,Any})
-    if(typeof(branch["br_r"]) <: MultiPhaseMatrix)
-        y = pinv(branch["br_r"].values + im*branch["br_x"].values)
-        g = PowerModels.MultiPhaseMatrix(real(y))
-        b = PowerModels.MultiPhaseMatrix(imag(y))
-    else
-        r = branch["br_r"]
-        x = branch["br_x"]
-
-        ym = map(+, map(*, r, r), map(*, x, x))
-
-        g = map(_div_zero, r, ym)
-        b = map(-, map(_div_zero, x, ym))
-    end
+    y = pinv(branch["br_r"] + im * branch["br_x"])
+    g, b = real(y), imag(y)
     return g, b
-end
-
-
-# helpful for cases when r and x are zero
-""
-function _div_zero(a::Real, b::Real)
-    if a == 0.0
-        return 0.0
-    end
-    return a/b
 end
 
 

--- a/src/core/multiphase.jl
+++ b/src/core/multiphase.jl
@@ -51,41 +51,82 @@ Base.getindex(mpv::MultiPhaseValue, args...) = mpv.values[args...]
 
 Base.show(io::IO, mpv::MultiPhaseValue) = Base.show(io, mpv.values)
 
-Base.broadcast(f::Any, a, b::MultiPhaseValue) = broadcast(f, a, b.values)
-Base.broadcast(f::Any, a::MultiPhaseValue, b) = broadcast(f, a.values, b)
+Base.broadcast(f::Any, a::Any, b::MultiPhaseValue) = broadcast(f, a, b.values)
+Base.broadcast(f::Any, a::MultiPhaseValue, b::Any) = broadcast(f, a.values, b)
 Base.broadcast(f::Any, a::MultiPhaseValue, b::MultiPhaseValue) = broadcast(f, a.values, b.values)
 
-Base.:+(a::MultiPhaseVector{T}, b...) where T = MultiPhaseVector{T}(+(a.values, (isa(i, MultiPhaseValue) ? i.values : i for i in [b...])...))
-Base.:-(a::MultiPhaseVector{T}, b...) where T = MultiPhaseVector{T}(-(a.values, (isa(i, MultiPhaseValue) ? i.values : i for i in [b...])...))
-Base.:*(a::MultiPhaseVector{T}, b...) where T = MultiPhaseVector{T}(*(a.values, (isa(i, MultiPhaseValue) ? i.values : i for i in [b...])...))
-Base.:/(a::MultiPhaseVector{T}, b...) where T = MultiPhaseVector{T}(/(a.values, (isa(i, MultiPhaseValue) ? i.values : i for i in [b...])...))
-Base.:*(a::Real, b::MultiPhaseVector{T}) where T = MultiPhaseVector{T}(Base.broadcast(*, a, b.values))
-Base.:/(a::Real, b::MultiPhaseVector{T}) where T = MultiPhaseVector{T}(Base.broadcast(/, a, b.values))
+# Vectors
+Base.:+(a::MultiPhaseVector) = MultiPhaseVector(+(a.values))
+Base.:+(a::MultiPhaseVector, b::Union{Array,Number}) = MultiPhaseVector(+(a.values, b))
+Base.:+(a::Union{Array,Number}, b::MultiPhaseVector) = MultiPhaseVector(+(a, b.values))
+Base.:+(a::MultiPhaseVector, b::MultiPhaseVector) = MultiPhaseVector(+(a.values, b.values))
 
-Base.:+(a::MultiPhaseMatrix{T}, b...) where T = MultiPhaseMatrix{T}(+(a.values, (isa(i, MultiPhaseValue) ? i.values : i for i in [b...])...))
-Base.:-(a::MultiPhaseMatrix{T}, b...) where T = MultiPhaseMatrix{T}(-(a.values, (isa(i, MultiPhaseValue) ? i.values : i for i in [b...])...))
-Base.:*(a::MultiPhaseMatrix{T}, b...) where T = MultiPhaseMatrix{T}(*(a.values, (isa(i, MultiPhaseValue) ? i.values : i for i in [b...])...))
-Base.:/(a::MultiPhaseMatrix{T}, b...) where T = MultiPhaseMatrix{T}(/(a.values, (isa(i, MultiPhaseValue) ? i.values : i for i in [b...])...))
+Base.:-(a::MultiPhaseVector) = MultiPhaseVector(-(a.values))
+Base.:-(a::MultiPhaseVector, b::Union{Array,Number}) = MultiPhaseVector(-(a.values, b))
+Base.:-(a::Union{Array,Number}, b::MultiPhaseVector) = MultiPhaseVector(-(a, b.values))
+Base.:-(a::MultiPhaseVector, b::MultiPhaseVector) = MultiPhaseVector(-(a.values, b.values))
 
-Base.:*(a::MultiPhaseMatrix{T}, b::MultiPhaseVector) where T = MultiPhaseVector{T}(*(a.values, b.values))
-Base.:/(a::MultiPhaseMatrix{T}, b::MultiPhaseVector) where T = MultiPhaseVector{T}(*(a.values, b.values))
+Base.:*(a::Number, b::MultiPhaseVector) = MultiPhaseVector(*(a, b.values))
+Base.:*(a::MultiPhaseVector, b::Number) = MultiPhaseVector(*(a.values, b))
+Base.:*(a::Array, b::MultiPhaseVector) = MultiPhaseVector(Base.broadcast(*, a, b.values))
+Base.:*(a::MultiPhaseVector, b::Array) = MultiPhaseVector(Base.broadcast(*, a.values, b))
+Base.:*(a::MultiPhaseVector, b::MultiPhaseVector) = MultiPhaseVector(Base.broadcast(*, a.values, b.values))
 
-Base.:^(a::MultiPhaseVector{T}, b::Integer) where T = MultiPhaseVector{T}(a.values .^ b)
-Base.:^(a::MultiPhaseMatrix{T}, b::Integer) where T = MultiPhaseMatrix{T}(a.values ^ b)
+Base.:/(a::MultiPhaseVector, b::Number) = MultiPhaseVector(/(a.values, b))
+Base.:/(a::Union{Array,Number}, b::MultiPhaseVector) = MultiPhaseVector(Base.broadcast(/, a, b.values))
+Base.:/(a::MultiPhaseVector, b::MultiPhaseVector) = MultiPhaseVector(Base.broadcast(/, a.values, b.values))
 
-Base.:^(a::MultiPhaseVector{T}, b::AbstractFloat) where T = MultiPhaseVector{T}(a.values .^ b)
-Base.:^(a::MultiPhaseMatrix{T}, b::AbstractFloat) where T = MultiPhaseMatrix{T}(a.values ^ b)
+Base.:*(a::MultiPhaseVector, b::RowVector) = MultiPhaseMatrix(Base.broadcast(*, a.values, b))
+Base.:*(a::RowVector, b::MultiPhaseVector) = MultiPhaseMatrix(Base.broadcast(*, a, b.values))
+
+# Matrices
+Base.:+(a::MultiPhaseMatrix) = MultiPhaseMatrix(+(a.values))
+Base.:+(a::MultiPhaseMatrix, b::Union{Array,Number}) = MultiPhaseMatrix(+(a.values, b))
+Base.:+(a::Union{Array,Number}, b::MultiPhaseMatrix) = MultiPhaseMatrix(+(a, b.values))
+Base.:+(a::MultiPhaseMatrix, b::MultiPhaseMatrix) = MultiPhaseMatrix(+(a.values, b.values))
+
+Base.:-(a::MultiPhaseMatrix) = MultiPhaseMatrix(-(a.values))
+Base.:-(a::MultiPhaseMatrix, b::Union{Array,Number}) = MultiPhaseMatrix(-(a.values, b))
+Base.:-(a::Union{Array,Number}, b::MultiPhaseMatrix) = MultiPhaseMatrix(-(a, b.values))
+Base.:-(a::MultiPhaseMatrix, b::MultiPhaseMatrix) = MultiPhaseMatrix(-(a.values, b.values))
+
+Base.:*(a::MultiPhaseMatrix, b::Union{Array,Number}) = MultiPhaseMatrix(*(a.values, b))
+Base.:*(a::Union{Array,Number}, b::MultiPhaseMatrix) = MultiPhaseMatrix(*(a, b.values))
+Base.:*(a::MultiPhaseMatrix, b::MultiPhaseMatrix) = MultiPhaseMatrix(*(a.values, b.values))
+
+Base.:/(a::MultiPhaseMatrix, b::Union{Array,Number}) = MultiPhaseMatrix(/(a.values, b))
+Base.:/(a::Union{Array,Number}, b::MultiPhaseMatrix) = MultiPhaseMatrix(/(a, b.values))
+Base.:/(a::MultiPhaseMatrix, b::MultiPhaseMatrix) = MultiPhaseMatrix(/(a.values, b.values))
+
+Base.:*(a::MultiPhaseMatrix, b::MultiPhaseVector) = MultiPhaseVector(*(a.values, b.values))
+Base.:/(a::MultiPhaseMatrix, b::RowVector) = MultiPhaseVector(squeeze(/(a.values, b), 2))
+
+Base.:^(a::MultiPhaseVector, b::Complex) = MultiPhaseVector(Base.broadcast(^, a.values, b))
+Base.:^(a::MultiPhaseVector, b::Integer) = MultiPhaseVector(Base.broadcast(^, a.values, b))
+Base.:^(a::MultiPhaseVector, b::AbstractFloat) = MultiPhaseVector(Base.broadcast(^, a.values, b))
+Base.:^(a::MultiPhaseMatrix, b::Complex) = MultiPhaseMatrix(a.values ^ b)
+Base.:^(a::MultiPhaseMatrix, b::Integer) = MultiPhaseMatrix(a.values ^ b)
+Base.:^(a::MultiPhaseMatrix, b::AbstractFloat) = MultiPhaseMatrix(a.values ^ b)
+
+Base.inv(a::MultiPhaseMatrix) = MultiPhaseMatrix(inv(a.values))
+Base.pinv(a::MultiPhaseMatrix) = MultiPhaseMatrix(pinv(a.values))
+
+Base.real(a::MultiPhaseVector) = MultiPhaseVector(real(a.values))
+Base.real(a::MultiPhaseMatrix) = MultiPhaseMatrix(real(a.values))
+Base.imag(a::MultiPhaseVector) = MultiPhaseVector(imag(a.values))
+Base.imag(a::MultiPhaseMatrix) = MultiPhaseMatrix(imag(a.values))
 
 Base.transpose(a::MultiPhaseVector) = a.values'
-Base.transpose(a::MultiPhaseMatrix{T}) where T = MultiPhaseMatrix{T}(a.values')
+Base.transpose(a::MultiPhaseMatrix) = MultiPhaseMatrix(a.values')
 
-Base.diagm(a::MultiPhaseVector{T}) where T = MultiPhaseMatrix{T}(diagm(a.values))
+Base.diag(a::MultiPhaseMatrix) = MultiPhaseVector(diag(a.values))
+Base.diagm(a::MultiPhaseVector) = MultiPhaseMatrix(diagm(a.values))
 
-Base.rad2deg(a::MultiPhaseVector{T}) where T = MultiPhaseVector{T}(map(rad2deg, a.values))
-Base.rad2deg(a::MultiPhaseMatrix{T}) where T = MultiPhaseMatrix{T}(map(rad2deg, a.values))
+Base.rad2deg(a::MultiPhaseVector) = MultiPhaseVector(map(rad2deg, a.values))
+Base.rad2deg(a::MultiPhaseMatrix) = MultiPhaseMatrix(map(rad2deg, a.values))
 
-Base.deg2rad(a::MultiPhaseVector{T}) where T = MultiPhaseVector{T}(map(deg2rad, a.values))
-Base.deg2rad(a::MultiPhaseMatrix{T}) where T = MultiPhaseMatrix{T}(map(deg2rad, a.values))
+Base.deg2rad(a::MultiPhaseVector) = MultiPhaseVector(map(deg2rad, a.values))
+Base.deg2rad(a::MultiPhaseMatrix) = MultiPhaseMatrix(map(deg2rad, a.values))
 
 JSON.lower(mpv::MultiPhaseValue) = mpv.values
 

--- a/test/ots.jl
+++ b/test/ots.jl
@@ -29,7 +29,7 @@ end
         result = run_ots("../test/data/pti/case5_alc.raw", ACPPowerModel, juniper_solver)
 
         @test result["status"] == :LocalOptimal
-        @test isapprox(result["objective"], 1002.52; atol = 1e0)
+        @test isapprox(result["objective"], 1004.25; atol = 1e0)
     end
     #Omitting this test, returns local infeasible
     #@testset "6-bus case" begin


### PR DESCRIPTION
Fixes problems with MultiPhaseVector and MultiPhaseMatrix operations
not being symmetrical, e.g. `Number + MultiPhaseValue` might not work
whereas `MultiPhaseValue + Number` might. This has been fixed.

Added `inv` function for matrices.

Added `real` and `imag` functions for MutliPhaseValues

Updated `calc_branch_y`, and one OTS test whose objective value
changed due to the difference in rounding errors between doing
the calculation in complex vs float.

Closes #313