### PR TITLE
FIX: check_thermal_limits was returning NaN

### DIFF
--- a/src/core/data.jl
+++ b/src/core/data.jl
@@ -453,12 +453,11 @@ function check_thermal_limits(data::Dict{String,Any})
             if branch["rate_a"][c] <= 0.0
                 theta_max = max(abs(branch["angmin"][c]), abs(branch["angmax"][c]))
 
-                r = branch["br_r"][c, c]
-                x = branch["br_x"][c, c]
-                g =  r / (r^2 + x^2)
-                b = -x / (r^2 + x^2)
-
-                y_mag = sqrt(g^2 + b^2)
+                r = branch["br_r"]
+                x = branch["br_x"]
+                z = r + im * x
+                y = pinv(z)
+                y_mag = abs.(y[c,c])
 
                 fr_vmax = data["bus"][string(branch["f_bus"])]["vmax"][c]
                 to_vmax = data["bus"][string(branch["t_bus"])]["vmax"][c]

--- a/test/multiconductor.jl
+++ b/test/multiconductor.jl
@@ -317,7 +317,7 @@ end
         @test_warn(TESTLOG, "branch found with non-positive tap value of -1.0, setting a tap to 1.0", PowerModels.check_transformer_parameters(mp_data_3p))
 
         mp_data_3p["branch"]["1"]["rate_a"][2] = -1.0
-        @test_warn(TESTLOG, "this code only supports positive rate_a values, changing the value on branch 1, conductor 2 from -100.0 to 100.47227335656343", PowerModels.check_thermal_limits(mp_data_3p))
+        @test_warn(TESTLOG, "this code only supports positive rate_a values, changing the value on branch 1, conductor 2 from -100.0 to 100.47227335656346", PowerModels.check_thermal_limits(mp_data_3p))
         @test isapprox(mp_data_3p["branch"]["1"]["rate_a"][2], 1.0047227335; atol=1e-6)
 
         mp_data_3p["branch"]["4"] = deepcopy(mp_data_3p["branch"]["1"])


### PR DESCRIPTION
During check thermal limits, `r` or `x` are zero, `rate_{a,b,c}` would get set to NaN. Using `pinv` to solve this problem. Associated with ThreePhasePowerModels in the presence of inactive conductors.