### PR TITLE
FIX: Storage constraint warn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ PowerModels.jl Change Log
 
 ### Staged
 - Refactor connected_components to accept arbitrary edge-types with `edges` kwarg
+- Fixes bug in warnings inside storage constraints
 
 ### v0.10.0
 - Update to JuMP v0.19/MathOptInterface

--- a/src/core/constraint_template.jl
+++ b/src/core/constraint_template.jl
@@ -653,7 +653,7 @@ function constraint_storage_state(pm::GenericPowerModel, i::Int; nw::Int=pm.cnw)
     if haskey(pm.data, "time_elapsed")
         time_elapsed = pm.data["time_elapsed"]
     else
-        Memento.warn("network data should specify time_elapsed, using 1.0 as a default")
+        Memento.warn(LOGGER, "network data should specify time_elapsed, using 1.0 as a default")
         time_elapsed = 1.0
     end
 
@@ -667,7 +667,7 @@ function constraint_storage_state(pm::GenericPowerModel, i::Int, nw_1::Int, nw_2
     if haskey(pm.data, "time_elapsed")
         time_elapsed = pm.data["time_elapsed"]
     else
-        Memento.warn("network data should specify time_elapsed, using 1.0 as a default")
+        Memento.warn(LOGGER, "network data should specify time_elapsed, using 1.0 as a default")
         time_elapsed = 1.0
     end
 

--- a/test/multinetwork.jl
+++ b/test/multinetwork.jl
@@ -282,6 +282,12 @@ TESTLOG = Memento.getlogger(PowerModels)
             end
         end
 
+        @testset "storage constraint warning" begin
+            delete!(mn_data, "time_elapsed")
+            Memento.setlevel!(TESTLOG, "warn")
+            @test_warn(TESTLOG, "network data should specify time_elapsed, using 1.0 as a default", PowerModels.run_mn_strg_opf(mn_data, PowerModels.ACPPowerModel, ipopt_solver))
+            Memento.setlevel!(TESTLOG, "error")
+        end
     end
 
 

--- a/test/opf-var.jl
+++ b/test/opf-var.jl
@@ -1,4 +1,5 @@
 ### Tests for OPF variants ###
+TESTLOG = Memento.getlogger(PowerModels)
 
 function build_current_data(base_data)
     c_data = PowerModels.parse_file(base_data)
@@ -218,6 +219,14 @@ end
             @test isapprox(result["solution"]["storage"]["2"]["se"],  0.0; atol = 1e0)
             @test isapprox(result["solution"]["storage"]["2"]["ps"], -0.234501; atol = 1e-2)
         end
+    end
+
+    @testset "storage constraint warn" begin
+        mp_data = PowerModels.parse_file("../test/data/matpower/case5_strg.m")
+        delete!(mp_data, "time_elapsed")
+        Memento.setlevel!(TESTLOG, "warn")
+        @test_warn(TESTLOG, "network data should specify time_elapsed, using 1.0 as a default", PowerModels.run_strg_opf(mp_data, PowerModels.ACPPowerModel, ipopt_solver))
+        Memento.setlevel!(TESTLOG, "error")
     end
 
 end


### PR DESCRIPTION
`LOGGER` was missing from `Memento.warn` in the storage constraints.

Adds Unit tests and updates changelog