### PR TITLE
FIX: add old diagm default usage for <= 0.7

### DIFF
--- a/src/core/multiconductor.jl
+++ b/src/core/multiconductor.jl
@@ -178,6 +178,10 @@ LinearAlgebra.transpose(a::MultiConductorMatrix) = MultiConductorMatrix(a.values
 LinearAlgebra.diag(a::MultiConductorMatrix) = MultiConductorVector(diag(a.values))
 LinearAlgebra.diagm(p::Pair{<:Integer, MultiConductorVector{S}}) where S = MultiConductorMatrix(diagm(p.first => p.second.values))
 
+if VERSION <= v"0.7.0-"
+    LinearAlgebra.diagm(a::MultiConductorVector{S}) where S = LinearAlgebra.diagm(0 => a)
+end
+
 Base.rad2deg(a::MultiConductorVector) = MultiConductorVector(map(rad2deg, a.values))
 Base.rad2deg(a::MultiConductorMatrix) = MultiConductorMatrix(map(rad2deg, a.values))
 

--- a/test/multiconductor.jl
+++ b/test/multiconductor.jl
@@ -442,6 +442,9 @@ end
 
         # diagm
         @test all(LinearAlgebra.diagm(0 => c).values .== [0.225 0.0 0.0; 0.0 0.225 0.0; 0.0 0.0 0.225])
+        if VERSION <= v"0.7.0-"
+            @test all(LinearAlgebra.diagm(c).values .== [0.225 0.0 0.0; 0.0 0.225 0.0; 0.0 0.0 0.225])
+        end
 
         # rad2deg/deg2rad
         angs_deg = rad2deg(angs_rad)


### PR DESCRIPTION
adds function for old `diagm` default, i.e. `diagm(v)` was equivalent to
`diagm(0 => v)`. Only for `VERSION <= v"0.7.0"`. Test included. Necessary
for ThreePhasePowerModels support in Julia-0.6.
