### PR TITLE
REF: connected_components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@ PowerModels.jl Change Log
 =========================
 
 ### Staged
-- nothing
+- Refactor connected_components to accept arbitrary edge-types with `edges` kwarg
 
 ### v0.10.0
 - Update to JuMP v0.19/MathOptInterface

--- a/src/core/data.jl
+++ b/src/core/data.jl
@@ -1986,30 +1986,23 @@ end
 computes the connected components of the network graph
 returns a set of sets of bus ids, each set is a connected component
 """
-function connected_components(data::Dict{String,<:Any})
+function connected_components(data::Dict{String,<:Any}; lines=["branch", "dcline"])
     if InfrastructureModels.ismultinetwork(data)
         Memento.error(LOGGER, "connected_components does not yet support multinetwork data")
     end
 
     active_bus = Dict(x for x in data["bus"] if x.second["bus_type"] != 4)
-    #active_bus = filter((i, bus) -> bus["bus_type"] != 4, data["bus"])
     active_bus_ids = Set{Int64}([bus["bus_i"] for (i,bus) in active_bus])
-    #println(active_bus_ids)
 
     neighbors = Dict(i => [] for i in active_bus_ids)
-    for (i,branch) in data["branch"]
-        if branch["br_status"] != 0 && branch["f_bus"] in active_bus_ids && branch["t_bus"] in active_bus_ids
-            push!(neighbors[branch["f_bus"]], branch["t_bus"])
-            push!(neighbors[branch["t_bus"]], branch["f_bus"])
+    for line_type in lines
+        for line in values(get(data, line_type, Dict()))
+            if get(line, "br_status", 1) != 0 && line["f_bus"] in active_bus_ids && line["t_bus"] in active_bus_ids
+                push!(neighbors[line["f_bus"]], line["t_bus"])
+                push!(neighbors[line["t_bus"]], line["f_bus"])
+            end
         end
     end
-    for (i,dcline) in data["dcline"]
-        if dcline["br_status"] != 0 && dcline["f_bus"] in active_bus_ids && dcline["t_bus"] in active_bus_ids
-            push!(neighbors[dcline["f_bus"]], dcline["t_bus"])
-            push!(neighbors[dcline["t_bus"]], dcline["f_bus"])
-        end
-    end
-    #println(neighbors)
 
     component_lookup = Dict(i => Set{Int64}([i]) for i in active_bus_ids)
     touched = Set{Int64}()

--- a/src/core/data.jl
+++ b/src/core/data.jl
@@ -1986,7 +1986,7 @@ end
 computes the connected components of the network graph
 returns a set of sets of bus ids, each set is a connected component
 """
-function connected_components(data::Dict{String,<:Any}; lines=["branch", "dcline"])
+function connected_components(data::Dict{String,<:Any}; edges=["branch", "dcline"])
     if InfrastructureModels.ismultinetwork(data)
         Memento.error(LOGGER, "connected_components does not yet support multinetwork data")
     end
@@ -1995,7 +1995,7 @@ function connected_components(data::Dict{String,<:Any}; lines=["branch", "dcline
     active_bus_ids = Set{Int64}([bus["bus_i"] for (i,bus) in active_bus])
 
     neighbors = Dict(i => [] for i in active_bus_ids)
-    for line_type in lines
+    for line_type in edges
         for line in values(get(data, line_type, Dict()))
             if get(line, "br_status", 1) != 0 && line["f_bus"] in active_bus_ids && line["t_bus"] in active_bus_ids
                 push!(neighbors[line["f_bus"]], line["t_bus"])

--- a/test/data.jl
+++ b/test/data.jl
@@ -208,6 +208,14 @@ end
         @test length(cc_ordered) == 2
         @test length(cc_ordered[1]) == 3
         @test length(cc_ordered[2]) == 3
+
+        # arbitrary edge types test
+        data["trans"] = Dict{String,Any}()
+        data["trans"]["1"] = deepcopy(data["branch"]["6"])
+        delete!(data["branch"], "6")
+
+        cc2 = PowerModels.connected_components(data; edges=["branch", "trans"])
+        @test cc2 == cc
     end
 
     @testset "connecected components with propagate topology status" begin


### PR DESCRIPTION
Generalizes the function `connected_components` to allow specification of any component type as a line

Needed for new transformers model in ThreePhasePowerModels