### PR TITLE
FIX: import_remaining array eltype check

### DIFF
--- a/src/io/psse.jl
+++ b/src/io/psse.jl
@@ -102,9 +102,11 @@ function import_remaining!(data_out::Dict, data_in::Dict, import_all::Bool; excl
             if !(k in exclude)
                 if isa(v, Array)
                     for (n, item) in enumerate(v)
-                        import_remaining!(item, item, import_all)
-                        if isa(item, Dict) && !("index" in keys(item))
-                            item["index"] = n
+                        if isa(item, Dict)
+                            import_remaining!(item, item, import_all)
+                            if !("index" in keys(item))
+                                item["index"] = n
+                            end
                         end
                     end
                 elseif isa(v, Dict)


### PR DESCRIPTION
import_remaining! did not check for element type of arrays components, which broke behavior in ThreePhasePowerModels. Now checks to ensure that arrays have Dict elements.

Closes ThreePhasePowerModels#51