### PR TITLE
Minor Tidying of WRM Forms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,9 @@ PowerModels.jl Change Log
 =========================
 
 ### Staged
-- Improved OBBT bound update logic
+- Added SparseSDPWRMPowerModel model (thanks to @kersulis)
 - Added Julia version upper bound
+- Improved OBBT bound update logic
 
 ### v0.8.3
 - Added support for current limits, issue #342

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ This enables the definition of a wide variety of power network formulations and 
 **Core Network Formulations**
 * AC (polar and rectangular coordinates)
 * DC Approximation (polar coordinates)
+* SDP Relaxation (W-space)
 * SOC Relaxation (W-space)
 * QC Relaxation (W+L-space)
 
@@ -54,6 +55,7 @@ The primary developer is Carleton Coffrin(@ccoffrin) with support from the follo
 - David Fobes (@pseudocubic) LANL, PSS(R)E v33 data support
 - Rory Finnegan (@rofinn) Invenia, Memento Logging
 - Frederik Geth (@frederikgeth) CSIRO, Branch Flow formulation
+- Jonas Kersulis (@kersulis) University of Michigan, Sparse SDP formulation
 - Miles Lubin (@mlubin) MIT, Julia/JuMP advise
 - Yeesian Ng (@yeesian) MIT, Documenter.jl setup
 - Kaarthik Sundar (@kaarthiksundar) LANL, OBBT utility

