### PR TITLE
Fix/psse bus sourceid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ PowerModels.jl Change Log
 
 ### Staged
 - Cleaned up generator data in Matpower files
+- Fix source_id in PSS(R)E PTI parse of buses to be only bus id
 
 ### v0.9.2
 - Added tracking of modifications in check_network_data

--- a/src/io/psse.jl
+++ b/src/io/psse.jl
@@ -255,7 +255,7 @@ function psse2pm_bus!(pm_data::Dict, pti_data::Dict, import_all::Bool)
                 sub_data["vmin"] = 0.9
             end
 
-            sub_data["source_id"] = [sub_data["bus_i"], sub_data["name"]]
+            sub_data["source_id"] = ["$(bus["I"])"]
             sub_data["index"] = pop!(bus, "I")
 
             import_remaining!(sub_data, bus, import_all)


### PR DESCRIPTION
Corrects source_id for PSS(R)E PTI parsed buses to be a string of the
bus id.

Closes #447
