### PR TITLE
ADD: Support for Logging in Julia Standard Library

### DIFF
--- a/src/PowerModels.jl
+++ b/src/PowerModels.jl
@@ -5,14 +5,13 @@ using InfrastructureModels
 using MathProgBase
 using JuMP
 using Compat
-using Memento
 
 using Compat.LinearAlgebra
 using Compat.SparseArrays
 
-if VERSION < v"0.7.0-"
-    import Compat: @__MODULE__
+import Compat: @__MODULE__
 
+if VERSION < v"0.7.0-"
     import Compat: occursin
     import Compat: Nothing
     import Compat: round
@@ -40,6 +39,28 @@ if VERSION < v"0.7.0-"
     function pm_sum(v; dims::Int=0)
         return sum(v, dims)
     end
+
+    using Memento
+    # Create our module level logger (this will get precompiled)
+    const LOGGER = getlogger(@__MODULE__)
+
+    # Register the module level logger at runtime so that folks can access the logger via `getlogger(PowerModels)`
+    # NOTE: If this line is not included then the precompiled `PowerModels.LOGGER` won't be registered at runtime.
+    __init__() = Memento.register(LOGGER)
+
+    macro warn(message)
+        :(Memento.warn(LOGGER, $(esc(message))))
+    end
+
+    macro debug(message)
+        :(Memento.debug(LOGGER, $(esc(message))))
+    end
+
+    macro info(message)
+        :(Memento.info(LOGGER, $(esc(message))))
+    end
+else
+    using Logging
 end
 
 if VERSION > v"0.7.0-"
@@ -53,14 +74,6 @@ if VERSION > v"0.7.0-"
         return Tuple(CartesianIndices(x)[i])
     end
 end
-
-
-# Create our module level logger (this will get precompiled)
-const LOGGER = getlogger(@__MODULE__)
-
-# Register the module level logger at runtime so that folks can access the logger via `getlogger(PowerModels)`
-# NOTE: If this line is not included then the precompiled `PowerModels.LOGGER` won't be registered at runtime.
-__init__() = Memento.register(LOGGER)
 
 include("io/matpower.jl")
 include("io/common.jl")

--- a/src/core/base.jl
+++ b/src/core/base.jl
@@ -178,7 +178,7 @@ function JuMP.solve(pm::GenericPowerModel)
     try
         solve_time = getsolvetime(pm.model)
     catch
-        warn(LOGGER, "there was an issue with getsolvetime() on the solver, falling back on @timed.  This is not a rigorous timing value.");
+        @warn "there was an issue with getsolvetime() on the solver, falling back on @timed.  This is not a rigorous timing value."
     end
 
     return status, solve_time
