### PR TITLE
FIX: Simplify Generator Data from PSS(R)E PTI parse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ PowerModels.jl Change Log
 
 ### Staged
 - Cleaned up generator data in Matpower files
+- Cleaned up generator data in PSS(R)E PTI file parse
 
 ### v0.9.2
 - Added tracking of modifications in check_network_data

--- a/src/io/psse.jl
+++ b/src/io/psse.jl
@@ -191,21 +191,10 @@ function psse2pm_generator!(pm_data::Dict, pti_data::Dict, import_all::Bool)
             sub_data["qg"] = pop!(gen, "QG")
             sub_data["vg"] = pop!(gen, "VS")
             sub_data["mbase"] = pop!(gen, "MBASE")
-            sub_data["ramp_agc"] = 0.0
-            sub_data["ramp_q"] = 0.0
-            sub_data["ramp_10"] = 0.0
-            sub_data["ramp_30"] = 0.0
             sub_data["pmin"] = pop!(gen, "PB")
             sub_data["pmax"] = pop!(gen, "PT")
-            sub_data["apf"] = 0.0
             sub_data["qmin"] = pop!(gen, "QB")
             sub_data["qmax"] = pop!(gen, "QT")
-            sub_data["pc1"] = 0.0
-            sub_data["pc2"] = 0.0
-            sub_data["qc1min"] = 0.0
-            sub_data["qc1max"] = 0.0
-            sub_data["qc2min"] = 0.0
-            sub_data["qc2max"] = 0.0
 
             # Default Cost functions
             sub_data["model"] = 2

--- a/test/psse.jl
+++ b/test/psse.jl
@@ -350,7 +350,7 @@ end
         @testset "30-bus case" begin
             data = PowerModels.parse_file("../test/data/pti/case30.raw"; import_all=true)
 
-            for (key, n) in zip(["bus", "load", "shunt", "gen", "branch"], [15, 14, 14, 45, 29])
+            for (key, n) in zip(["bus", "load", "shunt", "gen", "branch"], [15, 14, 14, 34, 29])
                 for item in values(data[key])
                     if key == "branch" && item["transformer"]
                         @test length(item) == 42


### PR DESCRIPTION
Simplifies generator data created by PSS(R)E PTI parse by removing the
following data fields:

* pc1
* pc2
* qc1min
* qc1max
* qc2min
* qc2max
* ramp_agc
* ramp_10
* ramp_30
* ramp_q
* apf

PSS(R)E PTI format does not contain information that correspond to
these values.

Closes #446