### PR TITLE
Moi julia v0.7

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,5 +1,6 @@
 name = "PowerModels"
 uuid = "23a24fe6-a169-11e8-146b-9d23c58f08d1"
+version = "0.7.0"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"

--- a/Project.toml
+++ b/Project.toml
@@ -1,5 +1,5 @@
 name = "PowerModels"
-uuid = "23a24fe6-a169-11e8-146b-9d23c58f08d1"
+uuid = "bcd98974-b02a-5e2f-9ee0-a103f5c450dd"
 version = "0.7.0"
 
 [deps]


### PR DESCRIPTION
It was identified that the `uuid` assigned to PowerModels in the automatic transition of packages to v0.7 is not the same as the one assigned to the local transition. This mismatch creates errors in the registry of Julia. 