### PR TITLE
multiconductor support for acr solution_builder

### DIFF
--- a/src/form/acr.jl
+++ b/src/form/acr.jl
@@ -42,6 +42,7 @@ end
 "reference bus angle constraint"
 function constraint_theta_ref(pm::GenericPowerModel{T}, n::Int, c::Int, i::Int) where T <: AbstractACRForm
     @constraint(pm.model, var(pm, n, c, :vi)[i] == 0)
+    @constraint(pm.model, var(pm, n, c, :vr)[i] >= 0)
 end
 
 

--- a/src/form/acr.jl
+++ b/src/form/acr.jl
@@ -152,7 +152,7 @@ function add_bus_voltage_setpoint(sol, pm::GenericPowerModel{T}) where T <: Abst
             try
                 vr = getvalue(var(pm, :vr, cnd=c)[idx])
                 vi = getvalue(var(pm, :vi, cnd=c)[idx])
-                
+
                 vm = sqrt(vr^2 + vi^2)
 
                 sol_item["vm"][c] = vm
@@ -166,20 +166,5 @@ function add_bus_voltage_setpoint(sol, pm::GenericPowerModel{T}) where T <: Abst
             sol_item["vm"] = sol_item["vm"][1]
             sol_item["va"] = sol_item["va"][1]
         end
-    end
-end
-
-"Calculates the angle in the range ]-π, π]. Returns NaN for (0, 0)"
-function atan2(xi, xr)
-    if xr==0
-        if xi > 0
-            return pi/2
-        elseif xi < 0
-            return -pi/2
-        else
-            return NaN
-        end
-    else
-        return atan(xi/xr) + Int(xr<=0)*(Int(xi>=0) - Int(xi<0))*pi
     end
 end

--- a/src/form/acr.jl
+++ b/src/form/acr.jl
@@ -13,8 +13,8 @@ function constraint_voltage(pm::GenericPowerModel{T}, n::Int, c::Int) where T <:
     vi = var(pm, n, c, :vi)
 
     for (i,bus) in ref(pm, n, :bus)
-        @constraint(pm.model, bus["vmin"]^2 <= (vr[i]^2 + vi[i]^2))
-        @constraint(pm.model, bus["vmax"]^2 >= (vr[i]^2 + vi[i]^2))
+        @constraint(pm.model, bus["vmin"][c]^2 <= (vr[i]^2 + vi[i]^2))
+        @constraint(pm.model, bus["vmax"][c]^2 >= (vr[i]^2 + vi[i]^2))
     end
 
     # does not seem to improve convergence

--- a/src/form/acr.jl
+++ b/src/form/acr.jl
@@ -156,7 +156,7 @@ function add_bus_voltage_setpoint(sol, pm::GenericPowerModel{T}) where T <: Abst
                 vm = sqrt(vr^2 + vi^2)
 
                 sol_item["vm"][c] = vm
-                sol_item["va"][c] = atan2(vi, vr)
+                sol_item["va"][c] = atan(vi, vr)
             catch
             end
         end

--- a/src/form/acr.jl
+++ b/src/form/acr.jl
@@ -152,7 +152,7 @@ function add_bus_voltage_setpoint(sol, pm::GenericPowerModel{T}) where T <: Abst
             try
                 vr = getvalue(var(pm, :vr, cnd=c)[idx])
                 vi = getvalue(var(pm, :vi, cnd=c)[idx])
-                println(vr)
+                
                 vm = sqrt(vr^2 + vi^2)
 
                 sol_item["vm"][c] = vm
@@ -160,12 +160,12 @@ function add_bus_voltage_setpoint(sol, pm::GenericPowerModel{T}) where T <: Abst
             catch
             end
         end
-    end
 
-    # remove MultiConductorValue, if it was not a ismulticonductor network
-    if !ismulticonductor(pm)
-        sol_item["vm"] = sol_item["vm"][1]
-        sol_item["va"] = sol_item["va"][1]
+        # remove MultiConductorValue, if it was not a ismulticonductor network
+        if !ismulticonductor(pm)
+            sol_item["vm"] = sol_item["vm"][1]
+            sol_item["va"] = sol_item["va"][1]
+        end
     end
 end
 

--- a/test/multiconductor.jl
+++ b/test/multiconductor.jl
@@ -113,6 +113,20 @@ end
             end
         end
 
