### PR TITLE
REF: Disables some warnings about missing fields in PTI

### DIFF
--- a/src/io/pti.jl
+++ b/src/io/pti.jl
@@ -287,7 +287,11 @@ function parse_line_element!(data::Dict, elements::Array, section::AbstractStrin
 
     if length(missing) > 0
         missing_str = join(missing, ", ")
-        warn(LOGGER, "The following fields in $section are missing: $missing_str")
+        if !(section == "SWITCHED SHUNT" && startswith(missing_str, "N")) &&
+            !(section == "MULTI-SECTION LINE" && startswith(missing_str, "DUM")) &&
+            !(section == "IMPEDANCE CORRECTION" && startswith(missing_str, "T"))
+            warn(LOGGER, "The following fields in $section are missing: $missing_str")
+        end
     end
 end
 


### PR DESCRIPTION
Specfically excludes warnings about missing fields in the sections
"IMPEDANCE CORRECTION, "MULTI-SECTION LINE", and "SWITCHED
SHUNT", which all have optional fields at the end, starting with "T#",
"DUM#", and "N#", respectively.