--- a/docs/src/formulation-details.md
+++ b/docs/src/formulation-details.md
@@ -70,11 +70,16 @@ DCPPowerModel
 SDPWRMPowerModel
 ```
 
+## `SparseSDPWRMPowerModel`
+```@docs
+SparseSDPWRMPowerModel
+```
+
+
 ## `SOCWRPowerModel`
 ```@docs
 SOCWRPowerModel
 ```
-
 
 
 ## `QCWRPowerModel`

--- a/src/form/wrm.jl
+++ b/src/form/wrm.jl
@@ -1,6 +1,6 @@
 export
     SDPWRMPowerModel, SDPWRMForm,
-    SDPDecompPowerModel, SDPDecompForm
+    SparseSDPWRMPowerModel, SparseSDPWRMForm
 
 ""
 abstract type AbstractWRMForm <: AbstractConicPowerFormulation end
@@ -43,10 +43,10 @@ First paper to use "W" variables in the BIM of AC OPF:
 const SDPWRMPowerModel = GenericPowerModel{SDPWRMForm}
 
 
-abstract type SDPDecompForm <: SDPWRMForm end
+abstract type SparseSDPWRMForm <: SDPWRMForm end
 
 ""
-const SDPDecompPowerModel = GenericPowerModel{SDPDecompForm}
+const SparseSDPWRMPowerModel = GenericPowerModel{SparseSDPWRMForm}
 
 struct SDconstraintDecomposition
     "Each sub-vector consists of bus IDs corresponding to a clique grouping"
@@ -68,7 +68,7 @@ end
 ""
 SDPWRMPowerModel(data::Dict{String,Any}; kwargs...) = GenericPowerModel(data, SDPWRMForm; kwargs...)
 
-SDPDecompPowerModel(data::Dict{String,Any}; kwargs...) = GenericPowerModel(data, SDPDecompForm; kwargs...)
+SparseSDPWRMPowerModel(data::Dict{String,Any}; kwargs...) = GenericPowerModel(data, SparseSDPWRMForm; kwargs...)
 
 ""
 function variable_voltage(pm::GenericPowerModel{SDPWRMForm}; nw::Int=pm.cnw, cnd::Int=pm.ccnd, bounded = true)
@@ -134,7 +134,7 @@ function variable_voltage(pm::GenericPowerModel{SDPWRMForm}; nw::Int=pm.cnw, cnd
     end
 end
 
-function variable_voltage(pm::GenericPowerModel{SDPDecompForm}; nw::Int=pm.cnw, cnd::Int=pm.ccnd, bounded=true)
+function variable_voltage(pm::GenericPowerModel{SparseSDPWRMForm}; nw::Int=pm.cnw, cnd::Int=pm.ccnd, bounded=true)
 
     if haskey(pm.ext, :SDconstraintDecomposition)
         decomp = pm.ext[:SDconstraintDecomposition]
@@ -233,7 +233,7 @@ function constraint_voltage(pm::GenericPowerModel{SDPWRMForm}, nw::Int, cnd::Int
     @SDconstraint(pm.model, [WR WI; -WI WR] >= 0)
 end
 
-function constraint_voltage(pm::GenericPowerModel{SDPDecompForm}, nw::Int, cnd::Int)
+function constraint_voltage(pm::GenericPowerModel{SparseSDPWRMForm}, nw::Int, cnd::Int)
     pair_matrix(group) = [(i, j) for i in group, j in group]
 
     decomp = pm.ext[:SDconstraintDecomposition]

--- a/src/form/wrm.jl
+++ b/src/form/wrm.jl
@@ -6,6 +6,26 @@ export
 abstract type AbstractWRMForm <: AbstractConicPowerFormulation end
 
 ""
+function constraint_current_limit(pm::GenericPowerModel{T}, n::Int, c::Int, f_idx, c_rating_a) where T <: AbstractWRMForm
+    l,i,j = f_idx
+    t_idx = (l,j,i)
+
+    w_fr = var(pm, n, c, :w, i)
+    w_to = var(pm, n, c, :w, j)
+
+    p_fr = var(pm, n, c, :p, f_idx)
+    q_fr = var(pm, n, c, :q, f_idx)
+    @constraint(pm.model, norm([2*p_fr; 2*q_fr; w_fr*c_rating_a^2-1]) <= w_fr*c_rating_a^2+1)
+
+    p_to = var(pm, n, c, :p, t_idx)
+    q_to = var(pm, n, c, :q, t_idx)
+    @constraint(pm.model, norm([2*p_to; 2*q_to; w_to*c_rating_a^2-1]) <= w_to*c_rating_a^2+1)
+end
+
+
+
+
+""
 abstract type SDPWRMForm <: AbstractWRMForm end
 
 """
@@ -42,36 +62,21 @@ First paper to use "W" variables in the BIM of AC OPF:
 """
 const SDPWRMPowerModel = GenericPowerModel{SDPWRMForm}
 
-
-abstract type SparseSDPWRMForm <: SDPWRMForm end
-
-""
-const SparseSDPWRMPowerModel = GenericPowerModel{SparseSDPWRMForm}
-
-struct SDconstraintDecomposition
-    "Each sub-vector consists of bus IDs corresponding to a clique grouping"
-    decomp::Vector{Vector{Int64}}
-    "`lookup_index[bus_id] --> idx` for mapping between 1:n and bus indices"
-    lookup_index::Dict
-    "A chordal extension and maximal cliques are uniquely determined by a graph ordering"
-    ordering::Vector{Int64}
-end
-import Base: ==
-function ==(d1::SDconstraintDecomposition, d2::SDconstraintDecomposition)
-    eq = true
-    for f in fieldnames(SDconstraintDecomposition)
-        eq = eq && (getfield(d1, f) == getfield(d2, f))
-    end
-    return eq
-end
-
 ""
 SDPWRMPowerModel(data::Dict{String,Any}; kwargs...) = GenericPowerModel(data, SDPWRMForm; kwargs...)
 
-SparseSDPWRMPowerModel(data::Dict{String,Any}; kwargs...) = GenericPowerModel(data, SparseSDPWRMForm; kwargs...)
 
 ""
-function variable_voltage(pm::GenericPowerModel{SDPWRMForm}; nw::Int=pm.cnw, cnd::Int=pm.ccnd, bounded = true)
+function constraint_voltage(pm::GenericPowerModel{T}, nw::Int, cnd::Int) where T <: SDPWRMForm
+    WR = var(pm, nw, cnd)[:WR]
+    WI = var(pm, nw, cnd)[:WI]
+
+    @SDconstraint(pm.model, [WR WI; -WI WR] >= 0)
+end
+
+
+""
+function variable_voltage(pm::GenericPowerModel{T}; nw::Int=pm.cnw, cnd::Int=pm.ccnd, bounded = true) where T <: SDPWRMForm
     wr_min, wr_max, wi_min, wi_max = calc_voltage_product_bounds(ref(pm, nw, :buspairs), cnd)
     bus_ids = ids(pm, nw, :bus)
 
@@ -134,7 +139,36 @@ function variable_voltage(pm::GenericPowerModel{SDPWRMForm}; nw::Int=pm.cnw, cnd
     end
 end
 
-function variable_voltage(pm::GenericPowerModel{SparseSDPWRMForm}; nw::Int=pm.cnw, cnd::Int=pm.ccnd, bounded=true)
+
+
+
+
+abstract type SparseSDPWRMForm <: SDPWRMForm end
+
+""
+const SparseSDPWRMPowerModel = GenericPowerModel{SparseSDPWRMForm}
+
+""
+SparseSDPWRMPowerModel(data::Dict{String,Any}; kwargs...) = GenericPowerModel(data, SparseSDPWRMForm; kwargs...)
+
+struct SDconstraintDecomposition
+    "Each sub-vector consists of bus IDs corresponding to a clique grouping"
+    decomp::Vector{Vector{Int64}}
+    "`lookup_index[bus_id] --> idx` for mapping between 1:n and bus indices"
+    lookup_index::Dict
+    "A chordal extension and maximal cliques are uniquely determined by a graph ordering"
+    ordering::Vector{Int64}
+end
+import Base: ==
+function ==(d1::SDconstraintDecomposition, d2::SDconstraintDecomposition)
+    eq = true
+    for f in fieldnames(SDconstraintDecomposition)
+        eq = eq && (getfield(d1, f) == getfield(d2, f))
+    end
+    return eq
+end
+
+function variable_voltage(pm::GenericPowerModel{T}; nw::Int=pm.cnw, cnd::Int=pm.ccnd, bounded=true) where T <: SparseSDPWRMForm
 
     if haskey(pm.ext, :SDconstraintDecomposition)
         decomp = pm.ext[:SDconstraintDecomposition]
@@ -225,15 +259,8 @@ function variable_voltage(pm::GenericPowerModel{SparseSDPWRMForm}; nw::Int=pm.cn
     end
 end
 
-""
-function constraint_voltage(pm::GenericPowerModel{SDPWRMForm}, nw::Int, cnd::Int)
-    WR = var(pm, nw, cnd)[:WR]
-    WI = var(pm, nw, cnd)[:WI]
 
-    @SDconstraint(pm.model, [WR WI; -WI WR] >= 0)
-end
-
-function constraint_voltage(pm::GenericPowerModel{SparseSDPWRMForm}, nw::Int, cnd::Int)
+function constraint_voltage(pm::GenericPowerModel{T}, nw::Int, cnd::Int) where T <: SparseSDPWRMForm
     pair_matrix(group) = [(i, j) for i in group, j in group]
 
     decomp = pm.ext[:SDconstraintDecomposition]
@@ -281,6 +308,7 @@ function constraint_voltage(pm::GenericPowerModel{SparseSDPWRMForm}, nw::Int, cn
     end
 end
 
+
 """
     adj, lookup_index = adjacency_matrix(pm, nw)
 Return:
@@ -301,6 +329,7 @@ function adjacency_matrix(pm::GenericPowerModel, nw::Int=pm.cnw)
 
     return sparse([f;t], [t;f], trues(2nl), nb, nb), lookup_index
 end
+
 
 """
     cadj, lookup_index, ordering = chordal_extension(pm, nw)
@@ -326,6 +355,7 @@ function chordal_extension(pm::GenericPowerModel, nw::Int=pm.cnw)
     cadj = cadj[q, q] # revert to original bus ordering (invert cholfact permutation)
     return cadj, lookup_index, p
 end
+
 
 """
     mc = maximal_cliques(cadj, peo)
@@ -411,6 +441,7 @@ function prim(A, minweight=false)
     return T
 end
 
+
 """
     A = overlap_graph(groups)
 Return adjacency matrix for overlap graph associated with `groups`.
@@ -436,6 +467,7 @@ function overlap_graph(groups)
     return sparse(I, J, V, n, n)
 end
 
+
 function filter_flipped_pairs!(pairs)
     for (i, j) in pairs
         if i != j && (j, i) in pairs
@@ -443,6 +475,7 @@ function filter_flipped_pairs!(pairs)
         end
     end
 end
+
 
 """
     idx_a, idx_b = overlap_indices(A, B)
@@ -461,6 +494,7 @@ function overlap_indices(A::Array, B::Array, symmetric=true)
     return idx_a, idx_b
 end
 
+
 """
     ps = problem_size(groups)
 Returns the sum of variables and linking constraints corresponding to the
@@ -473,23 +507,4 @@ function problem_size(groups)
     A = prim(overlap_graph(groups))
     return sum(nvars.(Int64.(nonzeros(A)))) + sum(nvars.(length.(groups)))
 end
-
-
-""
-function constraint_current_limit(pm::GenericPowerModel{T}, n::Int, c::Int, f_idx, c_rating_a) where T <: AbstractWRMForm
-    l,i,j = f_idx
-    t_idx = (l,j,i)
-
-    w_fr = var(pm, n, c, :w, i)
-    w_to = var(pm, n, c, :w, j)
-
-    p_fr = var(pm, n, c, :p, f_idx)
-    q_fr = var(pm, n, c, :q, f_idx)
-    @constraint(pm.model, norm([2*p_fr; 2*q_fr; w_fr*c_rating_a^2-1]) <= w_fr*c_rating_a^2+1)
-
-    p_to = var(pm, n, c, :p, t_idx)
-    q_to = var(pm, n, c, :q, t_idx)
-    @constraint(pm.model, norm([2*p_to; 2*q_to; w_to*c_rating_a^2-1]) <= w_to*c_rating_a^2+1)
-end
-
 

--- a/test/opf.jl
+++ b/test/opf.jl
@@ -647,26 +647,26 @@ end
 
 @testset "test sdp opf with constraint decomposition" begin
     @testset "3-bus case" begin
-        result = run_opf("../test/data/matpower/case3.m", SDPDecompPowerModel, scs_solver)
+        result = run_opf("../test/data/matpower/case3.m", SparseSDPWRMPowerModel, scs_solver)
 
         @test result["status"] == :Optimal
         @test isapprox(result["objective"], 5851.3; atol = 1e0)
     end
     @testset "5-bus with asymmetric line charge" begin
-        result = run_opf("../test/data/pti/case5_alc.raw", SDPDecompPowerModel, scs_solver)
+        result = run_opf("../test/data/pti/case5_alc.raw", SparseSDPWRMPowerModel, scs_solver)
 
         @test result["status"] == :Optimal
         @test isapprox(result["objective"], 1005.31; atol = 1e-1)
     end
     @testset "14-bus case" begin
-        result = run_opf("../test/data/matpower/case14.m", SDPDecompPowerModel, scs_solver)
+        result = run_opf("../test/data/matpower/case14.m", SparseSDPWRMPowerModel, scs_solver)
 
         @test result["status"] == :Optimal
         @test isapprox(result["objective"], 8079.97; atol = 1e0)
     end
     # multiple components are not currently supported by this form
     #@testset "6-bus case" begin
-    #    result = run_opf("../test/data/matpower/case6.m", SDPDecompPowerModel, scs_solver)
+    #    result = run_opf("../test/data/matpower/case6.m", SparseSDPWRMPowerModel, scs_solver)
     #
     #    @test result["status"] == :Optimal
     #    @test isapprox(result["objective"], 11578.8; atol = 1e0)
@@ -674,7 +674,7 @@ end
     @testset "passing in decomposition" begin
         PMs = PowerModels
         data = PMs.parse_file("../test/data/matpower/case14.m")
-        pm = GenericPowerModel(data, SDPDecompForm)
+        pm = GenericPowerModel(data, SparseSDPWRMForm)
 
         cadj, lookup_index, sigma = PMs.chordal_extension(pm)
         cliques = PMs.maximal_cliques(cadj)


### PR DESCRIPTION
Renamed the SDP Decomp formulation Sparse because this is consistent with Julia naming conventions.  Reorganized the order of `wrm.jl` to be similar to other formulation files.

@kersulis look reasonable to you?