+        @testset "3-bus 3-conductor case with theta_ref=pi" begin
+            mp_data = build_mc_data("../test/data/matpower/case3.m", conductors=3)
+            pm = PowerModels.build_generic_model(mp_data, ACRPowerModel, PowerModels.post_mc_opf, multiconductor=true)
+            result = PowerModels.solve_generic_model(pm, ipopt_solver)
+
+            @test result["status"] == :LocalOptimal
+            @test isapprox(result["objective"], 47267.9; atol = 1e-1)
+
+            for c in 1:mp_data["conductors"]
+                @test isapprox(result["solution"]["gen"]["1"]["pg"][c], 1.58067; atol = 1e-3)
+                @test isapprox(result["solution"]["bus"]["2"]["va"][c], 0.12669; atol = 1e-3)
+            end
+        end
+
         @testset "5-bus 5-conductor case" begin
             mp_data = build_mc_data("../test/data/matpower/case5.m", conductors=5)
 

--- a/test/multiconductor.jl
+++ b/test/multiconductor.jl
@@ -113,39 +113,6 @@ end
             end
         end
 
-        @testset "3-bus 3-conductor case with theta_ref=pi" begin
-            mp_data = build_mc_data("../test/data/matpower/case3.m", conductors=3)
-            pm = PowerModels.build_generic_model(mp_data, ACRPowerModel, PowerModels.post_mc_opf, multiconductor=true)
-            # the current implementation does not allow for setting theta to any value but zero
-            # we need theta ∈ (π/2, 3*π/2) to test atan2 however
-            # however, we can set theta=pi because constraint_theta_ref does not constrain vr>=0
-            # this allows us to test for theta=pi by adding the constraint
-            # vr<=0 at the reference bus
-            # because of convergence issues, we need to give a better starting point
-            # the default is (vr=1, vi=0),
-            # whilst the solution will now be close to (vr=-1, vi=0)
-            for i in ids(pm, :bus)
-                # update starting point from (vr=1, vi=0) to (vr=-1, vi=0)
-                setvalue(var(pm, :vr, i, cnd=1), -1)
-                if i in ids(pm, :ref_buses)
-                    # set theta of conductor 1 at reference bus to pi
-                    @constraint(pm.model, var(pm, :vr, i, cnd=1)<=0)
-                end
-            end
-            result = PowerModels.solve_generic_model(pm, ipopt_solver)
-
-            @test result["status"] == :LocalOptimal
-            @test isapprox(result["objective"], 47267.9; atol = 1e-1)
-            @test isapprox(result["solution"]["gen"]["1"]["pg"][1], 1.58067; atol = 1e-3)
-            # the first conductor should now have a va in the third kwadrant,
-            # not the first, if atan(y,x) works correctly
-            @test isapprox(result["solution"]["bus"]["2"]["va"][1], -3.0149; atol = 1e-3)
-            for c in 2:mp_data["conductors"]
-                @test isapprox(result["solution"]["gen"]["1"]["pg"][c], 1.58067; atol = 1e-3)
-                @test isapprox(result["solution"]["bus"]["2"]["va"][c], 0.12669; atol = 1e-3)
-            end
-        end
-
         @testset "5-bus 5-conductor case" begin
             mp_data = build_mc_data("../test/data/matpower/case5.m", conductors=5)
 

--- a/test/util.jl
+++ b/test/util.jl
@@ -9,10 +9,10 @@
         @test isnan(stats["final_rel_gap_from_ub"])
         @test stats["iteration_count"] == 5
 
