### PR TITLE
Add dangling bus test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ PowerModels.jl Change Log
 =========================
 
 ### Staged
+- Added a test network with dangling buses, case5_db.m
 - Fixed voltage bound persistence bug in acr formulation (#497)
 
 ### v0.9.7

--- a/test/data/matpower/case5_db.m
+++ b/test/data/matpower/case5_db.m
@@ -1,0 +1,49 @@
+% tests network with dangeling buses, a feature that occurs in many large datasets
+
+function mpc = case5_dc
+mpc.version = '2';
+mpc.baseMVA = 100.0;
+
+%% bus data
+%	bus_i	type	Pd	Qd	Gs	Bs	area	Vm	Va	baseKV	zone	Vmax	Vmin
+mpc.bus = [
+	1	 1	 300.0	  98.61	 0.0	 0.0	 1	    1.06355	    2.87619	 230.0	 1	    1.10000	    0.90000;
+	2	 1	   0.0	   0.00	 0.0	 0.0	 1	    1.08009	   -0.79708	 230.0	 1	    1.10000	    0.90000;
+	3	 1	   0.0	   0.00	 0.0	 0.0	 1	    1.10000	   -0.64925	 230.0	 1	    1.10000	    0.90000;
+	4	 3	 400.0	 131.47	 0.0	 0.0	 1	    1.06414	    0.00000	 230.0	 1	    1.10000	    0.90000;
+	5	 1	 300.0	  98.61	 0.0	 0.0	 1	    1.05304	    3.70099	 230.0	 1	    1.10000	    0.90000;
+];
+
+%% generator data
+%	bus	Pg	Qg	Qmax	Qmin	Vg	mBase	status	Pmax	Pmin
+mpc.gen = [
+	1	 40.0	 30.0	 30.0	 -30.0	 1.06355	 100.0	 1	 40.0	 0.0;
+	1	 170.0	 127.5	 127.5	 -127.5	 1.07762	 100.0	 1	 170.0	 0.0;
+	4	 0.0	 -70.8186	 150.0	 -150.0	 1.06414	 100.0	 1	 200.0	 0.0;
+	5	 463.5555	 -184.9224	 450.0	 -450.0	 1.06907	 100.0	 1	 600.0	 0.0;
+];
+
+%% generator cost data
+%	2	startup	shutdown	n	c(n-1)	...	c0
+mpc.gencost = [
+	2	 0.0	 0.0	 2	  14.000000	   0.000000;
+	2	 0.0	 0.0	 2	  15.000000	   0.000000;
+	2	 0.0	 0.0	 2	  40.000000	   0.000000;
+	2	 0.0	 0.0	 2	  10.000000	   0.000000;
+];
+
+%% branch data
+%	fbus	tbus	r	x	b	rateA	rateB	rateC	ratio	angle	status	angmin	angmax
+mpc.branch = [
+	1	 2	 0.00281	 0.0281	 0.00712	 400.0	 400.0	 400.0	 0.0	 0.0	 1	 -30.0	 30.0;
+	1	 4	 0.00304	 0.0304	 0.00658	 426	 426	 426	 0.0	 0.0	 1	 -30.0	 30.0;
+	1	 5	 0.00064	 0.0064	 0.03126	 426	 426	 426	 0.0	 0.0	 1	 -30.0	 30.0;
+	4	 5	 0.00297	 0.0297	 0.00674	 240.0	 240.0	 240.0	 0.0	 0.0	 1	 -30.0	 30.0;
+];
+
+%% dcline data
+%	fbus	tbus	status	Pf	Pt	Qf	Qt	Vf	Vt	Pmin	Pmax	QminF	QmaxF	QminT	QmaxT	loss0	loss1
+mpc.dcline = [
+	3	5	1	10	8.9	99.9934	-10.4049	1.1	1.05555	0	100 	-100	100	-100 100	0	0;
+];
+

--- a/test/opf.jl
+++ b/test/opf.jl
@@ -61,6 +61,12 @@
         @test result["status"] == :LocalOptimal
         @test isapprox(result["objective"], 18742.2; atol = 1e0)
     end
+    @testset "5-bus with dangling bus" begin
+        result = run_ac_opf("../test/data/matpower/case5_db.m", ipopt_solver)
+
+        @test result["status"] == :LocalOptimal
+        @test isapprox(result["objective"], 16739.1; atol = 1e0)
+    end
     @testset "6-bus case" begin
         result = run_ac_opf("../test/data/matpower/case6.m", ipopt_solver)
 
@@ -220,6 +226,12 @@ end
 
         @test result["status"] == :LocalOptimal
         @test isapprox(result["objective"], 18064.5; atol = 1e0)
+    end
+    @testset "5-bus with dangling bus" begin
+        result = run_dc_opf("../test/data/matpower/case5_db.m", ipopt_solver)
+
+        @test result["status"] == :LocalOptimal
+        @test isapprox(result["objective"], 16710.0; atol = 1e0)
     end
     @testset "6-bus case" begin
         result = run_dc_opf("../test/data/matpower/case6.m", ipopt_solver)
@@ -446,6 +458,12 @@ end
 
         @test result["status"] == :LocalOptimal
         @test isapprox(result["objective"], 42895; atol = 1e0)
+    end
+    @testset "5-bus with dangling bus" begin
+        result = run_opf("../test/data/matpower/case5_db.m", SOCWRPowerModel, ipopt_solver)
+
+        @test result["status"] == :LocalOptimal
+        @test isapprox(result["objective"], 16739.1; atol = 1e0)
     end
     @testset "6-bus case" begin
         result = run_opf("../test/data/matpower/case6.m", SOCWRPowerModel, ipopt_solver)


### PR DESCRIPTION
This test covers a feature that is fairly common in real datasets but was not covered by current tests.

The test limitation was highlighted when this issue was found in JuMP v0.19, https://github.com/JuliaOpt/JuMP.jl/issues/1954