@@ -215,11 +215,11 @@ function build_generic_model(data::Dict{String,Any}, model_constructor, post_met
     pm = model_constructor(data; kwargs...)
 
     if !multinetwork && ismultinetwork(pm)
-        error(LOGGER, "attempted to build a single-network model with multi-network data")
+        throw(error("attempted to build a single-network model with multi-network data"))
     end
 
     if !multiconductor && ismulticonductor(pm)
-        error(LOGGER, "attempted to build a single-conductor model with multi-conductor data")
+        throw(error("attempted to build a single-conductor model with multi-conductor data"))
     end
 
     post_method(pm)
@@ -397,11 +397,11 @@ function build_ref(data::Dict{String,Any})
             gen_bus = big_gen["gen_bus"]
             ref_bus = ref_buses[gen_bus] = ref[:bus][gen_bus]
             ref_bus["bus_type"] = 3
-            warn(LOGGER, "no reference bus found, setting bus $(gen_bus) as reference based on generator $(big_gen["index"])")
+            @warn "no reference bus found, setting bus $(gen_bus) as reference based on generator $(big_gen["index"])"
         end
 
         if length(ref_buses) > 1
-            warn(LOGGER, "multiple reference buses found, $(keys(ref_buses)), this can cause infeasibility if they are in the same connected component")
+            @warn "multiple reference buses found, $(keys(ref_buses)), this can cause infeasibility if they are in the same connected component"
         end
 
         ref[:ref_buses] = ref_buses

--- a/src/core/data.jl
+++ b/src/core/data.jl
@@ -96,7 +96,7 @@ function _calc_max_cost_index(data::Dict{String,Any})
                     max_index = max(max_index, length(gen["cost"]))
                 end
             else
-                warn(LOGGER, "skipping cost generator $(i) cost model in calc_cost_order, only model 2 is supported.")
+                @warn "skipping cost generator $(i) cost model in calc_cost_order, only model 2 is supported."
             end
         end
     end
@@ -108,7 +108,7 @@ function _calc_max_cost_index(data::Dict{String,Any})
                     max_index = max(max_index, length(dcline["cost"]))
                 end
             else
-                warn(LOGGER, "skipping cost dcline $(i) cost model in calc_cost_order, only model 2 is supported.")
+                @warn "skipping cost dcline $(i) cost model in calc_cost_order, only model 2 is supported."
             end
         end
     end
@@ -158,7 +158,7 @@ function update_data(data::Dict{String,Any}, new_data::Dict{String,Any})
         end
     else
         if (haskey(data, "conductors") && !haskey(new_data, "conductors")) || (!haskey(data, "conductors") && haskey(new_data, "conductors"))
-            warn(LOGGER, "running update_data with missing onductors fields, conductors may be incorrect")
+            @warn "running update_data with missing onductors fields, conductors may be incorrect"
         end
     end
     InfrastructureModels.update_data!(data, new_data)
@@ -464,7 +464,7 @@ function _rescale_cost_model(comp::Dict{String,Any}, scale::Real)
                 comp["cost"][i] = item*(scale^(degree-i))
             end
         else
-            warn(LOGGER, "Skipping cost model of type $(comp["model"]) in per unit transformation")
+            @warn "Skipping cost model of type $(comp["model"]) in per unit transformation"
         end
     end
 end
@@ -505,7 +505,7 @@ function check_voltage_angle_differences(data::Dict{String,Any}, default_pad = 1
             angmax = branch["angmax"][c]
 
             if angmin <= -pi/2
-                warn(LOGGER, "this code only supports angmin values in -90 deg. to 90 deg., tightening the value on branch $i$(cnd_str) from $(rad2deg(angmin)) to -$(rad2deg(default_pad)) deg.")
+                @warn "this code only supports angmin values in -90 deg. to 90 deg., tightening the value on branch $i$(cnd_str) from $(rad2deg(angmin)) to -$(rad2deg(default_pad)) deg."
                 if haskey(data, "conductors")
                     branch["angmin"][c] = -default_pad
                 else
@@ -514,7 +514,7 @@ function check_voltage_angle_differences(data::Dict{String,Any}, default_pad = 1
             end
 
             if angmax >= pi/2
-                warn(LOGGER, "this code only supports angmax values in -90 deg. to 90 deg., tightening the value on branch $i$(cnd_str) from $(rad2deg(angmax)) to $(rad2deg(default_pad)) deg.")
+                @warn "this code only supports angmax values in -90 deg. to 90 deg., tightening the value on branch $i$(cnd_str) from $(rad2deg(angmax)) to $(rad2deg(default_pad)) deg."
                 if haskey(data, "conductors")
                     branch["angmax"][c] = default_pad
                 else
@@ -524,7 +524,7 @@ function check_voltage_angle_differences(data::Dict{String,Any}, default_pad = 1
             end
 
             if angmin == 0.0 && angmax == 0.0
-                warn(LOGGER, "angmin and angmax values are 0, widening these values on branch $i$(cnd_str) to +/- $(rad2deg(default_pad)) deg.")
+                @warn "angmin and angmax values are 0, widening these values on branch $i$(cnd_str) to +/- $(rad2deg(default_pad)) deg."
                 if haskey(data, "conductors")
                     branch["angmin"][c] = -default_pad
                     branch["angmax"][c] =  default_pad
@@ -584,7 +584,7 @@ function check_thermal_limits(data::Dict{String,Any})
                     new_rate = min(new_rate, branch["c_rating_a"][c]*m_vmax)
                 end
 
-                warn(LOGGER, "this code only supports positive rate_a values, changing the value on branch $(branch["index"])$(cnd_str) to $(mva_base*new_rate)")
+                @warn "this code only supports positive rate_a values, changing the value on branch $(branch["index"])$(cnd_str) to $(mva_base*new_rate)"
 
                 if haskey(data, "conductors")
                     branch["rate_a"][c] = new_rate
@@ -646,7 +646,7 @@ function check_current_limits(data::Dict{String,Any})
                     new_c_rating = min(new_c_rating, branch["rate_a"]/vm_min)
                 end
 
-                warn(LOGGER, "this code only supports positive c_rating_a values, changing the value on branch $(branch["index"])$(cnd_str) to $(mva_base*new_c_rating)")
+                @warn "this code only supports positive c_rating_a values, changing the value on branch $(branch["index"])$(cnd_str) to $(mva_base*new_c_rating)"
                 if haskey(data, "conductors")
                     branch["c_rating_a"][c] = new_c_rating
                 else
@@ -670,7 +670,7 @@ function check_branch_directions(data::Dict{String,Any})
         orientation_rev = (branch["t_bus"], branch["f_bus"])
 
         if in(orientation_rev, orientations)
-            warn(LOGGER, "reversing the orientation of branch $(i) $(orientation) to be consistent with other parallel branches")
+            @warn "reversing the orientation of branch $(i) $(orientation) to be consistent with other parallel branches"
             branch_orginal = copy(branch)
             branch["f_bus"] = branch_orginal["t_bus"]
             branch["t_bus"] = branch_orginal["f_bus"]
@@ -700,7 +700,7 @@ function check_branch_loops(data::Dict{String,Any})
 
     for (i, branch) in data["branch"]
         if branch["f_bus"] == branch["t_bus"]
-            error(LOGGER, "both sides of branch $(i) connect to bus $(branch["f_bus"])")
+            error("both sides of branch $(i) connect to bus $(branch["f_bus"])")
         end
     end
 end
@@ -717,47 +717,47 @@ function check_connectivity(data::Dict{String,Any})
 
     for (i, load) in data["load"]
         if !(load["load_bus"] in bus_ids)
-            error(LOGGER, "bus $(load["load_bus"]) in load $(i) is not defined")
+            error("bus $(load["load_bus"]) in load $(i) is not defined")
         end
     end
 
     for (i, shunt) in data["shunt"]
         if !(shunt["shunt_bus"] in bus_ids)
-            error(LOGGER, "bus $(shunt["shunt_bus"]) in shunt $(i) is not defined")
+            error("bus $(shunt["shunt_bus"]) in shunt $(i) is not defined")
         end
     end
 
     for (i, gen) in data["gen"]
         if !(gen["gen_bus"] in bus_ids)
-            error(LOGGER, "bus $(gen["gen_bus"]) in generator $(i) is not defined")
+            error("bus $(gen["gen_bus"]) in generator $(i) is not defined")
         end
     end
 
     if haskey(data, "storage")
         for (i, strg) in data["storage"]
             if !(strg["storage_bus"] in bus_ids)
-                error(LOGGER, "bus $(strg["storage_bus"]) in storage unit $(i) is not defined")
+                error("bus $(strg["storage_bus"]) in storage unit $(i) is not defined")
             end
         end
     end
 
     for (i, branch) in data["branch"]
         if !(branch["f_bus"] in bus_ids)
-            error(LOGGER, "from bus $(branch["f_bus"]) in branch $(i) is not defined")
+            error("from bus $(branch["f_bus"]) in branch $(i) is not defined")
         end
 
         if !(branch["t_bus"] in bus_ids)
-            error(LOGGER, "to bus $(branch["t_bus"]) in branch $(i) is not defined")
+            error("to bus $(branch["t_bus"]) in branch $(i) is not defined")
         end
     end
 
     for (i, dcline) in data["dcline"]
         if !(dcline["f_bus"] in bus_ids)
-            error(LOGGER, "from bus $(dcline["f_bus"]) in dcline $(i) is not defined")
+            error("from bus $(dcline["f_bus"]) in dcline $(i) is not defined")
         end
 
         if !(dcline["t_bus"] in bus_ids)
-            error(LOGGER, "to bus $(dcline["t_bus"]) in dcline $(i) is not defined")
+            error("to bus $(dcline["t_bus"]) in dcline $(i) is not defined")
         end
     end
 end
@@ -777,7 +777,7 @@ function check_transformer_parameters(data::Dict{String,Any})
 
     for (i, branch) in data["branch"]
         if !haskey(branch, "tap")
-            warn(LOGGER, "branch found without tap value, setting a tap to 1.0")
+            @warn "branch found without tap value, setting a tap to 1.0"
             if haskey(data, "conductors")
                 branch["tap"] = MultiConductorVector{Float64}(ones(data["conductors"]))
             else
@@ -787,7 +787,7 @@ function check_transformer_parameters(data::Dict{String,Any})
             for c in 1:get(data, "conductors", 1)
                 cnd_str = haskey(data, "conductors") ? " on conductor $(c)" : ""
                 if branch["tap"][c] <= 0.0
-                    warn(LOGGER, "branch found with non-positive tap value of $(branch["tap"][c]), setting a tap to 1.0$(cnd_str)")
+                    @warn "branch found with non-positive tap value of $(branch["tap"][c]), setting a tap to 1.0$(cnd_str)"
                     if haskey(data, "conductors")
                         branch["tap"][c] = 1.0
                     else
@@ -797,7 +797,7 @@ function check_transformer_parameters(data::Dict{String,Any})
             end
         end
         if !haskey(branch, "shift")
-            warn(LOGGER, "branch found without shift value, setting a shift to 0.0")
+            @warn "branch found without shift value, setting a shift to 0.0"
             if haskey(data, "conductors")
                 branch["shift"] = MultiConductorVector{Float64}(zeros(data["conductors"]))
             else
@@ -822,56 +822,56 @@ function check_storage_parameters(data::Dict{String,Any})
 
     for (i, strg) in data["storage"]
         if strg["energy"] < 0.0
-            error(LOGGER, "storage unit $(strg["index"]) has a non-positive energy level $(strg["energy"])")
+            error("storage unit $(strg["index"]) has a non-positive energy level $(strg["energy"])")
         end
         if strg["energy_rating"] < 0.0
-            error(LOGGER, "storage unit $(strg["index"]) has a non-positive energy rating $(strg["energy_rating"])")
+            error("storage unit $(strg["index"]) has a non-positive energy rating $(strg["energy_rating"])")
         end
         if strg["charge_rating"] < 0.0
-            error(LOGGER, "storage unit $(strg["index"]) has a non-positive charge rating $(strg["energy_rating"])")
+            error("storage unit $(strg["index"]) has a non-positive charge rating $(strg["energy_rating"])")
         end
         if strg["discharge_rating"] < 0.0
-            error(LOGGER, "storage unit $(strg["index"]) has a non-positive discharge rating $(strg["energy_rating"])")
+            error("storage unit $(strg["index"]) has a non-positive discharge rating $(strg["energy_rating"])")
         end
         if strg["r"] < 0.0
-            error(LOGGER, "storage unit $(strg["index"]) has a non-positive resistance $(strg["r"])")
+            error("storage unit $(strg["index"]) has a non-positive resistance $(strg["r"])")
         end
         if strg["x"] < 0.0
-            error(LOGGER, "storage unit $(strg["index"]) has a non-positive reactance $(strg["x"])")
+            error("storage unit $(strg["index"]) has a non-positive reactance $(strg["x"])")
         end
         if strg["standby_loss"] < 0.0
-            error(LOGGER, "storage unit $(strg["index"]) has a non-positive standby losses $(strg["standby_loss"])")
+            error("storage unit $(strg["index"]) has a non-positive standby losses $(strg["standby_loss"])")
         end
 
         if haskey(strg, "thermal_rating") && strg["thermal_rating"] < 0.0
-            error(LOGGER, "storage unit $(strg["index"]) has a non-positive thermal rating $(strg["thermal_rating"])")
+            error("storage unit $(strg["index"]) has a non-positive thermal rating $(strg["thermal_rating"])")
         end
         if haskey(strg, "current_rating") && strg["current_rating"] < 0.0
-            error(LOGGER, "storage unit $(strg["index"]) has a non-positive current rating $(strg["thermal_rating"])")
+            error("storage unit $(strg["index"]) has a non-positive current rating $(strg["thermal_rating"])")
         end
 
 
         if strg["charge_efficiency"] < 0.0
-            error(LOGGER, "storage unit $(strg["index"]) has a non-positive charge efficiency of $(strg["charge_efficiency"])")
+            error("storage unit $(strg["index"]) has a non-positive charge efficiency of $(strg["charge_efficiency"])")
         end
         if strg["charge_efficiency"] <= 0.0 || strg["charge_efficiency"] > 1.0
-            warn(LOGGER, "storage unit $(strg["index"]) charge efficiency of $(strg["charge_efficiency"]) is out of the valid range (0.0. 1.0]")
+            @warn "storage unit $(strg["index"]) charge efficiency of $(strg["charge_efficiency"]) is out of the valid range (0.0. 1.0]"
         end
 
         if strg["discharge_efficiency"] < 0.0
-            error(LOGGER, "storage unit $(strg["index"]) has a non-positive discharge efficiency of $(strg["discharge_efficiency"])")
+            error("storage unit $(strg["index"]) has a non-positive discharge efficiency of $(strg["discharge_efficiency"])")
         end
         if strg["discharge_efficiency"] <= 0.0 || strg["discharge_efficiency"] > 1.0
-            warn(LOGGER, "storage unit $(strg["index"]) discharge efficiency of $(strg["discharge_efficiency"]) is out of the valid range (0.0. 1.0]")
+            @warn "storage unit $(strg["index"]) discharge efficiency of $(strg["discharge_efficiency"]) is out of the valid range (0.0. 1.0]"
         end
 
         if !isapprox(strg["x"], 0.0, atol=1e-6, rtol=1e-6)
-            warn(LOGGER, "storage unit $(strg["index"]) has a non-zero reactance $(strg["x"]), which is currently ignored")
+            @warn "storage unit $(strg["index"]) has a non-zero reactance $(strg["x"]), which is currently ignored"
         end
 
 
         if strg["standby_loss"] > 0.0 && strg["energy"] <= 0.0
-            warn(LOGGER, "storage unit $(strg["index"]) has standby losses but zero initial energy.  This can lead to model infeasiblity.")
+            @warn "storage unit $(strg["index"]) has standby losses but zero initial energy.  This can lead to model infeasiblity."
         end
     end
 end
@@ -897,12 +897,12 @@ function check_bus_types(data::Dict{String,Any})
             bus_gens_count = length(bus_gens[i])
 
             if bus_gens_count == 0 && bus["bus_type"] != 1
-                warn(LOGGER, "no active generators found at bus $(bus["bus_i"]), updating to bus type from $(bus["bus_type"]) to 1")
+                @warn "no active generators found at bus $(bus["bus_i"]), updating to bus type from $(bus["bus_type"]) to 1"
                 bus["bus_type"] = 1
             end
 
             if bus_gens_count != 0 && bus["bus_type"] != 2
-                warn(LOGGER, "active generators found at bus $(bus["bus_i"]), updating to bus type from $(bus["bus_type"]) to 2")
+                @warn "active generators found at bus $(bus["bus_i"]), updating to bus type from $(bus["bus_type"]) to 2"
                 bus["bus_type"] = 2
             end
 
@@ -925,7 +925,7 @@ function check_dcline_limits(data::Dict{String,Any})
         for (i, dcline) in data["dcline"]
             if dcline["loss0"][c] < 0.0
                 new_rate = 0.0
-                warn(LOGGER, "this code only supports positive loss0 values, changing the value on dcline $(dcline["index"])$(cnd_str) from $(mva_base*dcline["loss0"][c]) to $(mva_base*new_rate)")
+                @warn "this code only supports positive loss0 values, changing the value on dcline $(dcline["index"])$(cnd_str) from $(mva_base*dcline["loss0"][c]) to $(mva_base*new_rate)"
                 if haskey(data, "conductors")
                     dcline["loss0"][c] = new_rate
                 else
@@ -935,7 +935,7 @@ function check_dcline_limits(data::Dict{String,Any})
 
             if dcline["loss0"][c] >= dcline["pmaxf"][c]*(1-dcline["loss1"][c] )+ dcline["pmaxt"][c]
                 new_rate = 0.0
-                warn(LOGGER, "this code only supports loss0 values which are consistent with the line flow bounds, changing the value on dcline $(dcline["index"])$(cnd_str) from $(mva_base*dcline["loss0"][c]) to $(mva_base*new_rate)")
+                @warn "this code only supports loss0 values which are consistent with the line flow bounds, changing the value on dcline $(dcline["index"])$(cnd_str) from $(mva_base*dcline["loss0"][c]) to $(mva_base*new_rate)"
                 if haskey(data, "conductors")
                     dcline["loss0"][c] = new_rate
                 else
@@ -945,7 +945,7 @@ function check_dcline_limits(data::Dict{String,Any})
 
             if dcline["loss1"][c] < 0.0
                 new_rate = 0.0
-                warn(LOGGER, "this code only supports positive loss1 values, changing the value on dcline $(dcline["index"])$(cnd_str) from $(dcline["loss1"][c]) to $(new_rate)")
+                @warn "this code only supports positive loss1 values, changing the value on dcline $(dcline["index"])$(cnd_str) from $(dcline["loss1"][c]) to $(new_rate)"
                 if haskey(data, "conductors")
                     dcline["loss1"][c] = new_rate
                 else
@@ -955,7 +955,7 @@ function check_dcline_limits(data::Dict{String,Any})
 
             if dcline["loss1"][c] >= 1.0
                 new_rate = 0.0
-                warn(LOGGER, "this code only supports loss1 values < 1, changing the value on dcline $(dcline["index"])$(cnd_str) from $(dcline["loss1"][c]) to $(new_rate)")
+                @warn "this code only supports loss1 values < 1, changing the value on dcline $(dcline["index"])$(cnd_str) from $(dcline["loss1"][c]) to $(new_rate)"
                 if haskey(data, "conductors")
                     dcline["loss1"][c] = new_rate
                 else
@@ -965,7 +965,7 @@ function check_dcline_limits(data::Dict{String,Any})
 
             if dcline["pmint"][c] <0.0 && dcline["loss1"][c] > 0.0
                 #new_rate = 0.0
-                warn(LOGGER, "the dc line model is not meant to be used bi-directionally when loss1 > 0, be careful interpreting the results as the dc line losses can now be negative. change loss1 to 0 to avoid this warning")
+                @warn "the dc line model is not meant to be used bi-directionally when loss1 > 0, be careful interpreting the results as the dc line losses can now be negative. change loss1 to 0 to avoid this warning"
                 #dcline["loss0"] = new_rate
             end
         end
@@ -985,7 +985,7 @@ function check_voltage_setpoints(data::Dict{String,Any})
             bus_id = gen["gen_bus"]
             bus = data["bus"]["$(bus_id)"]
             if gen["vg"][c] != bus["vm"][c]
-                warn(LOGGER, "the $(cnd_str)voltage setpoint on generator $(i) does not match the value at bus $(bus_id)")
+                @warn "the $(cnd_str)voltage setpoint on generator $(i) does not match the value at bus $(bus_id)"
             end
         end
 
@@ -997,11 +997,11 @@ function check_voltage_setpoints(data::Dict{String,Any})
             bus_to = data["bus"]["$(bus_to_id)"]
 
             if dcline["vf"][c] != bus_fr["vm"][c]
-                warn(LOGGER, "the $(cnd_str)from bus voltage setpoint on dc line $(i) does not match the value at bus $(bus_fr_id)")
+                @warn "the $(cnd_str)from bus voltage setpoint on dc line $(i) does not match the value at bus $(bus_fr_id)"
             end
 
             if dcline["vt"][c] != bus_to["vm"][c]
-                warn(LOGGER, "the $(cnd_str)to bus voltage setpoint on dc line $(i) does not match the value at bus $(bus_to_id)")
+                @warn "the $(cnd_str)to bus voltage setpoint on dc line $(i) does not match the value at bus $(bus_to_id)"
             end
         end
     end
@@ -1045,7 +1045,7 @@ function _check_cost_functions(id, comp, type_name)
                 pmax = sum(comp["pmax"])
                 for i in 3:2:length(comp["cost"])
                     if comp["cost"][i] < pmin || comp["cost"][i] > pmax
-                        warn(LOGGER, "pwl x value $(comp["cost"][i]) is outside the bounds $(pmin)-$(pmax) on $(type_name) $(id)")
+                        @warn "pwl x value $(comp["cost"][i]) is outside the bounds $(pmin)-$(pmax) on $(type_name) $(id)"
                     end
                 end
             end
@@ -1055,7 +1055,7 @@ function _check_cost_functions(id, comp, type_name)
                 error("ncost of $(comp["ncost"]) not consistent with $(length(comp["cost"])) cost values on $(type_name) $(id)")
             end
         else
-            warn(LOGGER, "Unknown cost model of type $(comp["model"]) on $(type_name) $(id)")
+            @warn "Unknown cost model of type $(comp["model"]) on $(type_name) $(id)"
         end
     end
 end
@@ -1092,7 +1092,7 @@ function _simplify_pwl_cost(id, comp, type_name, tolerance = 1e-2)
     push!(smpl_cost, y2)
 
     if length(smpl_cost) < length(comp["cost"])
-        warn(LOGGER, "simplifying pwl cost on $(type_name) $(id), $(comp["cost"]) -> $(smpl_cost)")
+        @warn "simplifying pwl cost on $(type_name) $(id), $(comp["cost"]) -> $(smpl_cost)"
         comp["cost"] = smpl_cost
         comp["ncost"] = length(smpl_cost)/2
     end
@@ -1177,7 +1177,7 @@ function _standardize_cost_terms(components::Dict{String,Any}, comp_order::Int, 
             comp["ncost"] = comp_order
             #println("std gen cost: $(comp["cost"])")
 
-            warn(LOGGER, "Updated $(cost_comp_name) cost ($(comp["index"])) to a function of order $(comp_order): $(comp["cost"])")
+            @warn "Updated $(cost_comp_name) cost ($(comp["index"])) to a function of order $(comp_order): $(comp["cost"])"
         end
     end
 end
@@ -1211,14 +1211,14 @@ function _propagate_topology_status(data::Dict{String,Any})
 
     for (i,load) in data["load"]
         if load["status"] != 0 && all(load["pd"] .== 0.0) && all(load["qd"] .== 0.0)
-            info(LOGGER, "deactivating load $(load["index"]) due to zero pd and qd")
+            @info "deactivating load $(load["index"]) due to zero pd and qd"
             load["status"] = 0
         end
     end
 
     for (i,shunt) in data["shunt"]
         if shunt["status"] != 0 && all(shunt["gs"] .== 0.0) && all(shunt["bs"] .== 0.0)
-            info(LOGGER, "deactivating shunt $(shunt["index"]) due to zero gs and bs")
+            @info "deactivating shunt $(shunt["index"]) due to zero gs and bs"
             shunt["status"] = 0
         end
     end
@@ -1271,7 +1271,7 @@ function _propagate_topology_status(data::Dict{String,Any})
                     t_bus = buses[branch["t_bus"]]
 
                     if f_bus["bus_type"] == 4 || t_bus["bus_type"] == 4
-                        info(LOGGER, "deactivating branch $(i):($(branch["f_bus"]),$(branch["t_bus"])) due to connecting bus status")
+                        @info "deactivating branch $(i):($(branch["f_bus"]),$(branch["t_bus"])) due to connecting bus status"
                         branch["br_status"] = 0
                         updated = true
                     end
@@ -1284,7 +1284,7 @@ function _propagate_topology_status(data::Dict{String,Any})
                     t_bus = buses[dcline["t_bus"]]
 
                     if f_bus["bus_type"] == 4 || t_bus["bus_type"] == 4
-                        info(LOGGER, "deactivating dcline $(i):($(dcline["f_bus"]),$(dcline["t_bus"])) due to connecting bus status")
+                        @info "deactivating dcline $(i):($(dcline["f_bus"]),$(dcline["t_bus"])) due to connecting bus status"
                         dcline["br_status"] = 0
                         updated = true
                     end
@@ -1307,7 +1307,7 @@ function _propagate_topology_status(data::Dict{String,Any})
                     #println("bus $(i) active shunt $(incident_active_shunt)")
 
                     if incident_active_edge == 1 && length(incident_active_gen[i]) == 0 && length(incident_active_load[i]) == 0 && length(incident_active_shunt[i]) == 0
-                        info(LOGGER, "deactivating bus $(i) due to dangling bus without generation and load")
+                        @info "deactivating bus $(i) due to dangling bus without generation and load"
                         bus["bus_type"] = 4
                         updated = true
                     end
@@ -1315,7 +1315,7 @@ function _propagate_topology_status(data::Dict{String,Any})
                 else # bus type == 4
                     for load in incident_active_load[i]
                         if load["status"] != 0
-                            info(LOGGER, "deactivating load $(load["index"]) due to inactive bus $(i)")
+                            @info "deactivating load $(load["index"]) due to inactive bus $(i)"
                             load["status"] = 0
                             updated = true
                         end
@@ -1323,7 +1323,7 @@ function _propagate_topology_status(data::Dict{String,Any})
 
                     for shunt in incident_active_shunt[i]
                         if shunt["status"] != 0
-                            info(LOGGER, "deactivating shunt $(shunt["index"]) due to inactive bus $(i)")
+                            @info "deactivating shunt $(shunt["index"]) due to inactive bus $(i)"
                             shunt["status"] = 0
                             updated = true
                         end
@@ -1331,7 +1331,7 @@ function _propagate_topology_status(data::Dict{String,Any})
 
                     for gen in incident_active_gen[i]
                         if gen["gen_status"] != 0
-                            info(LOGGER, "deactivating generator $(gen["index"]) due to inactive bus $(i)")
+                            @info "deactivating generator $(gen["index"]) due to inactive bus $(i)"
                             gen["gen_status"] = 0
                             updated = true
                         end
@@ -1361,7 +1361,7 @@ function _propagate_topology_status(data::Dict{String,Any})
             active_gen_count = sum(cc_active_gens)
 
             if (active_load_count == 0 && active_shunt_count == 0) || active_gen_count == 0
-                info(LOGGER, "deactivating connected component $(cc) due to isolation without generation and load")
+                @info "deactivating connected component $(cc) due to isolation without generation and load"
                 for i in cc
                     buses[i]["bus_type"] = 4
                 end
@@ -1371,7 +1371,7 @@ function _propagate_topology_status(data::Dict{String,Any})
 
     end
 
-    info(LOGGER, "topology status propagation fixpoint reached in $(iteration) rounds")
+    @info "topology status propagation fixpoint reached in $(iteration) rounds"
 
     check_reference_buses(data)
 end
@@ -1394,17 +1394,17 @@ end
 ""
 function _select_largest_component(data::Dict{String,Any})
     ccs = connected_components(data)
-    info(LOGGER, "found $(length(ccs)) components")
+    @info "found $(length(ccs)) components"
 
     ccs_order = sort(collect(ccs); by=length)
     largest_cc = ccs_order[end]
 
-    info(LOGGER, "largest component has $(length(largest_cc)) buses")
+    @info "largest component has $(length(largest_cc)) buses"
 
     for (i,bus) in data["bus"]
         if bus["bus_type"] != 4 && !(bus["index"] in largest_cc)
             bus["bus_type"] = 4
-            info(LOGGER, "deactivating bus $(i) due to small connected component")
+            @info "deactivating bus $(i) due to small connected component"
         end
     end
 
@@ -1469,15 +1469,15 @@ function check_component_refrence_bus(component_bus_ids, bus_lookup, component_g
     end
 
     if length(refrence_buses) == 0
-        warn(LOGGER, "no reference bus found in connected component $(component_bus_ids)")
+        @warn "no reference bus found in connected component $(component_bus_ids)"
 
         if length(component_gens) > 0
             big_gen = biggest_generator(component_gens)
             gen_bus = bus_lookup[big_gen["gen_bus"]]
             gen_bus["bus_type"] = 3
-            warn(LOGGER, "setting bus $(gen_bus["index"]) as reference bus in connected component $(component_bus_ids), based on generator $(big_gen["index"])")
+            @warn "setting bus $(gen_bus["index"]) as reference bus in connected component $(component_bus_ids), based on generator $(big_gen["index"])"
         else
-            warn(LOGGER, "no generators found in connected component $(component_bus_ids), try running propagate_topology_status")
+            @warn "no generators found in connected component $(component_bus_ids), try running propagate_topology_status"
         end
     end
 end
@@ -1599,7 +1599,7 @@ conductor_matrix = Set(["br_r", "br_x"])
 ""
 function _make_multiconductor(data::Dict{String,Any}, conductors::Real)
     if haskey(data, "conductors")
-        warn(LOGGER, "skipping network that is already multiconductor")
+        @warn "skipping network that is already multiconductor"
         return
     end
 

--- a/src/core/solution.jl
+++ b/src/core/solution.jl
@@ -354,7 +354,7 @@ function add_dual(
                         sol_item[param_name][cnd_idx] = scale(getdual(constraint), item)
                     end
                 catch
-                    info(LOGGER, "No constraint: $(con_symbol), $(idx)")
+                    @info "No constraint: $(con_symbol), $(idx)"
                 end
                 cnd_idx += 1
             end

--- a/src/io/common.jl
+++ b/src/io/common.jl
@@ -9,7 +9,7 @@ function parse_file(file::String; import_all=false)
     if endswith(file, ".m")
         pm_data = PowerModels.parse_matpower(file)
     elseif endswith(lowercase(file), ".raw")
-        info(LOGGER, "The PSS(R)E parser currently supports buses, loads, shunts, generators, branches, transformers, and dc lines")
+        @info "The PSS(R)E parser currently supports buses, loads, shunts, generators, branches, transformers, and dc lines"
         pm_data = PowerModels.parse_psse(file; import_all=import_all)
     else
         pm_data = parse_json(file)

--- a/src/io/matpower.jl
+++ b/src/io/matpower.jl
@@ -164,7 +164,7 @@ function parse_matpower_string(data_string::String)
     if func_name != nothing
         case["name"] = func_name
     else
-        warn(LOGGER, string("no case name found in matpower file.  The file seems to be missing \"function mpc = ...\""))
+        @warn string("no case name found in matpower file.  The file seems to be missing \"function mpc = ...\"")
         case["name"] = "no_name_found"
     end
 
@@ -172,14 +172,14 @@ function parse_matpower_string(data_string::String)
     if haskey(matlab_data, "mpc.version")
         case["source_version"] = VersionNumber(matlab_data["mpc.version"])
     else
-        warn(LOGGER, string("no case version found in matpower file.  The file seems to be missing \"mpc.version = ...\""))
+        @warn string("no case version found in matpower file.  The file seems to be missing \"mpc.version = ...\"")
         case["source_version"] = "0.0.0+"
     end
 
     if haskey(matlab_data, "mpc.baseMVA")
         case["baseMVA"] = matlab_data["mpc.baseMVA"]
     else
-        warn(LOGGER, string("no baseMVA found in matpower file.  The file seems to be missing \"mpc.baseMVA = ...\""))
+        @warn string("no baseMVA found in matpower file.  The file seems to be missing \"mpc.baseMVA = ...\"")
         case["baseMVA"] = 1.0
     end
 
@@ -193,7 +193,7 @@ function parse_matpower_string(data_string::String)
         end
         case["bus"] = buses
     else
-        error(string("no bus table found in matpower file.  The file seems to be missing \"mpc.bus = [...];\""))
+        throw(error(string("no bus table found in matpower file.  The file seems to be missing \"mpc.bus = [...];\"")))
     end
 
     if haskey(matlab_data, "mpc.gen")
@@ -205,7 +205,7 @@ function parse_matpower_string(data_string::String)
         end
         case["gen"] = gens
     else
-        error(string("no gen table found in matpower file.  The file seems to be missing \"mpc.gen = [...];\""))
+        throw(error(string("no gen table found in matpower file.  The file seems to be missing \"mpc.gen = [...];\"")))
     end
 
     if haskey(matlab_data, "mpc.branch")
@@ -217,7 +217,7 @@ function parse_matpower_string(data_string::String)
         end
         case["branch"] = branches
     else
-        error(string("no branch table found in matpower file.  The file seems to be missing \"mpc.branch = [...];\""))
+        throw(error(string("no branch table found in matpower file.  The file seems to be missing \"mpc.branch = [...];\"")))
     end
 
     if haskey(matlab_data, "mpc.dcline")
@@ -251,7 +251,7 @@ function parse_matpower_string(data_string::String)
         case["bus_name"] = bus_names
 
         if length(case["bus_name"]) != length(case["bus"])
-            error("incorrect Matpower file, the number of bus names ($(length(case["bus_name"]))) is inconsistent with the number of buses ($(length(case["bus"]))).\n")
+            throw(error("incorrect Matpower file, the number of bus names ($(length(case["bus_name"]))) is inconsistent with the number of buses ($(length(case["bus"]))).\n"))
         end
     end
 
@@ -265,7 +265,7 @@ function parse_matpower_string(data_string::String)
         case["gencost"] = gencost
 
         if length(case["gencost"]) != length(case["gen"]) && length(case["gencost"]) != 2*length(case["gen"])
-            error("incorrect Matpower file, the number of generator cost functions ($(length(case["gencost"]))) is inconsistent with the number of generators ($(length(case["gen"]))).\n")
+            throw(error("incorrect Matpower file, the number of generator cost functions ($(length(case["gencost"]))) is inconsistent with the number of generators ($(length(case["gen"]))).\n"))
         end
     end
 
@@ -279,7 +279,7 @@ function parse_matpower_string(data_string::String)
         case["dclinecost"] = dclinecosts
 
         if length(case["dclinecost"]) != length(case["dcline"])
-            error("incorrect Matpower file, the number of dcline cost functions ($(length(case["dclinecost"]))) is inconsistent with the number of dclines ($(length(case["dcline"]))).\n")
+            throw(error("incorrect Matpower file, the number of dcline cost functions ($(length(case["dclinecost"]))) is inconsistent with the number of dclines ($(length(case["dcline"]))).\n"))
         end
     end
 
@@ -299,10 +299,10 @@ function parse_matpower_string(data_string::String)
                     push!(tbl, row_data)
                 end
                 case[case_name] = tbl
-                info(LOGGER, "extending matpower format with data: $(case_name) $(length(tbl))x$(length(tbl[1])-1)")
+                @info "extending matpower format with data: $(case_name) $(length(tbl))x$(length(tbl[1])-1)"
             else
                 case[case_name] = value
-                info(LOGGER, "extending matpower format with constant data: $(case_name)")
+                @info "extending matpower format with constant data: $(case_name)"
             end
         end
     end
@@ -333,7 +333,7 @@ function mp_cost_data(cost_row)
     cost_values = [InfrastructureModels.check_type(Float64, x) for x in cost_row[5:length(cost_row)]]
     if cost_data["model"] == 1:
         if length(cost_values)%2 != 0
-            error("incorrect matpower file, odd number of pwl cost function values")
+            throw(error("incorrect matpower file, odd number of pwl cost function values"))
         end
         for i in 0:(length(cost_values)/2-1)
             p_idx = 1+2*i
@@ -530,7 +530,7 @@ end
 "adds dcline costs, if gen costs exist"
 function add_dcline_costs(data::Dict{String,Any})
     if length(data["gencost"]) > 0 && length(data["dclinecost"]) <= 0 && length(data["dcline"]) > 0
-        warn(LOGGER, "added zero cost function data for dclines")
+        @warn "added zero cost function data for dclines"
         model = data["gencost"][1]["model"]
         if model == 1
             for (i, dcline) in enumerate(data["dcline"])
@@ -619,10 +619,10 @@ function merge_generic_data(data::Dict{String,Any})
                     push!(key_to_delete, k)
 
                     if length(mp_matrix) != length(v)
-                        error("failed to extend the matpower matrix \"$(mp_name)\" with the matrix \"$(k)\" because they do not have the same number of rows, $(length(mp_matrix)) and $(length(v)) respectively.")
+                        throw(error("failed to extend the matpower matrix \"$(mp_name)\" with the matrix \"$(k)\" because they do not have the same number of rows, $(length(mp_matrix)) and $(length(v)) respectively."))
                     end
 
-                    info(LOGGER, "extending matpower format by appending matrix \"$(k)\" in to \"$(mp_name)\"")
+                    @info "extending matpower format by appending matrix \"$(k)\" in to \"$(mp_name)\""
 
                     for (i, row) in enumerate(mp_matrix)
                         merge_row = v[i]
@@ -630,7 +630,7 @@ function merge_generic_data(data::Dict{String,Any})
                         delete!(merge_row, "index")
                         for key in keys(merge_row)
                             if haskey(row, key)
-                                error("failed to extend the matpower matrix \"$(mp_name)\" with the matrix \"$(k)\" because they both share \"$(key)\" as a column name.")
+                                throw(error("failed to extend the matpower matrix \"$(mp_name)\" with the matrix \"$(k)\" because they both share \"$(key)\" as a column name."))
                             end
                             row[key] = merge_row[key]
                         end
@@ -780,7 +780,7 @@ function export_matpower(io::IO, data::Dict{String,Any})
     i = 1
     for (idx,gen) in sort(generators)
         if idx != gen["index"]
-            warn(LOGGER, "The index of the generator does not match the matpower assigned index. Any data that uses generator indexes for reference is corrupted.");
+            @warn "The index of the generator does not match the matpower assigned index. Any data that uses generator indexes for reference is corrupted.";
         end
     println(io, "\t", gen["gen_bus"],
                 "\t", get_default(gen, "pg"),
@@ -821,7 +821,7 @@ function export_matpower(io::IO, data::Dict{String,Any})
     i = 1
     for (idx,branch) in sort(branches)
         if idx != branch["index"]
-            warn(LOGGER, "The index of the branch does not match the matpower assigned index. Any data that uses branch indexes for reference is corrupted.");
+            @warn "The index of the branch does not match the matpower assigned index. Any data that uses branch indexes for reference is corrupted.";
         end
         println(io,
             "\t", get_default(branch, "f_bus"),
@@ -900,7 +900,7 @@ function export_matpower(io::IO, data::Dict{String,Any})
         i = 1
         for (idx,branch) in sort(ne_branches)
             if idx != branch["index"]
-                warn(LOGGER, "The index of the ne_branch does not match the matpower assigned index. Any data that uses branch indexes for reference is corrupted.");
+                @warn "The index of the ne_branch does not match the matpower assigned index. Any data that uses branch indexes for reference is corrupted.";
             end
             println(io,
                 "\t", branch["f_bus"],
@@ -1016,7 +1016,7 @@ function export_extra_data(io::IO, data::Dict{String,Any}, component, excluded_f
     i = 1
     for (idx,c) in sort(components)
         if idx != c["index"]
-            warn(LOGGER, "The index of a component does not match the matpower assigned index. Any data that uses component indexes for reference is corrupted.");
+            @warn "The index of a component does not match the matpower assigned index. Any data that uses component indexes for reference is corrupted.";
         end
 
         for field in included_fields
@@ -1049,7 +1049,7 @@ function export_cost_data(io::IO, components::Dict{Int,Dict}, prefix::String)
 
         for (i,comp) in components
             if length(comp["cost"]) != ncost || comp["model"] != model
-                warn(LOGGER, "heterogeneous cost functions will be ommited in Matpower data")
+                @warn "heterogeneous cost functions will be ommited in Matpower data"
                 return
             end
         end

--- a/src/io/psse.jl
+++ b/src/io/psse.jl
@@ -43,7 +43,7 @@ function get_bus_value(bus_i, field, pm_data)
         end
     end
 
-    warn(LOGGER, "Could not find bus $bus_i, returning 0 for field $field")
+    @warn "Could not find bus $bus_i, returning 0 for field $field"
     return 0
 end
 
@@ -250,7 +250,7 @@ function psse2pm_bus!(pm_data::Dict, pti_data::Dict, import_all::Bool)
                 sub_data["vmax"] = pop!(bus, "NVHI")
                 sub_data["vmin"] = pop!(bus, "NVLO")
             else
-                warn(LOGGER, "PTI v$(pm_data["source_version"]) does not contain vmin and vmax values, defaults of 0.9 and 1.1, respectively, assumed.")
+                @warn "PTI v$(pm_data["source_version"]) does not contain vmin and vmax values, defaults of 0.9 and 1.1, respectively, assumed."
                 sub_data["vmax"] = 1.1
                 sub_data["vmin"] = 0.9
             end
@@ -324,7 +324,7 @@ function psse2pm_shunt!(pm_data::Dict, pti_data::Dict, import_all::Bool)
     end
 
     if haskey(pti_data, "SWITCHED SHUNT")
-        info(LOGGER, "Switched shunt converted to fixed shunt, with default value gs=0.0")
+        @info "Switched shunt converted to fixed shunt, with default value gs=0.0"
 
         for shunt in pti_data["SWITCHED SHUNT"]
             sub_data = Dict{String,Any}()
@@ -550,7 +550,7 @@ function psse2pm_dcline!(pm_data::Dict, pti_data::Dict, import_all::Bool)
 
     if haskey(pti_data, "TWO-TERMINAL DC")
         for dcline in pti_data["TWO-TERMINAL DC"]
-            info(LOGGER, "Two-Terminal DC lines are supported via a simple *lossless* dc line model approximated by two generators.")
+            @info "Two-Terminal DC lines are supported via a simple *lossless* dc line model approximated by two generators."
             sub_data = Dict{String,Any}()
 
             # Unit conversions?
@@ -577,7 +577,7 @@ function psse2pm_dcline!(pm_data::Dict, pti_data::Dict, import_all::Bool)
                     push!(anmn, pop!(dcline, key))
                 else
                     push!(anmn, 0)
-                    warn(LOGGER, "$key outside reasonable limits, setting to 0 degress")
+                    @warn "$key outside reasonable limits, setting to 0 degress"
                 end
             end
 
@@ -607,7 +607,7 @@ function psse2pm_dcline!(pm_data::Dict, pti_data::Dict, import_all::Bool)
     end
 
     if haskey(pti_data, "VOLTAGE SOURCE CONVERTER")
-        info(LOGGER, "VSC-HVDC lines are supported via a dc line model approximated by two generators and an associated loss.")
+        @info "VSC-HVDC lines are supported via a dc line model approximated by two generators and an associated loss."
         for dcline in pti_data["VOLTAGE SOURCE CONVERTER"]
             # Converter buses : is the distinction between ac and dc side meaningful?
             dcside, acside = dcline["CONVERTER BUSES"]

--- a/src/prob/opf_bf.jl
+++ b/src/prob/opf_bf.jl
@@ -7,7 +7,7 @@ end
 
 ""
 function run_opf_bf(file, model_constructor, solver; kwargs...)
-    error(LOGGER, "The problem type opf_bf at the moment only supports subtypes of AbstractBFForm")
+    throw(error("The problem type opf_bf at the moment only supports subtypes of AbstractBFForm"))
 end
 
 ""

--- a/src/prob/pf_bf.jl
+++ b/src/prob/pf_bf.jl
@@ -3,7 +3,7 @@ export run_pf_bf, run_ac_pf_bf, run_dc_pf_bf
 ""
 function run_pf_bf(file, model_constructor, solver; kwargs...)
     if model_constructor != SOCBFPowerModel
-        error(LOGGER, "The problem type pf_bf at the moment only supports the SOCBFForm formulation")
+        throw(error("The problem type pf_bf at the moment only supports the SOCBFForm formulation"))
     end
     return run_generic_model(file, model_constructor, solver, post_pf_bf; kwargs...)
 end

--- a/src/util/obbt.jl
+++ b/src/util/obbt.jl
@@ -5,30 +5,30 @@ function check_variables(pm::GenericPowerModel)
     try
         vm = var(pm, :vm)
     catch err
-        (isa(error, KeyError)) && (error(LOGGER, "OBBT is not supported for models without explicit voltage magnitude variables"))
+        (isa(error, KeyError)) && (error("OBBT is not supported for models without explicit voltage magnitude variables"))
     end
 
     try
         td = var(pm, :td)
     catch err
-        (isa(error, KeyError)) && (error(LOGGER, "OBBT is not supported for models without explicit voltage angle difference variables"))
+        (isa(error, KeyError)) && (error("OBBT is not supported for models without explicit voltage angle difference variables"))
     end
 end
 
 function check_obbt_options(ub::Float64, rel_gap::Float64, ub_constraint::Bool)
     if ub_constraint && isinf(ub)
-        error(LOGGER, "the option upper_bound_constraint cannot be set to true without specifying an upper bound")
+        throw(error("the option upper_bound_constraint cannot be set to true without specifying an upper bound"))
     end
 
     if !isinf(rel_gap) && isinf(ub)
-        error(LOGGER, "rel_gap_tol is specified without providing an upper bound")
+        throw(error("rel_gap_tol is specified without providing an upper bound"))
     end
 end
 
 function constraint_obj_bound(pm::GenericPowerModel, bound)
     model = PowerModels.check_cost_models(pm)
     if model != 2
-        error("Only cost models of type 2 is supported at this time, given cost model type $(model)")
+        throw(error("Only cost models of type 2 is supported at this time, given cost model type $(model)"))
     end
 
     PowerModels.check_polynomial_cost_models(pm)
@@ -95,12 +95,12 @@ function run_obbt_opf(data::Dict{String,Any}, solver;
     termination = :avg,
     kwargs...)
 
-    info(LOGGER, "maximum OBBT iterations set to default value of $max_iter")
-    info(LOGGER, "maximum time limit for OBBT set to default value of $time_limit seconds")
+    @info "maximum OBBT iterations set to default value of $max_iter"
+    @info "maximum time limit for OBBT set to default value of $time_limit seconds"
 
     model_relaxation = build_generic_model(data, model_constructor, PowerModels.post_opf)
-    (ismultinetwork(model_relaxation)) && (error(LOGGER, "OBBT is not supported for multi-networks"))
-    (ismulticonductor(model_relaxation)) && (error(LOGGER, "OBBT is not supported for multi-phase networks"))
+    (ismultinetwork(model_relaxation)) && (error("OBBT is not supported for multi-networks"))
+    (ismulticonductor(model_relaxation)) && (error("OBBT is not supported for multi-phase networks"))
 
     # check for model_constructor compatability with OBBT
     check_variables(model_relaxation)
@@ -109,7 +109,7 @@ function run_obbt_opf(data::Dict{String,Any}, solver;
     check_obbt_options(upper_bound, rel_gap_tol, upper_bound_constraint)
 
     # check termination norm criteria for obbt
-    (termination != :avg && termination != :max) && (error(LOGGER, "OBBT termination criteria can only be :max or :avg"))
+    (termination != :avg && termination != :max) && (error("OBBT termination criteria can only be :max or :avg"))
 
     # pass status
     status_pass = [:LocalOptimal, :Optimal]
@@ -118,18 +118,18 @@ function run_obbt_opf(data::Dict{String,Any}, solver;
     result_relaxation = solve_generic_model(model_relaxation, solver)
     current_relaxation_objective = result_relaxation["objective"]
     if upper_bound < current_relaxation_objective
-        error(LOGGER, "the upper bound provided to OBBT is not a valid ACOPF upper bound")
-    end
-    if !(result_relaxation["status"] in status_pass)
-        warn(LOGGER, "initial relaxation solve status is $(result_relaxation["status"])")
+        throw(error("the upper bound provided to OBBT is not a valid ACOPF upper bound"))
+            end
+            if !(result_relaxation["status"] in status_pass)
+        @warn "initial relaxation solve status is $(result_relaxation["status"])"
         if result_relaxation["status"] == :SubOptimal
-            warn(LOGGER, "continuing with the bound-tightening algorithm")
+            @warn "continuing with the bound-tightening algorithm"
         end
     end
     current_rel_gap = Inf
     if !isinf(upper_bound)
         current_rel_gap = (upper_bound - current_relaxation_objective)/upper_bound
-        info(LOGGER, "Initial relaxation gap = $current_rel_gap")
+        @info "Initial relaxation gap = $current_rel_gap"
     end
 
 
@@ -205,7 +205,7 @@ function run_obbt_opf(data::Dict{String,Any}, solver;
                 nlb = floor(10.0^precision * getobjectivevalue(model_bt.model))/(10.0^precision)
                 (nlb > vm_lb[bus]) && (lb = nlb)
             else
-                warn(LOGGER, "BT minimization problem for vm[$bus] errored - change tolerances.")
+                @warn "BT minimization problem for vm[$bus] errored - change tolerances."
                 continue
             end
 
@@ -217,14 +217,14 @@ function run_obbt_opf(data::Dict{String,Any}, solver;
                 nub = ceil(10.0^precision * getobjectivevalue(model_bt.model))/(10.0^precision)
                 (nub < vm_ub[bus]) && (ub = nub)
             else
-                warn(LOGGER, "BT maximization problem for vm[$bus] errored - change tolerances.")
+                @warn "BT maximization problem for vm[$bus] errored - change tolerances."
                 continue
             end
             end_time = time() - start_time
             max_vm_iteration_time = max(end_time, max_vm_iteration_time)
 
             # sanity checks
-            (lb > ub) && (warn(LOGGER, "bt lb > ub - adjust tolerances in solver to avoid issue"); continue)
+            (lb > ub) && (@warn "bt lb > ub - adjust tolerances in solver to avoid issue"; continue)
             (!isnan(lb) && lb > vm_ub[bus]) && (lb = vm_lb[bus])
             (!isnan(ub) && ub < vm_lb[bus]) && (ub = vm_ub[bus])
             isnan(lb) && (lb = vm_lb[bus])
@@ -265,7 +265,7 @@ function run_obbt_opf(data::Dict{String,Any}, solver;
                 nlb = floor(10.0^precision * getobjectivevalue(model_bt.model))/(10.0^precision)
                 (nlb > td_lb[bp]) && (lb = nlb)
             else
-                warn(LOGGER, "BT minimization problem for td[$bp] errored - change tolerances")
+                @warn "BT minimization problem for td[$bp] errored - change tolerances"
                 continue
             end
 
@@ -277,14 +277,14 @@ function run_obbt_opf(data::Dict{String,Any}, solver;
                 nub = ceil(10.0^precision * getobjectivevalue(model_bt.model))/(10.0^precision)
                 (nub < td_ub[bp]) && (ub = nub)
             else
-                warn(LOGGER, "BT maximization problem for td[$bp] errored - change tolerances.")
+                @warn "BT maximization problem for td[$bp] errored - change tolerances."
                 continue
             end
             end_time = time() - start_time
             max_td_iteration_time = max(end_time, max_td_iteration_time)
 
             # sanity checks
-            (lb > ub) && (warn(LOGGER, "bt lb > ub - adjust tolerances in solver to avoid issue"); continue)
+            (lb > ub) && (@warn "bt lb > ub - adjust tolerances in solver to avoid issue"; continue)
             (!isnan(lb) && lb > td_ub[bp]) && (lb = td_lb[bp])
             (!isnan(ub) && ub < td_lb[bp]) && (ub = td_ub[bp])
             isnan(lb) && (lb = td_lb[bp])
@@ -332,11 +332,11 @@ function run_obbt_opf(data::Dict{String,Any}, solver;
             current_rel_gap = (upper_bound - result_relaxation["objective"])/upper_bound
             final_relaxation_objective = result_relaxation["objective"]
         else
-            warn(LOGGER, "relaxation solve failed in iteration $(current_iteration+1)")
-            warn(LOGGER, "using the previous iteration's gap to check relative gap stopping criteria")
+            @warn "relaxation solve failed in iteration $(current_iteration+1)"
+            @warn "using the previous iteration's gap to check relative gap stopping criteria"
         end
 
-        info(LOGGER, "iteration $(current_iteration+1), vm range: $vm_range_final, td range: $td_range_final, relaxation obj: $final_relaxation_objective")
+        @info "iteration $(current_iteration+1), vm range: $vm_range_final, td range: $td_range_final, relaxation obj: $final_relaxation_objective"
 
         # termination criteria update
         (termination == :avg) && (check_termination = (avg_vm_reduction > improvement_tol || avg_td_reduction > improvement_tol))
@@ -344,10 +344,10 @@ function run_obbt_opf(data::Dict{String,Any}, solver;
         # interation counter update
         current_iteration += 1
         # check all the stopping criteria
-        (current_iteration >= max_iter) && (info(LOGGER, "maximum iteration limit reached"); break)
-        (time_elapsed > time_limit) && (info(LOGGER, "maximum time limit reached"); break)
+        (current_iteration >= max_iter) && (@info "maximum iteration limit reached"; break)
+        (time_elapsed > time_limit) && (@info "maximum time limit reached"; break)
         if (!isinf(rel_gap_tol)) && (current_rel_gap < rel_gap_tol)
-            info(LOGGER, "relative optimality gap < $rel_gap_tol")
+            @info "relative optimality gap < $rel_gap_tol"
             break
         end
 

--- a/test/data.jl
+++ b/test/data.jl
@@ -1,4 +1,7 @@
 # Tests of data checking and transformation code
+if VERSION < v"0.7.0-"
+    TESTLOG = getlogger(PowerModels)
+end
 
 @testset "test data summary" begin
 
@@ -302,85 +305,169 @@ end
 @testset "test errors and warnings" begin
     data = PowerModels.parse_file("../test/data/matpower/case3.m")
 
-    # check_cost_functions
-    data["gen"]["1"]["model"] = 1
-    data["gen"]["1"]["ncost"] = 1
-    data["gen"]["1"]["cost"] = [0, 1, 0]
-    @test_throws(TESTLOG, ErrorException, PowerModels.check_cost_functions(data))
+    if VERSION < v"0.7.0-"
+        # check_cost_functions
+        data["gen"]["1"]["model"] = 1
+        data["gen"]["1"]["ncost"] = 1
+        data["gen"]["1"]["cost"] = [0, 1, 0]
+        Memento.Test.@test_throws(TESTLOG, ErrorException, PowerModels.check_cost_functions(data))
 
-    data["gen"]["1"]["cost"] = [0, 0]
-    @test_throws(TESTLOG, ErrorException, PowerModels.check_cost_functions(data))
+        data["gen"]["1"]["cost"] = [0, 0]
+        Memento.Test.@test_throws(TESTLOG, ErrorException, PowerModels.check_cost_functions(data))
 
-    data["gen"]["1"]["ncost"] = 2
-    data["gen"]["1"]["cost"] = [0, 0, 0, 0]
-    @test_throws(TESTLOG, ErrorException, PowerModels.check_cost_functions(data))
+        data["gen"]["1"]["ncost"] = 2
+        data["gen"]["1"]["cost"] = [0, 0, 0, 0]
+        Memento.Test.@test_throws(TESTLOG, ErrorException, PowerModels.check_cost_functions(data))
 
-    data["gen"]["1"]["model"] = 2
-    @test_throws(TESTLOG, ErrorException, PowerModels.check_cost_functions(data))
+        data["gen"]["1"]["model"] = 2
+        Memento.Test.@test_throws(TESTLOG, ErrorException, PowerModels.check_cost_functions(data))
 
-    # check_connectivity
-    data["load"]["1"]["load_bus"] = 1000
-    @test_throws(TESTLOG, ErrorException, PowerModels.check_connectivity(data))
+        # check_connectivity
+        data["load"]["1"]["load_bus"] = 1000
+        Memento.Test.@test_throws(TESTLOG, ErrorException, PowerModels.check_connectivity(data))
 
-    data["load"]["1"]["load_bus"] = 1
-    data["shunt"]["1"] = Dict{String,Any}("gs"=>0, "bs"=>1, "shunt_bus"=>1000, "index"=>1, "status"=>1)
-    @test_throws(TESTLOG, ErrorException, PowerModels.check_connectivity(data))
+        data["load"]["1"]["load_bus"] = 1
+        data["shunt"]["1"] = Dict{String,Any}("gs"=>0, "bs"=>1, "shunt_bus"=>1000, "index"=>1, "status"=>1)
+        Memento.Test.@test_throws(TESTLOG, ErrorException, PowerModels.check_connectivity(data))
 
-    data["shunt"]["1"]["shunt_bus"] = 1
-    data["gen"]["1"]["gen_bus"] = 1000
-    @test_throws(TESTLOG, ErrorException, PowerModels.check_connectivity(data))
+        data["shunt"]["1"]["shunt_bus"] = 1
+        data["gen"]["1"]["gen_bus"] = 1000
+        Memento.Test.@test_throws(TESTLOG, ErrorException, PowerModels.check_connectivity(data))
 
-    data["gen"]["1"]["gen_bus"] = 1
-    data["branch"]["1"]["f_bus"] = 1000
-    @test_throws(TESTLOG, ErrorException, PowerModels.check_connectivity(data))
+        data["gen"]["1"]["gen_bus"] = 1
+        data["branch"]["1"]["f_bus"] = 1000
+        Memento.Test.@test_throws(TESTLOG, ErrorException, PowerModels.check_connectivity(data))
 
-    data["branch"]["1"]["f_bus"] = 1
-    data["branch"]["1"]["t_bus"] = 1000
-    @test_throws(TESTLOG, ErrorException, PowerModels.check_connectivity(data))
+        data["branch"]["1"]["f_bus"] = 1
+        data["branch"]["1"]["t_bus"] = 1000
+        Memento.Test.@test_throws(TESTLOG, ErrorException, PowerModels.check_connectivity(data))
 
-    data["branch"]["1"]["t_bus"] = 3
-    data["dcline"]["1"]["f_bus"] = 1000
-    @test_throws(TESTLOG, ErrorException, PowerModels.check_connectivity(data))
+        data["branch"]["1"]["t_bus"] = 3
+        data["dcline"]["1"]["f_bus"] = 1000
+        Memento.Test.@test_throws(TESTLOG, ErrorException, PowerModels.check_connectivity(data))
 
-    data["dcline"]["1"]["f_bus"] = 1
-    data["dcline"]["1"]["t_bus"] = 1000
-    @test_throws(TESTLOG, ErrorException, PowerModels.check_connectivity(data))
-    data["dcline"]["1"]["t_bus"] = 2
+        data["dcline"]["1"]["f_bus"] = 1
+        data["dcline"]["1"]["t_bus"] = 1000
+        Memento.Test.@test_throws(TESTLOG, ErrorException, PowerModels.check_connectivity(data))
+        data["dcline"]["1"]["t_bus"] = 2
 
-    #warnings
-    setlevel!(TESTLOG, "warn")
+        #warnings
+        setlevel!(TESTLOG, "warn")
 
-    data["gen"]["1"]["model"] = 3
-    @test_warn(TESTLOG, "Skipping cost model of type 3 in per unit transformation", PowerModels.make_mixed_units(data))
-    @test_warn(TESTLOG, "Skipping cost model of type 3 in per unit transformation", PowerModels.make_per_unit(data))
-    @test_warn(TESTLOG, "Unknown cost model of type 3 on generator 1", PowerModels.check_cost_functions(data))
-    data["gen"]["1"]["model"] = 1
+        data["gen"]["1"]["model"] = 3
+        Memento.Test.@test_warn(TESTLOG, "Skipping cost model of type 3 in per unit transformation", PowerModels.make_mixed_units(data))
+        Memento.Test.@test_warn(TESTLOG, "Skipping cost model of type 3 in per unit transformation", PowerModels.make_per_unit(data))
+        Memento.Test.@test_warn(TESTLOG, "Unknown cost model of type 3 on generator 1", PowerModels.check_cost_functions(data))
+        data["gen"]["1"]["model"] = 1
 
-    data["gen"]["1"]["cost"][3] = 3000
-    @test_warn(TESTLOG, "pwl x value 3000 is outside the bounds 0.0-20.0 on generator 1", PowerModels.check_cost_functions(data))
+        data["gen"]["1"]["cost"][3] = 3000
+        Memento.Test.@test_warn(TESTLOG, "pwl x value 3000 is outside the bounds 0.0-20.0 on generator 1", PowerModels.check_cost_functions(data))
 
-    data["dcline"]["1"]["loss0"] = -1.0
-    @test_warn(TESTLOG, "this code only supports positive loss0 values, changing the value on dcline 1 from -100.0 to 0.0", PowerModels.check_dcline_limits(data))
+        data["dcline"]["1"]["loss0"] = -1.0
+        Memento.Test.@test_warn(TESTLOG, "this code only supports positive loss0 values, changing the value on dcline 1 from -100.0 to 0.0", PowerModels.check_dcline_limits(data))
 
-    data["dcline"]["1"]["loss1"] = -1.0
-    @test_warn(TESTLOG, "this code only supports positive loss1 values, changing the value on dcline 1 from -1.0 to 0.0", PowerModels.check_dcline_limits(data))
+        data["dcline"]["1"]["loss1"] = -1.0
+        Memento.Test.@test_warn(TESTLOG, "this code only supports positive loss1 values, changing the value on dcline 1 from -1.0 to 0.0", PowerModels.check_dcline_limits(data))
 
-    @test data["dcline"]["1"]["loss0"] == 0.0
-    @test data["dcline"]["1"]["loss1"] == 0.0
+        @test data["dcline"]["1"]["loss0"] == 0.0
+        @test data["dcline"]["1"]["loss1"] == 0.0
 
-    data["dcline"]["1"]["loss1"] = 100.0
-    @test_warn(TESTLOG, "this code only supports loss1 values < 1, changing the value on dcline 1 from 100.0 to 0.0", PowerModels.check_dcline_limits(data))
+        data["dcline"]["1"]["loss1"] = 100.0
+        Memento.Test.@test_warn(TESTLOG, "this code only supports loss1 values < 1, changing the value on dcline 1 from 100.0 to 0.0", PowerModels.check_dcline_limits(data))
 
-    delete!(data["branch"]["1"], "tap")
-    @test_warn(TESTLOG, "branch found without tap value, setting a tap to 1.0", PowerModels.check_transformer_parameters(data))
+        delete!(data["branch"]["1"], "tap")
+        Memento.Test.@test_warn(TESTLOG, "branch found without tap value, setting a tap to 1.0", PowerModels.check_transformer_parameters(data))
 
-    delete!(data["branch"]["1"], "shift")
-    @test_warn(TESTLOG, "branch found without shift value, setting a shift to 0.0", PowerModels.check_transformer_parameters(data))
+        delete!(data["branch"]["1"], "shift")
+        Memento.Test.@test_warn(TESTLOG, "branch found without shift value, setting a shift to 0.0", PowerModels.check_transformer_parameters(data))
 
-    data["branch"]["1"]["tap"] = -1.0
-    @test_warn(TESTLOG, "branch found with non-positive tap value of -1.0, setting a tap to 1.0", PowerModels.check_transformer_parameters(data))
+        data["branch"]["1"]["tap"] = -1.0
+        Memento.Test.@test_warn(TESTLOG, "branch found with non-positive tap value of -1.0, setting a tap to 1.0", PowerModels.check_transformer_parameters(data))
 
-    setlevel!(TESTLOG, "error")
+        setlevel!(TESTLOG, "error")
+    else
+        # check_cost_functions
+        data["gen"]["1"]["model"] = 1
+        data["gen"]["1"]["ncost"] = 1
+        data["gen"]["1"]["cost"] = [0, 1, 0]
+        @test_throws ErrorException PowerModels.check_cost_functions(data)
+
+        data["gen"]["1"]["cost"] = [0, 0]
+        @test_throws ErrorException PowerModels.check_cost_functions(data)
+
+        data["gen"]["1"]["ncost"] = 2
+        data["gen"]["1"]["cost"] = [0, 0, 0, 0]
+        @test_throws ErrorException PowerModels.check_cost_functions(data)
+
+        data["gen"]["1"]["model"] = 2
+        @test_throws ErrorException PowerModels.check_cost_functions(data)
+
+        # check_connectivity
+        data["load"]["1"]["load_bus"] = 1000
+        @test_throws ErrorException PowerModels.check_connectivity(data)
+
+        data["load"]["1"]["load_bus"] = 1
+        data["shunt"]["1"] = Dict{String,Any}("gs"=>0, "bs"=>1, "shunt_bus"=>1000, "index"=>1, "status"=>1)
+        @test_throws ErrorException PowerModels.check_connectivity(data)
+
+        data["shunt"]["1"]["shunt_bus"] = 1
+        data["gen"]["1"]["gen_bus"] = 1000
+        @test_throws ErrorException PowerModels.check_connectivity(data)
+
+        data["gen"]["1"]["gen_bus"] = 1
+        data["branch"]["1"]["f_bus"] = 1000
+        @test_throws ErrorException PowerModels.check_connectivity(data)
+
+        data["branch"]["1"]["f_bus"] = 1
+        data["branch"]["1"]["t_bus"] = 1000
+        @test_throws ErrorException PowerModels.check_connectivity(data)
+
+        data["branch"]["1"]["t_bus"] = 3
+        data["dcline"]["1"]["f_bus"] = 1000
+        @test_throws ErrorException PowerModels.check_connectivity(data)
+
+        data["dcline"]["1"]["f_bus"] = 1
+        data["dcline"]["1"]["t_bus"] = 1000
+        @test_throws ErrorException PowerModels.check_connectivity(data)
+        data["dcline"]["1"]["t_bus"] = 2
+
+        #warnings
+        Logging.disable_logging(Logging.Debug)
+
+        data["gen"]["1"]["model"] = 3
+        @test_logs (:warn, "Skipping cost model of type 3 in per unit transformation") PowerModels.make_mixed_units(data)
+        @test_logs (:warn, "Skipping cost model of type 3 in per unit transformation") PowerModels.make_per_unit(data)
+        @test_logs (:warn, "Unknown cost model of type 3 on generator 1") PowerModels.check_cost_functions(data)
+        data["gen"]["1"]["model"] = 1
+
+        data["gen"]["1"]["cost"][3] = 3000
+        @test_logs (:warn, "pwl x value 3000 is outside the bounds 0.0-20.0 on generator 1") PowerModels.check_cost_functions(data)
+
+        data["dcline"]["1"]["loss0"] = -1.0
+        @test_logs (:warn, "this code only supports positive loss0 values, changing the value on dcline 1 from -100.0 to 0.0") PowerModels.check_dcline_limits(data)
+
+        data["dcline"]["1"]["loss1"] = -1.0
+        @test_logs (:warn, "this code only supports positive loss1 values, changing the value on dcline 1 from -1.0 to 0.0") PowerModels.check_dcline_limits(data)
+
+        @test data["dcline"]["1"]["loss0"] == 0.0
+        @test data["dcline"]["1"]["loss1"] == 0.0
+
+        data["dcline"]["1"]["loss1"] = 100.0
+        @test_logs((:warn, "this code only supports loss0 values which are consistent with the line flow bounds, changing the value on dcline 1 from 0.0 to 0.0"),
+                        (:warn, "this code only supports loss1 values < 1, changing the value on dcline 1 from 100.0 to 0.0"),
+                        PowerModels.check_dcline_limits(data))
+
+        delete!(data["branch"]["1"], "tap")
+        @test_logs (:warn, "branch found without tap value, setting a tap to 1.0") PowerModels.check_transformer_parameters(data)
+
+        delete!(data["branch"]["1"], "shift")
+        @test_logs (:warn, "branch found without shift value, setting a shift to 0.0") PowerModels.check_transformer_parameters(data)
+
+        data["branch"]["1"]["tap"] = -1.0
+        @test_logs (:warn, "branch found with non-positive tap value of -1.0, setting a tap to 1.0") PowerModels.check_transformer_parameters(data)
+
+        Logging.disable_logging(Logging.Warn)
+    end
 end
 
 

--- a/test/multiconductor.jl
+++ b/test/multiconductor.jl
@@ -1,4 +1,6 @@
-TESTLOG = getlogger(PowerModels)
+if VERSION < v"0.7.0-"
+    TESTLOG = Memento.getlogger(PowerModels)
+end
 
 "an example of building a multi-phase model in an extention package"
 function post_tp_opf(pm::PowerModels.GenericPowerModel)
@@ -236,116 +238,248 @@ end
         PowerModels.make_multiconductor(mp_data_2p, 2)
         PowerModels.make_multiconductor(mp_data_3p, 3)
 
-        @test_throws(TESTLOG, ErrorException, PowerModels.update_data(mp_data_2p, mp_data_3p))
-        @test_throws(TESTLOG, ErrorException, PowerModels.check_keys(mp_data_3p, ["load"]))
+        if VERSION < v"0.7.0-"
+            Memento.Test.@test_throws(TESTLOG, ErrorException, PowerModels.update_data(mp_data_2p, mp_data_3p))
+            Memento.Test.@test_throws(TESTLOG, ErrorException, PowerModels.check_keys(mp_data_3p, ["load"]))
 
-        # check_cost_functions
-        mp_data_3p["gen"]["1"]["model"] = 1
-        mp_data_3p["gen"]["1"]["ncost"] = 1
-        mp_data_3p["gen"]["1"]["cost"] = [0.0, 1.0, 0.0]
-        @test_throws(TESTLOG, ErrorException, PowerModels.check_cost_functions(mp_data_3p))
+            # check_cost_functions
+            mp_data_3p["gen"]["1"]["model"] = 1
+            mp_data_3p["gen"]["1"]["ncost"] = 1
+            mp_data_3p["gen"]["1"]["cost"] = [0.0, 1.0, 0.0]
+            Memento.Test.@test_throws(TESTLOG, ErrorException, PowerModels.check_cost_functions(mp_data_3p))
 
-        mp_data_3p["gen"]["1"]["cost"] = [0.0, 0.0]
-        @test_throws(TESTLOG, ErrorException, PowerModels.check_cost_functions(mp_data_3p))
+            mp_data_3p["gen"]["1"]["cost"] = [0.0, 0.0]
+            Memento.Test.@test_throws(TESTLOG, ErrorException, PowerModels.check_cost_functions(mp_data_3p))
 
-        mp_data_3p["gen"]["1"]["ncost"] = 2
-        mp_data_3p["gen"]["1"]["cost"] = [0.0, 0.0, 0.0, 0.0]
-        @test_throws(TESTLOG, ErrorException, PowerModels.check_cost_functions(mp_data_3p))
+            mp_data_3p["gen"]["1"]["ncost"] = 2
+            mp_data_3p["gen"]["1"]["cost"] = [0.0, 0.0, 0.0, 0.0]
+            Memento.Test.@test_throws(TESTLOG, ErrorException, PowerModels.check_cost_functions(mp_data_3p))
 
-        mp_data_3p["gen"]["1"]["model"] = 2
-        @test_throws(TESTLOG, ErrorException, PowerModels.check_cost_functions(mp_data_3p))
+            mp_data_3p["gen"]["1"]["model"] = 2
+            Memento.Test.@test_throws(TESTLOG, ErrorException, PowerModels.check_cost_functions(mp_data_3p))
 
-        setlevel!(TESTLOG, "info")
+            setlevel!(TESTLOG, "info")
 
-        mp_data_3p["gen"]["1"]["model"] = 3
-        @test_warn(TESTLOG, "Skipping cost model of type 3 in per unit transformation", PowerModels.make_mixed_units(mp_data_3p))
-        @test_warn(TESTLOG, "Skipping cost model of type 3 in per unit transformation", PowerModels.make_per_unit(mp_data_3p))
-        @test_warn(TESTLOG, "Unknown cost model of type 3 on generator 1", PowerModels.check_cost_functions(mp_data_3p))
+            mp_data_3p["gen"]["1"]["model"] = 3
+            Memento.Test.@test_warn(TESTLOG, "Skipping cost model of type 3 in per unit transformation", PowerModels.make_mixed_units(mp_data_3p))
+            Memento.Test.@test_warn(TESTLOG, "Skipping cost model of type 3 in per unit transformation", PowerModels.make_per_unit(mp_data_3p))
+            Memento.Test.@test_warn(TESTLOG, "Unknown cost model of type 3 on generator 1", PowerModels.check_cost_functions(mp_data_3p))
 
-        mp_data_3p["gen"]["1"]["model"] = 1
-        mp_data_3p["gen"]["1"]["cost"][3] = 3000
-        @test_warn(TESTLOG, "pwl x value 3000.0 is outside the bounds 0.0-60.0 on generator 1", PowerModels.check_cost_functions(mp_data_3p))
+            mp_data_3p["gen"]["1"]["model"] = 1
+            mp_data_3p["gen"]["1"]["cost"][3] = 3000
+            Memento.Test.@test_warn(TESTLOG, "pwl x value 3000.0 is outside the bounds 0.0-60.0 on generator 1", PowerModels.check_cost_functions(mp_data_3p))
 
-        @test_nowarn PowerModels.check_voltage_angle_differences(mp_data_3p)
+            Memento.Test.@test_nowarn PowerModels.check_voltage_angle_differences(mp_data_3p)
 
-        mp_data_2p["branch"]["1"]["angmin"] = [-pi, 0]
-        mp_data_2p["branch"]["1"]["angmax"] = [ pi, 0]
+            mp_data_2p["branch"]["1"]["angmin"] = [-pi, 0]
+            mp_data_2p["branch"]["1"]["angmax"] = [ pi, 0]
 
-        @test_warn(TESTLOG, "this code only supports angmin values in -90 deg. to 90 deg., tightening the value on branch 1, conductor 1 from -180.0 to -60.0001403060998 deg.",
-            PowerModels.check_voltage_angle_differences(mp_data_2p))
+            Memento.Test.@test_warn(TESTLOG, "this code only supports angmin values in -90 deg. to 90 deg., tightening the value on branch 1, conductor 1 from -180.0 to -60.0001403060998 deg.",
+                PowerModels.check_voltage_angle_differences(mp_data_2p))
 
-        mp_data_2p["branch"]["1"]["angmin"] = [-pi, 0]
-        mp_data_2p["branch"]["1"]["angmax"] = [ pi, 0]
+            mp_data_2p["branch"]["1"]["angmin"] = [-pi, 0]
+            mp_data_2p["branch"]["1"]["angmax"] = [ pi, 0]
 
-        @test_warn(TESTLOG, "angmin and angmax values are 0, widening these values on branch 1, conductor 2 to +/- 60.0001403060998 deg.",
-            PowerModels.check_voltage_angle_differences(mp_data_2p))
+            Memento.Test.@test_warn(TESTLOG, "angmin and angmax values are 0, widening these values on branch 1, conductor 2 to +/- 60.0001403060998 deg.",
+                PowerModels.check_voltage_angle_differences(mp_data_2p))
 
-        mp_data_2p["branch"]["1"]["angmin"] = [-pi, 0]
-        mp_data_2p["branch"]["1"]["angmax"] = [ pi, 0]
+            mp_data_2p["branch"]["1"]["angmin"] = [-pi, 0]
+            mp_data_2p["branch"]["1"]["angmax"] = [ pi, 0]
 
-        @test_warn(TESTLOG, "this code only supports angmax values in -90 deg. to 90 deg., tightening the value on branch 1, conductor 1 from 180.0 to 60.0001403060998 deg.",
-            PowerModels.check_voltage_angle_differences(mp_data_2p))
+            Memento.Test.@test_warn(TESTLOG, "this code only supports angmax values in -90 deg. to 90 deg., tightening the value on branch 1, conductor 1 from 180.0 to 60.0001403060998 deg.",
+                PowerModels.check_voltage_angle_differences(mp_data_2p))
 
-        @test_warn(TESTLOG, "skipping network that is already multiconductor", PowerModels.make_multiconductor(mp_data_3p, 3))
+            Memento.Test.@test_warn(TESTLOG, "skipping network that is already multiconductor", PowerModels.make_multiconductor(mp_data_3p, 3))
 
-        mp_data_3p["load"]["1"]["pd"] = mp_data_3p["load"]["1"]["qd"] = [0, 0, 0]
-        mp_data_3p["shunt"]["1"] = Dict{String,Any}("gs"=>[0,0,0], "bs"=>[0,0,0], "status"=>1, "shunt_bus"=>1, "index"=>1)
+            mp_data_3p["load"]["1"]["pd"] = mp_data_3p["load"]["1"]["qd"] = [0, 0, 0]
+            mp_data_3p["shunt"]["1"] = Dict{String,Any}("gs"=>[0,0,0], "bs"=>[0,0,0], "status"=>1, "shunt_bus"=>1, "index"=>1)
 
-        Memento.Test.@test_log(TESTLOG, "info", "deactivating load 1 due to zero pd and qd", PowerModels.propagate_topology_status(mp_data_3p))
-        @test mp_data_3p["load"]["1"]["status"] == 0
-        @test mp_data_3p["shunt"]["1"]["status"] == 0
+            Memento.Test.@test_log(TESTLOG, "info", "deactivating load 1 due to zero pd and qd", PowerModels.propagate_topology_status(mp_data_3p))
+            @test mp_data_3p["load"]["1"]["status"] == 0
+            @test mp_data_3p["shunt"]["1"]["status"] == 0
 
-        mp_data_3p["dcline"]["1"]["loss0"][2] = -1.0
-        @test_warn(TESTLOG, "this code only supports positive loss0 values, changing the value on dcline 1, conductor 2 from -100.0 to 0.0", PowerModels.check_dcline_limits(mp_data_3p))
+            mp_data_3p["dcline"]["1"]["loss0"][2] = -1.0
+            Memento.Test.@test_warn(TESTLOG, "this code only supports positive loss0 values, changing the value on dcline 1, conductor 2 from -100.0 to 0.0", PowerModels.check_dcline_limits(mp_data_3p))
 
-        mp_data_3p["dcline"]["1"]["loss1"][2] = -1.0
-        @test_warn(TESTLOG, "this code only supports positive loss1 values, changing the value on dcline 1, conductor 2 from -1.0 to 0.0", PowerModels.check_dcline_limits(mp_data_3p))
+            mp_data_3p["dcline"]["1"]["loss1"][2] = -1.0
+            Memento.Test.@test_warn(TESTLOG, "this code only supports positive loss1 values, changing the value on dcline 1, conductor 2 from -1.0 to 0.0", PowerModels.check_dcline_limits(mp_data_3p))
 
-        @test mp_data_3p["dcline"]["1"]["loss0"][2] == 0.0
-        @test mp_data_3p["dcline"]["1"]["loss1"][2] == 0.0
+            @test mp_data_3p["dcline"]["1"]["loss0"][2] == 0.0
+            @test mp_data_3p["dcline"]["1"]["loss1"][2] == 0.0
 
-        mp_data_3p["dcline"]["1"]["loss1"][2] = 100.0
-        @test_warn(TESTLOG, "this code only supports loss1 values < 1, changing the value on dcline 1, conductor 2 from 100.0 to 0.0", PowerModels.check_dcline_limits(mp_data_3p))
+            mp_data_3p["dcline"]["1"]["loss1"][2] = 100.0
+            Memento.Test.@test_warn(TESTLOG, "this code only supports loss1 values < 1, changing the value on dcline 1, conductor 2 from 100.0 to 0.0", PowerModels.check_dcline_limits(mp_data_3p))
 
-        delete!(mp_data_3p["branch"]["1"], "tap")
-        @test_warn(TESTLOG, "branch found without tap value, setting a tap to 1.0", PowerModels.check_transformer_parameters(mp_data_3p))
+            delete!(mp_data_3p["branch"]["1"], "tap")
+            Memento.Test.@test_warn(TESTLOG, "branch found without tap value, setting a tap to 1.0", PowerModels.check_transformer_parameters(mp_data_3p))
 
-        delete!(mp_data_3p["branch"]["1"], "shift")
-        @test_warn(TESTLOG, "branch found without shift value, setting a shift to 0.0", PowerModels.check_transformer_parameters(mp_data_3p))
+            delete!(mp_data_3p["branch"]["1"], "shift")
+            Memento.Test.@test_warn(TESTLOG, "branch found without shift value, setting a shift to 0.0", PowerModels.check_transformer_parameters(mp_data_3p))
 
-        mp_data_3p["branch"]["1"]["tap"][2] = -1.0
-        @test_warn(TESTLOG, "branch found with non-positive tap value of -1.0, setting a tap to 1.0", PowerModels.check_transformer_parameters(mp_data_3p))
+            mp_data_3p["branch"]["1"]["tap"][2] = -1.0
+            Memento.Test.@test_warn(TESTLOG, "branch found with non-positive tap value of -1.0, setting a tap to 1.0", PowerModels.check_transformer_parameters(mp_data_3p))
 
-        mp_data_3p["branch"]["1"]["rate_a"][2] = -1.0
-        @test_warn(TESTLOG, "this code only supports positive rate_a values, changing the value on branch 1, conductor 2 to 100.47227335656346", PowerModels.check_thermal_limits(mp_data_3p))
-        @test isapprox(mp_data_3p["branch"]["1"]["rate_a"][2], 1.0047227335; atol=1e-6)
+            mp_data_3p["branch"]["1"]["rate_a"][2] = -1.0
+            Memento.Test.@test_warn(TESTLOG, "this code only supports positive rate_a values, changing the value on branch 1, conductor 2 to 100.47227335656346", PowerModels.check_thermal_limits(mp_data_3p))
+            Memento.Test.@test isapprox(mp_data_3p["branch"]["1"]["rate_a"][2], 1.0047227335; atol=1e-6)
 
-        mp_data_3p["branch"]["4"] = deepcopy(mp_data_3p["branch"]["1"])
-        mp_data_3p["branch"]["4"]["f_bus"] = mp_data_3p["branch"]["1"]["t_bus"]
-        mp_data_3p["branch"]["4"]["t_bus"] = mp_data_3p["branch"]["1"]["f_bus"]
-        @test_warn(TESTLOG, "reversing the orientation of branch 1 (1, 3) to be consistent with other parallel branches", PowerModels.check_branch_directions(mp_data_3p))
-        @test mp_data_3p["branch"]["4"]["f_bus"] == mp_data_3p["branch"]["1"]["f_bus"]
-        @test mp_data_3p["branch"]["4"]["t_bus"] == mp_data_3p["branch"]["1"]["t_bus"]
+            mp_data_3p["branch"]["4"] = deepcopy(mp_data_3p["branch"]["1"])
+            mp_data_3p["branch"]["4"]["f_bus"] = mp_data_3p["branch"]["1"]["t_bus"]
+            mp_data_3p["branch"]["4"]["t_bus"] = mp_data_3p["branch"]["1"]["f_bus"]
+            Memento.Test.@test_warn(TESTLOG, "reversing the orientation of branch 1 (1, 3) to be consistent with other parallel branches", PowerModels.check_branch_directions(mp_data_3p))
+            @test mp_data_3p["branch"]["4"]["f_bus"] == mp_data_3p["branch"]["1"]["f_bus"]
+            @test mp_data_3p["branch"]["4"]["t_bus"] == mp_data_3p["branch"]["1"]["t_bus"]
 
-        mp_data_3p["gen"]["1"]["vg"][2] = 2.0
-        @test_warn(TESTLOG, "the conductor 2 voltage setpoint on generator 1 does not match the value at bus 1", PowerModels.check_voltage_setpoints(mp_data_3p))
+            mp_data_3p["gen"]["1"]["vg"][2] = 2.0
+            Memento.Test.@test_warn(TESTLOG, "the conductor 2 voltage setpoint on generator 1 does not match the value at bus 1", PowerModels.check_voltage_setpoints(mp_data_3p))
 
-        mp_data_3p["dcline"]["1"]["vf"][2] = 2.0
-        @test_warn(TESTLOG, "the conductor 2 from bus voltage setpoint on dc line 1 does not match the value at bus 1", PowerModels.check_voltage_setpoints(mp_data_3p))
+            mp_data_3p["dcline"]["1"]["vf"][2] = 2.0
+            Memento.Test.@test_warn(TESTLOG, "the conductor 2 from bus voltage setpoint on dc line 1 does not match the value at bus 1", PowerModels.check_voltage_setpoints(mp_data_3p))
 
-        mp_data_3p["dcline"]["1"]["vt"][2] = 2.0
-        @test_warn(TESTLOG, "the conductor 2 to bus voltage setpoint on dc line 1 does not match the value at bus 2", PowerModels.check_voltage_setpoints(mp_data_3p))
+            mp_data_3p["dcline"]["1"]["vt"][2] = 2.0
+            Memento.Test.@test_warn(TESTLOG, "the conductor 2 to bus voltage setpoint on dc line 1 does not match the value at bus 2", PowerModels.check_voltage_setpoints(mp_data_3p))
 
+            setlevel!(TESTLOG, "error")
 
-        setlevel!(TESTLOG, "error")
+            Memento.Test.@test_throws(TESTLOG, ErrorException, PowerModels.run_ac_opf(mp_data_3p, ipopt_solver))
 
-        @test_throws(TESTLOG, ErrorException, PowerModels.run_ac_opf(mp_data_3p, ipopt_solver))
+            mp_data_3p["branch"]["1"]["f_bus"] = mp_data_3p["branch"]["1"]["t_bus"] = 1
+            Memento.Test.@test_throws(TESTLOG, ErrorException, PowerModels.check_branch_loops(mp_data_3p))
 
-        mp_data_3p["branch"]["1"]["f_bus"] = mp_data_3p["branch"]["1"]["t_bus"] = 1
-        @test_throws(TESTLOG, ErrorException, PowerModels.check_branch_loops(mp_data_3p))
+            mp_data_3p["conductors"] = 0
+            Memento.Test.@test_throws(TESTLOG, ErrorException, PowerModels.check_conductors(mp_data_3p))
+        else
+            @test_throws ErrorException PowerModels.update_data(mp_data_2p, mp_data_3p)
+            @test_throws ErrorException PowerModels.check_keys(mp_data_3p, ["load"])
 
-        mp_data_3p["conductors"] = 0
-        @test_throws(TESTLOG, ErrorException, PowerModels.check_conductors(mp_data_3p))
+            # check_cost_functions
+            mp_data_3p["gen"]["1"]["model"] = 1
+            mp_data_3p["gen"]["1"]["ncost"] = 1
+            mp_data_3p["gen"]["1"]["cost"] = [0.0, 1.0, 0.0]
+            @test_throws ErrorException PowerModels.check_cost_functions(mp_data_3p)
+
+            mp_data_3p["gen"]["1"]["cost"] = [0.0, 0.0]
+            @test_throws ErrorException PowerModels.check_cost_functions(mp_data_3p)
+
+            mp_data_3p["gen"]["1"]["ncost"] = 2
+            mp_data_3p["gen"]["1"]["cost"] = [0.0, 0.0, 0.0, 0.0]
+            @test_throws ErrorException PowerModels.check_cost_functions(mp_data_3p)
+
+            mp_data_3p["gen"]["1"]["model"] = 2
+            @test_throws ErrorException PowerModels.check_cost_functions(mp_data_3p)
+
+            Logging.disable_logging(Logging.Info)
+
+            mp_data_3p["gen"]["1"]["model"] = 3
+            @test_logs (:warn, "Skipping cost model of type 3 in per unit transformation") PowerModels.make_mixed_units(mp_data_3p)
+            @test_logs (:warn, "Skipping cost model of type 3 in per unit transformation") PowerModels.make_per_unit(mp_data_3p)
+            @test_logs (:warn, "Unknown cost model of type 3 on generator 1") PowerModels.check_cost_functions(mp_data_3p)
+
+            mp_data_3p["gen"]["1"]["model"] = 1
+            mp_data_3p["gen"]["1"]["cost"][3] = 3000
+            @test_logs (:warn, "pwl x value 3000.0 is outside the bounds 0.0-60.0 on generator 1") PowerModels.check_cost_functions(mp_data_3p)
+
+            @test_nowarn PowerModels.check_voltage_angle_differences(mp_data_3p)
+
+            mp_data_2p["branch"]["1"]["angmin"] = [-pi, 0]
+            mp_data_2p["branch"]["1"]["angmax"] = [ pi, 0]
+
+            @test_logs((:warn, "this code only supports angmin values in -90 deg. to 90 deg., tightening the value on branch 1, conductor 1 from -180.0 to -60.0001403060998 deg."),
+                            (:warn, "this code only supports angmax values in -90 deg. to 90 deg., tightening the value on branch 1, conductor 1 from 180.0 to 60.0001403060998 deg."),
+                            (:warn, "angmin and angmax values are 0, widening these values on branch 1, conductor 2 to +/- 60.0001403060998 deg."),
+                            PowerModels.check_voltage_angle_differences(mp_data_2p))
+
+            mp_data_2p["branch"]["1"]["angmin"] = [-pi, 0]
+            mp_data_2p["branch"]["1"]["angmax"] = [ pi, 0]
+
+            @test_logs((:warn, "this code only supports angmin values in -90 deg. to 90 deg., tightening the value on branch 1, conductor 1 from -180.0 to -60.0001403060998 deg."),
+                            (:warn, "this code only supports angmax values in -90 deg. to 90 deg., tightening the value on branch 1, conductor 1 from 180.0 to 60.0001403060998 deg."),
+                            (:warn, "angmin and angmax values are 0, widening these values on branch 1, conductor 2 to +/- 60.0001403060998 deg."),
+                            PowerModels.check_voltage_angle_differences(mp_data_2p))
+
+            mp_data_2p["branch"]["1"]["angmin"] = [-pi, 0]
+            mp_data_2p["branch"]["1"]["angmax"] = [ pi, 0]
+
+            @test_logs((:warn, "this code only supports angmin values in -90 deg. to 90 deg., tightening the value on branch 1, conductor 1 from -180.0 to -60.0001403060998 deg."),
+                            (:warn, "this code only supports angmax values in -90 deg. to 90 deg., tightening the value on branch 1, conductor 1 from 180.0 to 60.0001403060998 deg."),
+                            (:warn, "angmin and angmax values are 0, widening these values on branch 1, conductor 2 to +/- 60.0001403060998 deg."),
+                            PowerModels.check_voltage_angle_differences(mp_data_2p))
+
+            @test_logs (:warn, "skipping network that is already multiconductor") PowerModels.make_multiconductor(mp_data_3p, 3)
+
+            mp_data_3p["load"]["1"]["pd"] = mp_data_3p["load"]["1"]["qd"] = [0, 0, 0]
+            mp_data_3p["shunt"]["1"] = Dict{String,Any}("gs"=>[0,0,0], "bs"=>[0,0,0], "status"=>1, "shunt_bus"=>1, "index"=>1)
+
+            Logging.disable_logging(Logging.Debug)
+            @test_logs((:info, "deactivating load 1 due to zero pd and qd"),
+                            (:info, "deactivating shunt 1 due to zero gs and bs"),
+                            (:info, "topology status propagation fixpoint reached in 1 rounds"),
+                            (:warn, "no reference bus found in connected component Set([2, 3, 1])"),
+                            (:warn, "setting bus 1 as reference bus in connected component Set([2, 3, 1]), based on generator 1"),
+                            PowerModels.propagate_topology_status(mp_data_3p))
+            Logging.disable_logging(Logging.Info)
+
+            @test mp_data_3p["load"]["1"]["status"] == 0
+            @test mp_data_3p["shunt"]["1"]["status"] == 0
+
+            mp_data_3p["dcline"]["1"]["loss0"][2] = -1.0
+            @test_logs (:warn, "this code only supports positive loss0 values, changing the value on dcline 1, conductor 2 from -100.0 to 0.0") PowerModels.check_dcline_limits(mp_data_3p)
+
+            mp_data_3p["dcline"]["1"]["loss1"][2] = -1.0
+            @test_logs (:warn, "this code only supports positive loss1 values, changing the value on dcline 1, conductor 2 from -1.0 to 0.0") PowerModels.check_dcline_limits(mp_data_3p)
+
+            @test mp_data_3p["dcline"]["1"]["loss0"][2] == 0.0
+            @test mp_data_3p["dcline"]["1"]["loss1"][2] == 0.0
+
+            mp_data_3p["dcline"]["1"]["loss1"][2] = 100.0
+            @test_logs((:warn, "this code only supports loss0 values which are consistent with the line flow bounds, changing the value on dcline 1, conductor 2 from 0.0 to 0.0"),
+                            (:warn, "this code only supports loss1 values < 1, changing the value on dcline 1, conductor 2 from 100.0 to 0.0"),
+                            PowerModels.check_dcline_limits(mp_data_3p))
+
+            delete!(mp_data_3p["branch"]["1"], "tap")
+            @test_logs (:warn, "branch found without tap value, setting a tap to 1.0") PowerModels.check_transformer_parameters(mp_data_3p)
+
+            delete!(mp_data_3p["branch"]["1"], "shift")
+            @test_logs (:warn, "branch found without shift value, setting a shift to 0.0") PowerModels.check_transformer_parameters(mp_data_3p)
+
+            mp_data_3p["branch"]["1"]["tap"][2] = -1.0
+            @test_logs (:warn, "branch found with non-positive tap value of -1.0, setting a tap to 1.0 on conductor 2") PowerModels.check_transformer_parameters(mp_data_3p)
+
+            mp_data_3p["branch"]["1"]["rate_a"][2] = -1.0
+            @test_logs (:warn, "this code only supports positive rate_a values, changing the value on branch 1, conductor 2 to 100.47227335656346") PowerModels.check_thermal_limits(mp_data_3p)
+            @test isapprox(mp_data_3p["branch"]["1"]["rate_a"][2], 1.0047227335; atol=1e-6)
+
+            mp_data_3p["branch"]["4"] = deepcopy(mp_data_3p["branch"]["1"])
+            mp_data_3p["branch"]["4"]["f_bus"] = mp_data_3p["branch"]["1"]["t_bus"]
+            mp_data_3p["branch"]["4"]["t_bus"] = mp_data_3p["branch"]["1"]["f_bus"]
+            @test_logs (:warn, "reversing the orientation of branch 1 (1, 3) to be consistent with other parallel branches") PowerModels.check_branch_directions(mp_data_3p)
+            @test mp_data_3p["branch"]["4"]["f_bus"] == mp_data_3p["branch"]["1"]["f_bus"]
+            @test mp_data_3p["branch"]["4"]["t_bus"] == mp_data_3p["branch"]["1"]["t_bus"]
+
+            mp_data_3p["gen"]["1"]["vg"][2] = 2.0
+            @test_logs (:warn, "the conductor 2 voltage setpoint on generator 1 does not match the value at bus 1") PowerModels.check_voltage_setpoints(mp_data_3p)
+
+            mp_data_3p["dcline"]["1"]["vf"][2] = 2.0
+            @test_logs((:warn, "the conductor 2 voltage setpoint on generator 1 does not match the value at bus 1"),
+                            (:warn, "the conductor 2 from bus voltage setpoint on dc line 1 does not match the value at bus 1"),
+                            PowerModels.check_voltage_setpoints(mp_data_3p))
+
+            mp_data_3p["dcline"]["1"]["vt"][2] = 2.0
+            @test_logs((:warn, "the conductor 2 voltage setpoint on generator 1 does not match the value at bus 1"),
+                            (:warn, "the conductor 2 from bus voltage setpoint on dc line 1 does not match the value at bus 1"),
+                            (:warn, "the conductor 2 to bus voltage setpoint on dc line 1 does not match the value at bus 2"),
+                            PowerModels.check_voltage_setpoints(mp_data_3p))
+
+            Logging.disable_logging(Logging.Warn)
+
+            @test_throws ErrorException PowerModels.run_ac_opf(mp_data_3p, ipopt_solver)
+
+            mp_data_3p["branch"]["1"]["f_bus"] = mp_data_3p["branch"]["1"]["t_bus"] = 1
+            @test_throws ErrorException PowerModels.check_branch_loops(mp_data_3p)
+
+            mp_data_3p["conductors"] = 0
+            @test_throws ErrorException PowerModels.check_conductors(mp_data_3p)
+        end
     end
 
     @testset "multiconductor extensions" begin
@@ -460,13 +594,24 @@ end
         @test isa(rad2deg(a), PowerModels.MultiConductorMatrix)
         @test isa(deg2rad(a), PowerModels.MultiConductorMatrix)
 
-        setlevel!(TESTLOG, "warn")
-        @test_nowarn show(devnull, a)
+        if VERSION < v"0.7.0-"
+            setlevel!(TESTLOG, "warn")
+            @test_nowarn show(devnull, a)
 
-        @test_nowarn a[1, 1] = 9.0
-        @test a[1,1] == 9.0
+            @test_nowarn a[1, 1] = 9.0
+            @test a[1,1] == 9.0
 
-        @test_nowarn PowerModels.summary(devnull, mp_data)
-        setlevel!(TESTLOG, "error")
+            @test_nowarn PowerModels.summary(devnull, mp_data)
+            setlevel!(TESTLOG, "error")
+        else
+            Logging.disable_logging(Logging.Info)
+            @test_nowarn show(devnull, a)
+
+            @test_nowarn a[1, 1] = 9.0
+            @test a[1,1] == 9.0
+
+            @test_nowarn PowerModels.summary(devnull, mp_data)
+            Logging.disable_logging(Logging.Warn)
+        end
     end
 end

--- a/test/multinetwork.jl
+++ b/test/multinetwork.jl
@@ -1,6 +1,8 @@
 using JuMP
 PMs = PowerModels
-TESTLOG = getlogger(PowerModels)
+if VERSION < v"0.7.0-"
+    TESTLOG = Memento.getlogger(PowerModels)
+end
 
 @testset "test multinetwork" begin
 
@@ -326,25 +328,47 @@ TESTLOG = getlogger(PowerModels)
     @testset "test errors and warnings" begin
         mn_data = build_mn_data("../test/data/matpower/case5.m")
 
-        @test_throws(TESTLOG, ErrorException, PowerModels.check_voltage_angle_differences(mn_data))
-        @test_throws(TESTLOG, ErrorException, PowerModels.check_thermal_limits(mn_data))
-        @test_throws(TESTLOG, ErrorException, PowerModels.check_branch_directions(mn_data))
-        @test_throws(TESTLOG, ErrorException, PowerModels.check_branch_loops(mn_data))
-        @test_throws(TESTLOG, ErrorException, PowerModels.check_connectivity(mn_data))
-        @test_throws(TESTLOG, ErrorException, PowerModels.check_transformer_parameters(mn_data))
-        @test_throws(TESTLOG, ErrorException, PowerModels.check_bus_types(mn_data))
-        @test_throws(TESTLOG, ErrorException, PowerModels.check_dcline_limits(mn_data))
-        @test_throws(TESTLOG, ErrorException, PowerModels.check_voltage_setpoints(mn_data))
-        @test_throws(TESTLOG, ErrorException, PowerModels.check_cost_functions(mn_data))
-        @test_throws(TESTLOG, ErrorException, PowerModels.connected_components(mn_data))
+        if VERSION < v"0.7.0-"
+            Memento.Test.@test_throws(TESTLOG, ErrorException, PowerModels.check_voltage_angle_differences(mn_data))
+            Memento.Test.@test_throws(TESTLOG, ErrorException, PowerModels.check_thermal_limits(mn_data))
+            Memento.Test.@test_throws(TESTLOG, ErrorException, PowerModels.check_branch_directions(mn_data))
+            Memento.Test.@test_throws(TESTLOG, ErrorException, PowerModels.check_branch_loops(mn_data))
+            Memento.Test.@test_throws(TESTLOG, ErrorException, PowerModels.check_connectivity(mn_data))
+            Memento.Test.@test_throws(TESTLOG, ErrorException, PowerModels.check_transformer_parameters(mn_data))
+            Memento.Test.@test_throws(TESTLOG, ErrorException, PowerModels.check_bus_types(mn_data))
+            Memento.Test.@test_throws(TESTLOG, ErrorException, PowerModels.check_dcline_limits(mn_data))
+            Memento.Test.@test_throws(TESTLOG, ErrorException, PowerModels.check_voltage_setpoints(mn_data))
+            Memento.Test.@test_throws(TESTLOG, ErrorException, PowerModels.check_cost_functions(mn_data))
+            Memento.Test.@test_throws(TESTLOG, ErrorException, PowerModels.connected_components(mn_data))
 
-        setlevel!(TESTLOG, "warn")
-        @test_nowarn PowerModels.check_reference_buses(mn_data)
-        @test_nowarn PowerModels.make_multiconductor(mn_data, 3)
-        @test_nowarn PowerModels.check_conductors(mn_data)
-        setlevel!(TESTLOG, "error")
+            setlevel!(TESTLOG, "warn")
+            @test_nowarn PowerModels.check_reference_buses(mn_data)
+            @test_nowarn PowerModels.make_multiconductor(mn_data, 3)
+            @test_nowarn PowerModels.check_conductors(mn_data)
+            setlevel!(TESTLOG, "error")
 
-        @test_throws(TESTLOG, ErrorException, PowerModels.run_ac_opf(mn_data, ipopt_solver))
+            Memento.Test.@test_throws(TESTLOG, ErrorException, PowerModels.run_ac_opf(mn_data, ipopt_solver))
+        else
+            @test_throws ErrorException PowerModels.check_voltage_angle_differences(mn_data)
+            @test_throws ErrorException PowerModels.check_thermal_limits(mn_data)
+            @test_throws ErrorException PowerModels.check_branch_directions(mn_data)
+            @test_throws ErrorException PowerModels.check_branch_loops(mn_data)
+            @test_throws ErrorException PowerModels.check_connectivity(mn_data)
+            @test_throws ErrorException PowerModels.check_transformer_parameters(mn_data)
+            @test_throws ErrorException PowerModels.check_bus_types(mn_data)
+            @test_throws ErrorException PowerModels.check_dcline_limits(mn_data)
+            @test_throws ErrorException PowerModels.check_voltage_setpoints(mn_data)
+            @test_throws ErrorException PowerModels.check_cost_functions(mn_data)
+            @test_throws ErrorException PowerModels.connected_components(mn_data)
+
+            Logging.disable_logging(Logging.Info)
+            @test_nowarn PowerModels.check_reference_buses(mn_data)
+            @test_nowarn PowerModels.make_multiconductor(mn_data, 3)
+            @test_nowarn PowerModels.check_conductors(mn_data)
+            disable_logging(Logging.Warn)
+
+            @test_throws ErrorException PowerModels.run_ac_opf(mn_data, ipopt_solver)
+        end
     end
 
 end

--- a/test/pti.jl
+++ b/test/pti.jl
@@ -1,21 +1,32 @@
 # Test cases for PTI RAW file parser
 
-TESTLOG = getlogger(PowerModels)
+if VERSION < v"0.7.0-"
+    TESTLOG = getlogger(PowerModels)
+end
 
 @testset "test .raw file parser" begin
     @testset "Check PTI exception handling" begin
-        setlevel!(TESTLOG, "warn")
+        if VERSION < v"0.7.0-"
+            Memento.setlevel!(TESTLOG, "warn")
 
-        @test_nowarn PowerModels.parse_pti("../test/data/pti/parser_test_a.raw")
-        @test_throws(TESTLOG, ErrorException, PowerModels.parse_pti("../test/data/pti/parser_test_b.raw"))
-        @test_warn(TESTLOG, "Version 32 of PTI format is unsupported, parser may not function correctly.",
-                   PowerModels.parse_pti("../test/data/pti/parser_test_c.raw"))
-        @test_throws(TESTLOG, ErrorException, PowerModels.parse_pti("../test/data/pti/parser_test_d.raw"))
-        @test_warn(TESTLOG, "GNE DEVICE parsing is not supported.", PowerModels.parse_pti("../test/data/pti/parser_test_h.raw"))
-        #Test not replicable in Julia7
-        #@test_throws(TESTLOG, ErrorException, PowerModels.parse_file("../test/data/pti/parser_test_j.raw"))
+            @test_nowarn PowerModels.parse_pti("../test/data/pti/parser_test_a.raw")
+            Memento.Test.@test_throws(TESTLOG, ErrorException, PowerModels.parse_pti("../test/data/pti/parser_test_b.raw"))
+            Memento.Test.@test_warn(TESTLOG, "Version 32 of PTI format is unsupported, parser may not function correctly.",
+                       PowerModels.parse_pti("../test/data/pti/parser_test_c.raw"))
+            Memento.Test.@test_throws(TESTLOG, ErrorException, PowerModels.parse_pti("../test/data/pti/parser_test_d.raw"))
+            Memento.Test.@test_warn(TESTLOG, "GNE DEVICE parsing is not supported.", PowerModels.parse_pti("../test/data/pti/parser_test_h.raw"))
 
-        setlevel!(TESTLOG, "error")
+            Memento.setlevel!(TESTLOG, "error")
+        else
+            @test_throws ErrorException PowerModels.parse_pti("../test/data/pti/parser_test_d.raw")
+            @test_throws ErrorException PowerModels.parse_pti("../test/data/pti/parser_test_b.raw")
+
+            Logging.disable_logging(Logging.Info)
+            @test_nowarn PowerModels.parse_pti("../test/data/pti/parser_test_a.raw")
+            @test_logs (:warn, "Version 32 of PTI format is unsupported, parser may not function correctly.") PowerModels.parse_pti("../test/data/pti/parser_test_c.raw")
+            @test_logs (:warn, "GNE DEVICE parsing is not supported.") PowerModels.parse_pti("../test/data/pti/parser_test_h.raw")
+            Logging.disable_logging(Logging.Warn)
+        end
     end
 
     @testset "4-bus frankenstein file" begin
@@ -159,7 +170,11 @@ TESTLOG = getlogger(PowerModels)
     end
 
     @testset "0-bus case file" begin
-        @test_throws(TESTLOG, ArgumentError, PowerModels.parse_pti("../test/data/pti/case0.raw"))
+        if VERSION < v"0.7.0-"
+            Memento.Test.@test_throws(TESTLOG, ErrorException, PowerModels.parse_pti("../test/data/pti/case0.raw"))
+        else
+            @test_throws ErrorException PowerModels.parse_pti("../test/data/pti/case0.raw")
+        end
     end
 
     @testset "73-bus case file" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,8 +5,6 @@ using Memento
 using MathProgBase
 
 # Suppress warnings during testing.
-setlevel!(getlogger(InfrastructureModels), "error")
-setlevel!(getlogger(PowerModels), "error")
 
 using Cbc
 using Ipopt
@@ -24,6 +22,17 @@ import Compat: pairs
 
 if VERSION < v"0.7.0-"
     LinearAlgebra = Compat.LinearAlgebra
+    Memento.setlevel!(getlogger(InfrastructureModels), "error")
+    Memento.setlevel!(getlogger(PowerModels), "error")
+
+    TESTLOG = Memento.getlogger(PowerModels)
+
+    macro test_logs(exs...)
+    end
+else
+    using Test
+    using Logging
+    Logging.disable_logging(Logging.Warn)
 end
 
 


### PR DESCRIPTION
Adds support for the Logging library within Julia v0.7/v1.0's standard
library. Support for Memento will be maintained until Julia v0.6 support
is dropped, due to no logging available in the Base before Julia v0.7.
Removal of Memento has been made easier by separating Memento-
based tests into their own blocks, and by creating temporary macros
upon load of PowerModels in VERSION < v"0.7.0-".

All unit tests were converted, no unit tests were dropped in this
addition.

TODO:

- [ ] Package-level logging (separate logger for package)