-        data, stats = run_obbt_opf("../test/data/matpower/case3.m", ipopt_solver,
+        data, stats = run_obbt_opf("../test/data/matpower/case3.m", ipopt_solver, 
             model_constructor = QCWRTriPowerModel,
-            upper_bound = upper_bound,
-            upper_bound_constraint = true,
+            upper_bound = upper_bound, 
+            upper_bound_constraint = true, 
             rel_gap_tol = 1e-3);
         @test isapprox(stats["final_rel_gap_from_ub"], 0; atol=1e0)
         @test stats["iteration_count"] == 2
@@ -31,10 +31,10 @@ end
         @test isnan(stats["final_rel_gap_from_ub"])
         @test stats["iteration_count"] == 5
 
-        data, stats = run_obbt_opf("../test/data/matpower/case3.m", ipopt_solver,
+        data, stats = run_obbt_opf("../test/data/matpower/case3.m", ipopt_solver, 
             model_constructor = QCWRPowerModel,
-            upper_bound = upper_bound,
-            upper_bound_constraint = true,
+            upper_bound = upper_bound, 
+            upper_bound_constraint = true, 
             rel_gap_tol = 1e-3);
         @test isapprox(stats["final_rel_gap_from_ub"], 0; atol=1e0)
         @test stats["iteration_count"] == 2
@@ -58,16 +58,4 @@ end
         @test isapprox(stats["final_rel_gap_from_ub"], 0.0; atol=1e-2)
         @test stats["iteration_count"] == 4
     end
-end
-
-@testset "atan2" begin
-    # check all kwadrants and all boundaries
-    @test PowerModels.atan2(0,1)==0
-    @test PowerModels.atan2(1,1)==45/180*pi
-    @test PowerModels.atan2(1,0)==pi/2
-    @test PowerModels.atan2(1,-1)==(45+90)/180*pi
-    @test PowerModels.atan2(0,-1)≈pi
-    @test PowerModels.atan2(-1,-1)==-(45+90)/180*pi
-    @test PowerModels.atan2(-1,0)==-pi/2
-    @test PowerModels.atan2(-1,1)==-45/180*pi
 end

--- a/test/util.jl
+++ b/test/util.jl
@@ -9,10 +9,10 @@
         @test isnan(stats["final_rel_gap_from_ub"])
         @test stats["iteration_count"] == 5
 
-        data, stats = run_obbt_opf("../test/data/matpower/case3.m", ipopt_solver, 
+        data, stats = run_obbt_opf("../test/data/matpower/case3.m", ipopt_solver,
             model_constructor = QCWRTriPowerModel,
-            upper_bound = upper_bound, 
-            upper_bound_constraint = true, 
+            upper_bound = upper_bound,
+            upper_bound_constraint = true,
             rel_gap_tol = 1e-3);
         @test isapprox(stats["final_rel_gap_from_ub"], 0; atol=1e0)
         @test stats["iteration_count"] == 2
@@ -31,10 +31,10 @@ end
         @test isnan(stats["final_rel_gap_from_ub"])
         @test stats["iteration_count"] == 5
 
-        data, stats = run_obbt_opf("../test/data/matpower/case3.m", ipopt_solver, 
+        data, stats = run_obbt_opf("../test/data/matpower/case3.m", ipopt_solver,
             model_constructor = QCWRPowerModel,
-            upper_bound = upper_bound, 
-            upper_bound_constraint = true, 
+            upper_bound = upper_bound,
+            upper_bound_constraint = true,
             rel_gap_tol = 1e-3);
         @test isapprox(stats["final_rel_gap_from_ub"], 0; atol=1e0)
         @test stats["iteration_count"] == 2
@@ -58,4 +58,16 @@ end
         @test isapprox(stats["final_rel_gap_from_ub"], 0.0; atol=1e-2)
         @test stats["iteration_count"] == 4
     end
+end
+
+@testset "atan2" begin
+    # check all kwadrants and all boundaries
+    @test PowerModels.atan2(0,1)==0
+    @test PowerModels.atan2(1,1)==45/180*pi
+    @test PowerModels.atan2(1,0)==pi/2
+    @test PowerModels.atan2(1,-1)==(45+90)/180*pi
+    @test PowerModels.atan2(0,-1)≈pi
+    @test PowerModels.atan2(-1,-1)==-(45+90)/180*pi
+    @test PowerModels.atan2(-1,0)==-pi/2
+    @test PowerModels.atan2(-1,1)==-45/180*pi
 end


### PR DESCRIPTION
acr.jl overloads add_bus_voltage_setpoint, but only implements single conductor support. This leads to unexpected behaviour in TPPM when implementing an ACR formulation.

This PR extends add_bus_voltage_setpoint to support multiconductor networks, analogous to the add_setpoint method in solution.jl.

**A small additional fix**
The current implementation relies on atan to recover the angle:
va = atan(vi/vr)
This returns an incorrect angle when the phasor is in the second or third kwadrant (shifted by 180 degrees). '[atan2](https://en.wikipedia.org/wiki/Atan2)' would give the correct angle.