### PR TITLE
FIX: starbus index

### DIFF
--- a/src/io/psse.jl
+++ b/src/io/psse.jl
@@ -56,7 +56,7 @@ Returns the maximum bus id in `pm_data`
 function find_max_bus_id(pm_data::Dict)::Int
     max_id = 0
     for bus in pm_data["bus"]
-        if bus["index"] > max_id
+        if bus["index"] > max_id && !endswith(bus["name"], "starbus")
             max_id = bus["index"]
         end
     end


### PR DESCRIPTION
Fixes bug in PSSE parser during the creation of a starbus for 3-winding
transformers where the starbus number would keep increasing in
magnitude due to `find_max_bus_id` running at every iteration and
finding a new, higher max bus id. Fixes this by excluding any busname
with `starbus` at the end, which is added to the name during the creation
of any starbus.