### PR TITLE
FIX: Parse of Bool arrays and Inf/NaN values from JSON

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ PowerModels.jl Change Log
 
 ### Staged
 - Refactor connected_components to accept arbitrary edge-types with `edges` kwarg
+- Add Bool to allowed data types in json parse of MultiConductorVector/Matrix
 
 ### v0.10.0
 - Update to JuMP v0.19/MathOptInterface

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ PowerModels.jl Change Log
 - Refactor connected_components to accept arbitrary edge-types with `edges` kwarg
 - Fixes bug in warnings inside storage constraints
 - Add Bool to allowed data types in json parse of MultiConductorVector/Matrix
-- Add handling of Inf/NaN values in JSON parser
+- Add handling of Inf/NaN values in JSON parser in MultiConductorVector/Matrix
 
 ### v0.10.0
 - Update to JuMP v0.19/MathOptInterface

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ PowerModels.jl Change Log
 ### Staged
 - Refactor connected_components to accept arbitrary edge-types with `edges` kwarg
 - Add Bool to allowed data types in json parse of MultiConductorVector/Matrix
+- Add handling of Inf/NaN values in JSON parser
 
 ### v0.10.0
 - Update to JuMP v0.19/MathOptInterface

--- a/src/core/multiconductor.jl
+++ b/src/core/multiconductor.jl
@@ -161,12 +161,16 @@ Base.rad2deg(a::MultiConductorMatrix) = MultiConductorMatrix(map(rad2deg, a.valu
 Base.deg2rad(a::MultiConductorVector) = MultiConductorVector(map(deg2rad, a.values))
 Base.deg2rad(a::MultiConductorMatrix) = MultiConductorMatrix(map(deg2rad, a.values))
 
-JSON.lower(mcv::PowerModels.MultiConductorValue) = Dict("values"=>[isinf(v) || isnan(v) ? string(v) : v for v in mcv.values], "type"=>string(typeof(mcv)))
+JSON.lower(mcv::PowerModels.MultiConductorValue) = Dict("values"=>[eltype(mcv) != String && (isinf(v) || isnan(v)) ? string(v) : v for v in mcv.values], "type"=>string(typeof(mcv)))
 function JSON.show_json(io::JSON.StructuralContext, s::JSON.CommonSerialization, p::PowerModels.MultiConductorValue)
-    if isa(p, MultiConductorMatrix)
-        values = [[isinf(v) || isnan(v) ? string(v) : v for v in row] for row in p.values]
-    elseif isa(p, MultiConductorVector)
-        values = [isinf(v) || isnan(v) ? string(v) : v for v in p.values]
+    if eltype(p) != String
+        if isa(p, MultiConductorMatrix)
+            values = [[!isa(v, String) && isinf(v) || isnan(v) ? string(v) : v for v in row] for row in p.values]
+        elseif isa(p, MultiConductorVector)
+            values = [!isa(v, String) && isinf(v) || isnan(v) ? string(v) : v for v in p.values]
+        end
+    else
+        values = p.values
     end
 
     a = Dict("values"=>values, "type"=>string(typeof(p)))

--- a/src/core/multiconductor.jl
+++ b/src/core/multiconductor.jl
@@ -161,9 +161,15 @@ Base.rad2deg(a::MultiConductorMatrix) = MultiConductorMatrix(map(rad2deg, a.valu
 Base.deg2rad(a::MultiConductorVector) = MultiConductorVector(map(deg2rad, a.values))
 Base.deg2rad(a::MultiConductorMatrix) = MultiConductorMatrix(map(deg2rad, a.values))
 
-JSON.lower(mcv::PowerModels.MultiConductorValue) = Dict("values"=>mcv.values, "type"=>string(typeof(mcv)))
+JSON.lower(mcv::PowerModels.MultiConductorValue) = Dict("values"=>[isinf(v) || isnan(v) ? string(v) : v for v in mcv.values], "type"=>string(typeof(mcv)))
 function JSON.show_json(io::JSON.StructuralContext, s::JSON.CommonSerialization, p::PowerModels.MultiConductorValue)
-    a = Dict("values"=>p.values, "type"=>string(typeof(p)))
+    if isa(p, MultiConductorMatrix)
+        values = [[isinf(v) || isnan(v) ? string(v) : v for v in row] for row in p.values]
+    elseif isa(p, MultiConductorVector)
+        values = [isinf(v) || isnan(v) ? string(v) : v for v in p.values]
+    end
+
+    a = Dict("values"=>values, "type"=>string(typeof(p)))
     JSON.begin_object(io)
     for kv in a
         JSON.show_pair(io, s, kv)

--- a/src/io/json.jl
+++ b/src/io/json.jl
@@ -24,10 +24,18 @@ function _parse_mcv!(pm_data)
                     if isa(value, Dict) && haskey(value, "values") && haskey(value, "type")
                         element_type = match(r"MultiConductor(?:Vector|Matrix){([a-zA-Z]+)\d*}", value["type"]).captures[1]
                         if startswith(value["type"], "MultiConductorVector") || startswith(value["type"], "PowerModels.MultiConductorVector")
-                            values = [isa(v, AbstractString) ? parse(eltypes[element_type], v) : v for v in value["values"]]
+                            if element_type != "String"
+                                values = [isa(v, AbstractString) ? parse(eltypes[element_type], v) : v for v in value["values"]]
+                            else
+                                values = value["values"]
+                            end
                             pm_data[comp_type][n][field] = PowerModels.MultiConductorVector(convert(Array{eltypes[element_type]}, values))
                         elseif startswith(value["type"], "MultiConductorMatrix") || startswith(value["type"], "PowerModels.MultiConductorMatrix")
-                            values = [[isa(v, AbstractString) ? parse(eltypes[element_type], v) : v for v in row] for row in value["values"]]
+                            if element_type != "String"
+                                values = [[isa(v, AbstractString) ? parse(eltypes[element_type], v) : v for v in row] for row in value["values"]]
+                            else
+                                values = value["values"]
+                            end
                             pm_data[comp_type][n][field] = PowerModels.MultiConductorMatrix(convert(Array{eltypes[element_type]}, hcat(values...)))
                         end
                     end

--- a/src/io/json.jl
+++ b/src/io/json.jl
@@ -14,7 +14,8 @@ function _parse_mcv!(pm_data)
                    "Int"=>Int64,
                    "Real"=>Real,
                    "Complex"=>Complex,
-                   "String"=>String)
+                   "String"=>String,
+                   "Bool"=>Bool)
 
     for (comp_type, comp_items) in pm_data
         if isa(comp_items, Dict)

--- a/src/io/json.jl
+++ b/src/io/json.jl
@@ -24,9 +24,11 @@ function _parse_mcv!(pm_data)
                     if isa(value, Dict) && haskey(value, "values") && haskey(value, "type")
                         element_type = match(r"MultiConductor(?:Vector|Matrix){([a-zA-Z]+)\d*}", value["type"]).captures[1]
                         if startswith(value["type"], "MultiConductorVector") || startswith(value["type"], "PowerModels.MultiConductorVector")
-                            pm_data[comp_type][n][field] = PowerModels.MultiConductorVector(convert(Array{eltypes[element_type]}, value["values"]))
+                            values = [isa(v, AbstractString) ? parse(eltypes[element_type], v) : v for v in value["values"]]
+                            pm_data[comp_type][n][field] = PowerModels.MultiConductorVector(convert(Array{eltypes[element_type]}, values))
                         elseif startswith(value["type"], "MultiConductorMatrix") || startswith(value["type"], "PowerModels.MultiConductorMatrix")
-                            pm_data[comp_type][n][field] = PowerModels.MultiConductorMatrix(convert(Array{eltypes[element_type]}, hcat(value["values"]...)))
+                            values = [[isa(v, AbstractString) ? parse(eltypes[element_type], v) : v for v in row] for row in value["values"]]
+                            pm_data[comp_type][n][field] = PowerModels.MultiConductorMatrix(convert(Array{eltypes[element_type]}, hcat(values...)))
                         end
                     end
                 end

--- a/test/multiconductor.jl
+++ b/test/multiconductor.jl
@@ -44,37 +44,34 @@ end
     @testset "json parser" begin
         mc_data = build_mc_data("../test/data/pti/parser_test_defaults.raw")
         mc_json_string = PowerModels.parse_json(JSON.json(mc_data))
-        if VERSION > v"0.7.0-"
-            @test mc_data == mc_json_string
-        end
+        @test mc_data == mc_json_string
 
         io = PipeBuffer()
         JSON.print(io, mc_data)
         mc_json_file = PowerModels.parse_file(io)
-        if VERSION > v"0.7.0-"
-            @test mc_data == mc_json_file
-        else
-            @test InfrastructureModels.compare_dict(mc_data, mc_json_file)
-        end
+        @test mc_data == mc_json_file
 
         mc_strg_data = build_mc_data("../test/data/matpower/case5_strg.m")
         mc_strg_json_string = PowerModels.parse_json(JSON.json(mc_strg_data))
-        if VERSION > v"0.7.0-"
-            @test mc_strg_data == mc_strg_json_string
-        else
-            @test InfrastructureModels.compare_dict(mc_strg_data, mc_strg_json_string)
-        end
+        @test mc_strg_data == mc_strg_json_string
 
         # test that non-multiconductor json still parses, pti_json_file will result in error if fails
         pti_data = PowerModels.parse_file("../test/data/pti/parser_test_defaults.raw")
         io = PipeBuffer()
         JSON.print(io, pti_data)
         pti_json_file = PowerModels.parse_file(io)
-        if VERSION > v"0.7.0-"
-            @test pti_data == pti_json_file
-        else
-            @test InfrastructureModels.compare_dict(pti_data, pti_json_file)
-        end
+        @test pti_data == pti_json_file
+
+        mc_data = build_mc_data("../test/data/matpower/case5.m")
+        mc_data["gen"]["1"]["pmax"] = PowerModels.MultiConductorVector([Inf, Inf, Inf])
+        mc_data["gen"]["1"]["qmin"] = PowerModels.MultiConductorVector([-Inf, -Inf, -Inf])
+        mc_data["gen"]["1"]["bool_test"] = PowerModels.MultiConductorVector([true, true, false])
+        mc_data["branch"]["1"]["br_x"][1,2] = -Inf
+        mc_data["branch"]["1"]["br_x"][1,3] = Inf
+
+        mc_data_json = PowerModels.parse_json(JSON.json(mc_data))
+        @test mc_data_json == mc_data
+
     end
 
     @testset "idempotent unit transformation" begin

--- a/test/multiconductor.jl
+++ b/test/multiconductor.jl
@@ -66,6 +66,7 @@ end
         mc_data["gen"]["1"]["pmax"] = PowerModels.MultiConductorVector([Inf, Inf, Inf])
         mc_data["gen"]["1"]["qmin"] = PowerModels.MultiConductorVector([-Inf, -Inf, -Inf])
         mc_data["gen"]["1"]["bool_test"] = PowerModels.MultiConductorVector([true, true, false])
+        mc_data["gen"]["1"]["string_test"] = PowerModels.MultiConductorVector(["a", "b", "c"])
         mc_data["branch"]["1"]["br_x"][1,2] = -Inf
         mc_data["branch"]["1"]["br_x"][1,3] = Inf
 

--- a/test/multiconductor.jl
+++ b/test/multiconductor.jl
@@ -73,6 +73,10 @@ end
         mc_data_json = PowerModels.parse_json(JSON.json(mc_data))
         @test mc_data_json == mc_data
 
+        mc_data["gen"]["1"]["nan_test"] = PowerModels.MultiConductorVector([0, NaN, 0])
+        mc_data_json = PowerModels.parse_json(JSON.json(mc_data))
+        @test isnan(mc_data_json["gen"]["1"]["nan_test"][2])
+
     end
 
     @testset "idempotent unit transformation" begin


### PR DESCRIPTION
ThreePhasePowerModels has instances where Bool arrays are used on transformers, adding support for Bool arrays in base JSON parser.

Adds support for outputting Inf/NaN values in JSON and parsing them back in (not natively supported by JSON) by outputting strings and using `parse` on string values whose eltype is not supposed to be String.

Updates changelog, adds unit tests.