### PR TITLE
Improvements to Ref

### DIFF
--- a/src/core/base.jl
+++ b/src/core/base.jl
@@ -205,7 +205,7 @@ function build_generic_model(file::String,  model_constructor, post_method; kwar
 end
 
 ""
-function build_generic_model(data::Dict{String,<:Any}, model_constructor, post_method; ref_extensions=[core_ref!], multinetwork=false, multiconductor=false, kwargs...)
+function build_generic_model(data::Dict{String,<:Any}, model_constructor, post_method; ref_extensions=[], multinetwork=false, multiconductor=false, kwargs...)
     # NOTE, this model constructor will build the ref dict using the latest info from the data
     #start = time()
     pm = model_constructor(data; kwargs...)
@@ -220,6 +220,7 @@ function build_generic_model(data::Dict{String,<:Any}, model_constructor, post_m
 
     #start = time()
     #println(ref_extensions)
+    core_ref!(pm)
     for ref_ext in ref_extensions
         ref_ext(pm)
     end

--- a/src/core/data.jl
+++ b/src/core/data.jl
@@ -1107,6 +1107,51 @@ function check_connectivity(data::Dict{String,<:Any})
 end
 
 
+"checks that contains at least one refrence bus"
+function check_reference_bus(data::Dict{String,<:Any})
+    if InfrastructureModels.ismultinetwork(data)
+        Memento.error(LOGGER, "check_reference_bus does not yet support multinetwork data")
+    end
+
+    ref_buses = Dict{String,Any}()
+    for (k,v) in data["bus"]
+        if v["bus_type"] == 3
+            ref_buses[k] = v
+        end
+    end
+
+    if length(ref_buses) == 0
+            if length(data["gen"]) > 0
+            big_gen = _biggest_generator(data["gen"])
+            gen_bus = big_gen["gen_bus"]
+            ref_bus = data["bus"]["$(gen_bus)"]
+            ref_bus["bus_type"] = 3
+            Memento.warn(LOGGER, "no reference bus found, setting bus $(gen_bus) as reference based on generator $(big_gen["index"])")
+        else
+            (bus_item, state) = Base.iterate(data["bus"])
+            bus_item.second["bus_type"] = 3
+            Memento.warn(LOGGER, "no reference bus found, setting bus $(bus_item.second["index"]) as reference")
+        end
+    end
+end
+
+
+"find the largest active generator in the network"
+function _biggest_generator(gens)
+    biggest_gen = nothing
+    biggest_value = -Inf
+    for (k,gen) in gens
+        pmax = maximum(gen["pmax"])
+        if pmax > biggest_value
+            biggest_gen = gen
+            biggest_value = pmax
+        end
+    end
+    @assert(biggest_gen != nothing)
+    return biggest_gen
+end
+
+
 """
 checks that each branch has a reasonable transformer parameters
 
@@ -1941,7 +1986,7 @@ function check_component_refrence_bus(component_bus_ids, bus_lookup, component_g
         Memento.warn(LOGGER, "no reference bus found in connected component $(component_bus_ids)")
 
         if length(component_gens) > 0
-            big_gen = biggest_generator(component_gens)
+            big_gen = _biggest_generator(component_gens)
             gen_bus = bus_lookup[big_gen["gen_bus"]]
             gen_bus["bus_type"] = 3
             Memento.warn(LOGGER, "setting bus $(gen_bus["index"]) as reference bus in connected component $(component_bus_ids), based on generator $(big_gen["index"])")

--- a/src/io/common.jl
+++ b/src/io/common.jl
@@ -41,8 +41,10 @@ function check_network_data(data::Dict{String,<:Any})
     mod_dcline = Dict{Symbol,Set{Int}}()
 
     check_conductors(data)
-    make_per_unit(data)
     check_connectivity(data)
+    check_reference_bus(data)
+
+    make_per_unit(data)
 
     mod_branch[:xfer_fix] = check_transformer_parameters(data)
     mod_branch[:vad_bounds] = check_voltage_angle_differences(data)

--- a/src/prob/opb.jl
+++ b/src/prob/opb.jl
@@ -7,7 +7,7 @@ end
 
 "the optimal power balance problem"
 function run_opb(file, model_constructor, optimizer; kwargs...)
-    return run_generic_model(file, model_constructor, optimizer, post_opb; ref_extensions=[core_ref!,cc_ref!], kwargs...)
+    return run_generic_model(file, model_constructor, optimizer, post_opb; ref_extensions=[cc_ref!], kwargs...)
 end
 
 ""

--- a/src/prob/opb.jl
+++ b/src/prob/opb.jl
@@ -1,13 +1,13 @@
-export run_opb, run_cpa_opb
+export run_opb, run_nfa_opb
 
 ""
-function run_cpa_opb(file, optimizer; kwargs...)
-    return run_opb(file, CPAPowerModel, optimizer; kwargs...)
+function run_nfa_opb(file, optimizer; kwargs...)
+    return run_opb(file, NFAPowerModel, optimizer; kwargs...)
 end
 
 "the optimal power balance problem"
 function run_opb(file, model_constructor, optimizer; kwargs...)
-    return run_generic_model(file, model_constructor, optimizer, post_opb; kwargs...)
+    return run_generic_model(file, model_constructor, optimizer, post_opb; ref_extensions=[core_ref!,cc_ref!], kwargs...)
 end
 
 ""
@@ -19,5 +19,21 @@ function post_opb(pm::GenericPowerModel)
 
     for i in ids(pm, :components)
         constraint_power_balance(pm, i)
+    end
+end
+
+
+function cc_ref!(pm::GenericPowerModel)
+    if InfrastructureModels.ismultinetwork(pm.data)
+        nws_data = pm.data["nw"]
+    else
+        nws_data = Dict("0" => pm.data)
+    end
+
+    for (n, nw_data) in nws_data
+        nw_id = parse(Int, n)
+        nw_ref = ref(pm, nw_id)
+        component_sets = PowerModels.connected_components(nw_data)
+        nw_ref[:components] = Dict(i => c for (i,c) in enumerate(sort(collect(component_sets); by=length)))
     end
 end

--- a/src/prob/ots.jl
+++ b/src/prob/ots.jl
@@ -8,7 +8,7 @@ export run_ots
 
 ""
 function run_ots(file, model_constructor, optimizer; kwargs...)
-    return run_generic_model(file, model_constructor, optimizer, post_ots; solution_builder = get_ots_solution, kwargs...)
+    return run_generic_model(file, model_constructor, optimizer, post_ots; ref_extensions=[core_ref!,on_off_va_bounds_ref!], solution_builder = get_ots_solution, kwargs...)
 end
 
 ""
@@ -43,6 +43,25 @@ function post_ots(pm::GenericPowerModel)
 
     for i in ids(pm, :dcline)
         constraint_dcline(pm, i)
+    end
+end
+
+
+""
+function on_off_va_bounds_ref!(pm::GenericPowerModel)
+    if InfrastructureModels.ismultinetwork(pm.data)
+        nws_data = pm.data["nw"]
+    else
+        nws_data = Dict("0" => pm.data)
+    end
+
+    for (n, nw_data) in nws_data
+        nw_id = parse(Int, n)
+        nw_ref = ref(pm, nw_id)
+
+        off_angmin, off_angmax = calc_theta_delta_bounds(nw_data)
+        nw_ref[:off_angmin] = off_angmin
+        nw_ref[:off_angmax] = off_angmax
     end
 end
 

--- a/src/prob/ots.jl
+++ b/src/prob/ots.jl
@@ -8,7 +8,7 @@ export run_ots
 
 ""
 function run_ots(file, model_constructor, optimizer; kwargs...)
-    return run_generic_model(file, model_constructor, optimizer, post_ots; ref_extensions=[core_ref!,on_off_va_bounds_ref!], solution_builder = get_ots_solution, kwargs...)
+    return run_generic_model(file, model_constructor, optimizer, post_ots; ref_extensions=[on_off_va_bounds_ref!], solution_builder = get_ots_solution, kwargs...)
 end
 
 ""

--- a/src/prob/test.jl
+++ b/src/prob/test.jl
@@ -158,7 +158,7 @@ end
 
 ""
 function run_mn_opb(file, model_constructor, optimizer; kwargs...)
-    return run_generic_model(file, model_constructor, optimizer, post_mn_opb; multinetwork=true, kwargs...)
+    return run_generic_model(file, model_constructor, optimizer, post_mn_opb; ref_extensions=[core_ref!,cc_ref!], multinetwork=true, kwargs...)
 end
 
 ""

--- a/src/prob/test.jl
+++ b/src/prob/test.jl
@@ -158,7 +158,7 @@ end
 
 ""
 function run_mn_opb(file, model_constructor, optimizer; kwargs...)
-    return run_generic_model(file, model_constructor, optimizer, post_mn_opb; ref_extensions=[core_ref!,cc_ref!], multinetwork=true, kwargs...)
+    return run_generic_model(file, model_constructor, optimizer, post_mn_opb; ref_extensions=[cc_ref!], multinetwork=true, kwargs...)
 end
 
 ""

--- a/src/prob/tnep.jl
+++ b/src/prob/tnep.jl
@@ -6,7 +6,7 @@ export run_tnep
 
 ""
 function run_tnep(file, model_constructor, optimizer; kwargs...)
-    return run_generic_model(file, model_constructor, optimizer, post_tnep; ref_extensions=[core_ref!,on_off_va_bounds_ref!,ne_branch_ref!], solution_builder = get_tnep_solution, kwargs...)
+    return run_generic_model(file, model_constructor, optimizer, post_tnep; ref_extensions=[on_off_va_bounds_ref!,ne_branch_ref!], solution_builder = get_tnep_solution, kwargs...)
 end
 
 "the general form of the tnep optimization model"

--- a/src/prob/tnep.jl
+++ b/src/prob/tnep.jl
@@ -6,7 +6,7 @@ export run_tnep
 
 ""
 function run_tnep(file, model_constructor, optimizer; kwargs...)
-    return run_generic_model(file, model_constructor, optimizer, post_tnep; solution_builder = get_tnep_solution, kwargs...)
+    return run_generic_model(file, model_constructor, optimizer, post_tnep; ref_extensions=[core_ref!,on_off_va_bounds_ref!,ne_branch_ref!], solution_builder = get_tnep_solution, kwargs...)
 end
 
 "the general form of the tnep optimization model"
@@ -54,6 +54,37 @@ function post_tnep(pm::GenericPowerModel)
 
     for i in ids(pm, :dcline)
         constraint_dcline(pm, i)
+    end
+end
+
+
+""
+function ne_branch_ref!(pm::GenericPowerModel)
+    if InfrastructureModels.ismultinetwork(pm.data)
+        nws_data = pm.data["nw"]
+    else
+        nws_data = Dict("0" => pm.data)
+    end
+
+    for (n, nw_data) in nws_data
+        nw_id = parse(Int, n)
+        nw_ref = ref(pm, nw_id)
+
+        if haskey(nw_ref, :ne_branch)
+            nw_ref[:ne_branch] = Dict(x for x in nw_ref[:ne_branch] if (x.second["br_status"] == 1 && x.second["f_bus"] in keys(nw_ref[:bus]) && x.second["t_bus"] in keys(nw_ref[:bus])))
+
+            nw_ref[:ne_arcs_from] = [(i,branch["f_bus"],branch["t_bus"]) for (i,branch) in nw_ref[:ne_branch]]
+            nw_ref[:ne_arcs_to]   = [(i,branch["t_bus"],branch["f_bus"]) for (i,branch) in nw_ref[:ne_branch]]
+            nw_ref[:ne_arcs] = [nw_ref[:ne_arcs_from]; nw_ref[:ne_arcs_to]]
+
+            ne_bus_arcs = Dict((i, []) for (i,bus) in nw_ref[:bus])
+            for (l,i,j) in nw_ref[:ne_arcs]
+                push!(ne_bus_arcs[i], (l,i,j))
+            end
+            nw_ref[:ne_bus_arcs] = ne_bus_arcs
+
+            nw_ref[:ne_buspairs] = buspair_parameters(nw_ref[:ne_arcs_from], nw_ref[:ne_branch], nw_ref[:bus], nw_ref[:conductor_ids], haskey(nw_ref, :conductors))
+        end
     end
 end
 

--- a/test/opf.jl
+++ b/test/opf.jl
@@ -792,6 +792,7 @@ end
     @testset "passing in decomposition" begin
         data = PowerModels.parse_file("../test/data/matpower/case14.m")
         pm = GenericPowerModel(data, SparseSDPWRMForm)
+        PowerModels.core_ref!(pm)
 
         cadj, lookup_index, sigma = PowerModels.chordal_extension(pm)
         cliques = PowerModels.maximal_cliques(cadj)


### PR DESCRIPTION
This is a refactor on how the `ref` data structure is built, with the goals of improved model build times and allowing problem formulations to extend the precomputed values before the post method is called.

Notable changes,
- The GenericPowerModel constructor now only builds a very basic version of `ref`, which does the fully automatic and generic transformation steps of `data` into `ref`.  See `build_generic_ref`
- `core_ref!(pm)` can be used to populate `ref` with the basic info that nearly all models will need. It is called after the GenericPowerModel construct and before the model `post` method in `run_generic_model`.
- problem specific `run` methods can optionally add functions to the list defined by `ref_extensions`, which will be executed after `core_ref!(pm)` and before `post`.

The problem formulations OTS, TNEP, and OPB provide example for how this feature can be used.  For example see, `ne_branch_ref!`.

On a slightly tangential point, also updated how the `dcline` variables are setup to remove the need for `arcs_dc_param` and further simplify `core_ref!`.

Comments, questions and suggestions are welcome.  This will be merged shortly after the MOI transition is made. 

CC @frederikgeth, @hakanergun @rb004f, @pseudocubic, @sanderclaeys, @kaarthiksundar