### PR TITLE
FIX: MultiConductorValue Broadcasting in Julia > v0.7.0-

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,8 @@ PowerModels.jl Change Log
 =========================
 
 ### Staged
-- Fixed multiconductor broadcasting in Julia > v0.7.0-
-- Added Base.norm for multiconductorvectors for Julia < v0.7.0-
+- Added Base.norm for multiconductorvectors
+- Minor fix to multiconductor broadcasting
 
 ### v0.9.5
 - Added generator on/off constraints

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@ PowerModels.jl Change Log
 =========================
 
 ### Staged
-- nothing
+- Fixed multiconductor broadcasting in Julia > v0.7.0-
+- Added Base.norm for multiconductorvectors for Julia < v0.7.0-
 
 ### v0.9.5
 - Added generator on/off constraints

--- a/src/core/multiconductor.jl
+++ b/src/core/multiconductor.jl
@@ -77,6 +77,7 @@ if VERSION > v"0.7.0-"
 
     "`A = find_mcv(As)` returns the first MultiConductorVector among the arguments."
     find_mcv(bc::Base.Broadcast.Broadcasted) = find_mcv(bc.args)
+    find_mcv(args::Base.Broadcast.Extruded) = find_mcv(args.x)
     find_mcv(args::Tuple) = find_mcv(find_mcv(args[1]), Base.tail(args))
     find_mcv(x) = x
     find_mcv(a::MultiConductorVector, rest) = a
@@ -90,6 +91,7 @@ if VERSION > v"0.7.0-"
 
     "`A = find_mcm(As)` returns the first MultiConductorMatrix among the arguments."
     find_mcm(bc::Base.Broadcast.Broadcasted) = find_mcm(bc.args)
+    find_mcm(args::Base.Broadcast.Extruded) = find_mcm(args.x)
     find_mcm(args::Tuple) = find_mcm(find_mcm(args[1]), Base.tail(args))
     find_mcm(x) = x
     find_mcm(a::MultiConductorMatrix, rest) = a
@@ -121,6 +123,7 @@ Base.:/(a::MultiConductorVector, b::MultiConductorVector) = MultiConductorVector
 if VERSION < v"0.7.0-"
     Base.:*(a::MultiConductorVector, b::RowVector) = MultiConductorMatrix(Base.broadcast(*, a.values, b))
     Base.:*(a::RowVector, b::MultiConductorVector) = MultiConductorMatrix(Base.broadcast(*, a, b.values))
+    Base.norm(a::MultiConductorVector, p::Real=2) = Base.norm(a.values, p)
 else
     Base.:*(a::MultiConductorVector, b::LinearAlgebra.Adjoint) = MultiConductorMatrix(Base.broadcast(*, a.values, b))
     Base.:*(a::LinearAlgebra.Adjoint, b::MultiConductorVector) = MultiConductorMatrix(Base.broadcast(*, a, b.values))

--- a/test/multiconductor.jl
+++ b/test/multiconductor.jl
@@ -504,5 +504,21 @@ end
 
         @test_nowarn PowerModels.summary(devnull, mp_data)
         setlevel!(TESTLOG, "error")
+
+        # Test Julia v0.7+ broadcasting edge-case
+        if VERSION > v"0.7.0-"
+            v = ones(Real, 3)
+            mcv = PowerModels.MultiConductorVector(v)
+            @test all(floor.(mcv) .+ mcv .== PowerModels.MultiConductorVector(floor.(v) .+ v))
+
+            m = LinearAlgebra.diagm(0 => v)
+            mcm = PowerModels.MultiConductorMatrix(m)
+            @test all(floor.(mcm) .+ mcm .== PowerModels.MultiConductorMatrix(floor.(m) .+ m))
+        end
+
+        # Test norm for Julia v0.6 backwards compatibility
+        if VERSION <= v"0.7.0-"
+            @test norm(e, Inf) == norm(e.values, Inf)
+        end
     end
 end


### PR DESCRIPTION
In some cases broadcasting will result in a scenario where the Broadcasted struct field args is of type Extruded, which causes the find_mcv/find_mcm functions to fail. This Extruded structure contains the necessary information in the field x, instead of being in the structure of a tuple. This PR adds new functions to handle cases where the Extruded struct is utilized, e.g. when the element type is Real.

Also added is `norm()` for MultiConductorVectors, only for Julia 0.6, to be removed after Julia < v1.0 support is dropped. This is for a use case in ThreePhasePowerModels (transformers PR)

Unit tests added.