### PR TITLE
Update Voltage Constraint Name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,9 @@ PowerModels.jl Change Log
 =========================
 
 ### Staged
+- Update constraint_voltage to constraint_model_specific (#499)
 - Update Matpower "bus_name" to map to bus parameter "name"
-- Updated slope and intercept data structure (#521)
+- Update slope and intercept data structure (#521)
 
 ### Staged
 - Added source_id to Matpower parser (#512)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,10 @@ PowerModels.jl Change Log
 =========================
 
 ### Staged
-- Update constraint_voltage to constraint_model_specific (#499)
-- Update Matpower "bus_name" to map to bus parameter "name"
-- Update slope and intercept data structure (#521)
+- Update constraint_voltage to constraint_model_voltage (#499) (breaking)
+- Added constraint_model_current to bfm formulations (breaking)
+- Update Matpower "bus_name" to map to bus parameter "name" (breaking)
+- Update slope and intercept data structure (#521) (breaking)
 
 ### Staged
 - Added source_id to Matpower parser (#512)

--- a/docs/src/constraints.md
+++ b/docs/src/constraints.md
@@ -13,8 +13,8 @@ These templates should be defined over `GenericPowerModel` and should not refer 
 
 ```@docs
 constraint_voltage
-constraint_voltage_on_off
-constraint_voltage_ne
+constraint_model_voltage_on_off
+constraint_model_voltage_ne
 ```
 
 ## Generator Constraints

--- a/docs/src/constraints.md
+++ b/docs/src/constraints.md
@@ -107,7 +107,6 @@ constraint_voltage_angle_difference_ne
 constraint_loss_lb
 constraint_flow_losses
 constraint_voltage_magnitude_difference
-constraint_branch_current
 ```
 
 ### Storage Constraints

--- a/docs/src/math-model.md
+++ b/docs/src/math-model.md
@@ -122,5 +122,5 @@ Note that constraints $\eqref{eq_line_losses} - \eqref{eq_ohms_bfm}$ replace $\e
 - Eq. $\eqref{var_branch_current}$ - `variable_branch_current` in `variable.jl`
 - Eq. $\eqref{eq_line_losses}$ - `constraint_flow_losses` in `constraint_template.jl`
 - Eq. $\eqref{eq_series_power_flow}$ - implicit, substituted out before implementation
-- Eq. $\eqref{eq_complex_power_definition}$ - `constraint_model_specific` in `constraint_template.jl`
+- Eq. $\eqref{eq_complex_power_definition}$ - `constraint_model_voltage` in `constraint_template.jl`
 - Eq. $\eqref{eq_ohms_bfm}$ - `constraint_voltage_magnitude_difference` in `constraint_template.jl`

--- a/docs/src/math-model.md
+++ b/docs/src/math-model.md
@@ -122,5 +122,5 @@ Note that constraints $\eqref{eq_line_losses} - \eqref{eq_ohms_bfm}$ replace $\e
 - Eq. $\eqref{var_branch_current}$ - `variable_branch_current` in `variable.jl`
 - Eq. $\eqref{eq_line_losses}$ - `constraint_flow_losses` in `constraint_template.jl`
 - Eq. $\eqref{eq_series_power_flow}$ - implicit, substituted out before implementation
-- Eq. $\eqref{eq_complex_power_definition}$ - `constraint_branch_current` in `constraint_template.jl`
+- Eq. $\eqref{eq_complex_power_definition}$ - `constraint_model_specific` in `constraint_template.jl`
 - Eq. $\eqref{eq_ohms_bfm}$ - `constraint_voltage_magnitude_difference` in `constraint_template.jl`

--- a/docs/src/specifications.md
+++ b/docs/src/specifications.md
@@ -18,7 +18,7 @@ variable_dcline_flow(pm)
 
 ### Constraints
 ```julia
-constraint_voltage(pm)
+constraint_model_specific(pm)
 for i in ids(pm, :ref_buses)
     constraint_theta_ref(pm, i)
 end
@@ -58,7 +58,7 @@ variable_dcline_flow(pm)
 
 ### Constraints
 ```julia
-constraint_voltage(pm)
+constraint_model_specific(pm)
 for i in ids(pm, :ref_buses)
     constraint_theta_ref(pm, i)
 end
@@ -68,7 +68,6 @@ end
 for i in ids(pm, :branch)
     constraint_flow_losses(pm, i)
     constraint_voltage_magnitude_difference(pm, i)
-    constraint_branch_current(pm, i)
 
     constraint_voltage_angle_difference(pm, i)
 
@@ -143,7 +142,7 @@ variable_dcline_flow(pm, bounded = false)
 
 ### Constraints
 ```julia
-constraint_voltage(pm)
+constraint_model_specific(pm)
 for (i,bus) in ref(pm, :ref_buses)
     @assert bus["bus_type"] == 3
     constraint_theta_ref(pm, i)
@@ -196,6 +195,7 @@ variable_dcline_flow(pm, bounded = false)
 
 ### Constraints
 ```julia
+constraint_model_specific(pm)
 for (i,bus) in ref(pm, :ref_buses)
     @assert bus["bus_type"] == 3
     constraint_theta_ref(pm, i)
@@ -215,7 +215,6 @@ end
 for i in ids(pm, :branch)
     constraint_flow_losses(pm, i)
     constraint_voltage_magnitude_difference(pm, i)
-    constraint_branch_current(pm, i)
 end
 for (i,dcline) in ref(pm, :dcline)
     constraint_active_dcline_setpoint(pm, i)
@@ -253,7 +252,7 @@ variable_branch_flow_ne(pm)
 
 ### Constraints
 ```julia
-constraint_voltage(pm)
+constraint_model_specific(pm)
 constraint_voltage_ne(pm)
 for i in ids(pm, :ref_buses)
     constraint_theta_ref(pm, i)

--- a/docs/src/specifications.md
+++ b/docs/src/specifications.md
@@ -18,7 +18,7 @@ variable_dcline_flow(pm)
 
 ### Constraints
 ```julia
-constraint_model_specific(pm)
+constraint_model_voltage(pm)
 for i in ids(pm, :ref_buses)
     constraint_theta_ref(pm, i)
 end
@@ -58,7 +58,7 @@ variable_dcline_flow(pm)
 
 ### Constraints
 ```julia
-constraint_model_specific(pm)
+constraint_model_voltage(pm)
 for i in ids(pm, :ref_buses)
     constraint_theta_ref(pm, i)
 end
@@ -106,7 +106,7 @@ objective_min_fuel_cost(pm)
 ### Constraints
 
 ```julia
-constraint_voltage_on_off(pm)
+constraint_model_voltage_on_off(pm)
 for i in ids(pm, :ref_buses)
     constraint_theta_ref(pm, i)
 end
@@ -142,7 +142,7 @@ variable_dcline_flow(pm, bounded = false)
 
 ### Constraints
 ```julia
-constraint_model_specific(pm)
+constraint_model_voltage(pm)
 for (i,bus) in ref(pm, :ref_buses)
     @assert bus["bus_type"] == 3
     constraint_theta_ref(pm, i)
@@ -195,7 +195,7 @@ variable_dcline_flow(pm, bounded = false)
 
 ### Constraints
 ```julia
-constraint_model_specific(pm)
+constraint_model_voltage(pm)
 for (i,bus) in ref(pm, :ref_buses)
     @assert bus["bus_type"] == 3
     constraint_theta_ref(pm, i)
@@ -252,8 +252,8 @@ variable_branch_flow_ne(pm)
 
 ### Constraints
 ```julia
-constraint_model_specific(pm)
-constraint_voltage_ne(pm)
+constraint_model_voltage(pm)
+constraint_model_voltage_ne(pm)
 for i in ids(pm, :ref_buses)
     constraint_theta_ref(pm, i)
 end

--- a/src/core/base.jl
+++ b/src/core/base.jl
@@ -410,3 +410,18 @@ function core_ref!(nw_refs::Dict)
 
     end
 end
+
+
+"checks of any of the given keys are missing from the given dict"
+function check_missing_keys(dict, keys, type)
+    missing = []
+    for key in keys
+        if !haskey(dict, key)
+            push!(missing, key)
+        end
+    end
+    if length(missing) > 0
+        error(LOGGER, "the formulation $(type) requires the following varible(s) $(keys) but the $(missing) variable(s) were not found in the model")
+    end
+end
+

--- a/src/core/constraint.jl
+++ b/src/core/constraint.jl
@@ -115,8 +115,10 @@ function constraint_active_dcline_setpoint(pm::GenericPowerModel, n::Int, c::Int
     JuMP.@constraint(pm.model, p_to == pt)
 end
 
-"do nothing, this model does not have complex voltage constraints"
-function constraint_voltage(pm::GenericPowerModel, n::Int, c::Int)
+"""
+do nothing, most models to not require any model-specific constraints
+"""
+function constraint_model_specific(pm::GenericPowerModel, n::Int, c::Int)
 end
 
 

--- a/src/core/constraint.jl
+++ b/src/core/constraint.jl
@@ -116,9 +116,27 @@ function constraint_active_dcline_setpoint(pm::GenericPowerModel, n::Int, c::Int
 end
 
 """
-do nothing, most models to not require any model-specific constraints
+do nothing, most models to not require any model-specific voltage constraints
 """
-function constraint_model_specific(pm::GenericPowerModel, n::Int, c::Int)
+function constraint_model_voltage(pm::GenericPowerModel, n::Int, c::Int)
+end
+
+"""
+do nothing, most models to not require any model-specific on/off voltage constraints
+"""
+function constraint_model_voltage_on_off(pm::GenericPowerModel, n::Int, c::Int)
+end
+
+"""
+do nothing, most models to not require any model-specific network expansion voltage constraints
+"""
+function constraint_model_voltage_ne(pm::GenericPowerModel, n::Int, c::Int)
+end
+
+"""
+do nothing, most models to not require any model-specific current constraints
+"""
+function constraint_model_current(pm::GenericPowerModel, n::Int, c::Int)
 end
 
 

--- a/src/core/constraint_template.jl
+++ b/src/core/constraint_template.jl
@@ -14,9 +14,22 @@
 
 ### Voltage Constraints ###
 
-""
-function constraint_voltage(pm::GenericPowerModel; nw::Int=pm.cnw, cnd::Int=pm.ccnd)
-    constraint_voltage(pm, nw, cnd)
+"""
+This constraint captures problem agnostic constraints that are used to link
+the model's variables together, in addition to the standard problem formulation
+constraints.
+
+Notable examples include the constraints linking the voltages in the
+ACTPowerModel, constraints linking convex relaxations of voltage variables
+and the constraints linking the voltage, current and power variables in the BFM
+models.
+
+Note that model specific constraints should be problem agnostic and not make
+assuptions about the other constraints occuring in the rest of the problem
+specification
+"""
+function constraint_model_specific(pm::GenericPowerModel; nw::Int=pm.cnw, cnd::Int=pm.ccnd)
+    constraint_model_specific(pm, nw, cnd)
 end
 
 ""
@@ -602,21 +615,6 @@ function constraint_voltage_magnitude_difference(pm::GenericPowerModel, i::Int; 
 
     constraint_voltage_magnitude_difference(pm, nw, cnd, i, f_bus, t_bus, f_idx, t_idx, r, x, g_sh_fr, b_sh_fr, tm)
 end
-
-""
-function constraint_branch_current(pm::GenericPowerModel, i::Int; nw::Int=pm.cnw, cnd::Int=pm.ccnd)
-    branch = ref(pm, nw, :branch, i)
-    f_bus = branch["f_bus"]
-    t_bus = branch["t_bus"]
-    f_idx = (i, f_bus, t_bus)
-
-    tm = branch["tap"][cnd]
-    g_sh_fr = branch["g_fr"][cnd]
-    b_sh_fr = branch["b_fr"][cnd]
-
-    constraint_branch_current(pm, nw, cnd, i, f_bus, f_idx, g_sh_fr, b_sh_fr, tm)
-end
-
 
 
 

--- a/src/core/constraint_template.jl
+++ b/src/core/constraint_template.jl
@@ -16,30 +16,62 @@
 
 """
 This constraint captures problem agnostic constraints that are used to link
-the model's variables together, in addition to the standard problem formulation
-constraints.
+the model's voltage variables together, in addition to the standard problem
+formulation constraints.
 
 Notable examples include the constraints linking the voltages in the
 ACTPowerModel, constraints linking convex relaxations of voltage variables
-and the constraints linking the voltage, current and power variables in the BFM
-models.
-
-Note that model specific constraints should be problem agnostic and not make
-assuptions about the other constraints occuring in the rest of the problem
-specification.
+and the constraints linking the voltage.
 """
-function constraint_model_specific(pm::GenericPowerModel; nw::Int=pm.cnw, cnd::Int=pm.ccnd)
-    constraint_model_specific(pm, nw, cnd)
+function constraint_model_voltage(pm::GenericPowerModel; nw::Int=pm.cnw, cnd::Int=pm.ccnd)
+    constraint_model_voltage(pm, nw, cnd)
 end
 
-""
-function constraint_voltage_on_off(pm::GenericPowerModel; nw::Int=pm.cnw, cnd::Int=pm.ccnd)
-    constraint_voltage_on_off(pm, nw, cnd)
+"""
+This constraint captures problem agnostic constraints that are used to link
+the model's voltage variables together, in addition to the standard problem
+formulation constraints.  The on/off name indicates that the voltages in this
+constraint can be set to zero via an indicator variable
+
+Notable examples include the constraints linking the voltages in the
+ACTPowerModel, constraints linking convex relaxations of voltage variables
+and the constraints linking the voltage.
+"""
+function constraint_model_voltage_on_off(pm::GenericPowerModel; nw::Int=pm.cnw, cnd::Int=pm.ccnd)
+    constraint_model_voltage_on_off(pm, nw, cnd)
 end
 
-""
-function constraint_voltage_ne(pm::GenericPowerModel; nw::Int=pm.cnw, cnd::Int=pm.ccnd)
-    constraint_voltage_ne(pm, nw, cnd)
+"""
+This constraint captures problem agnostic constraints that are used to link
+the model's voltage variables together, in addition to the standard problem
+formulation constraints.  The network expantion name (ne) indicates that the
+voltages in this constraint can be set to zero via an indicator variable
+
+Notable examples include the constraints linking the voltages in the
+ACTPowerModel, constraints linking convex relaxations of voltage variables
+and the constraints linking the voltage.
+"""
+function constraint_model_voltage_ne(pm::GenericPowerModel; nw::Int=pm.cnw, cnd::Int=pm.ccnd)
+    constraint_model_voltage_ne(pm, nw, cnd)
+end
+
+
+### Current Constraints ###
+
+"""
+This constraint captures problem agnostic constraints that are used to link
+the model's current variables together, in addition to the standard problem
+formulation constraints.
+
+Notable examples include the constraints linking the current and power
+variables in the BFM models.
+
+Note that these model-based current constraints should be problem agnostic and
+not make assuptions about the other constraints occuring in the rest of the
+problem specification.
+"""
+function constraint_model_current(pm::GenericPowerModel; nw::Int=pm.cnw, cnd::Int=pm.ccnd)
+    constraint_model_current(pm, nw, cnd)
 end
 
 

--- a/src/core/constraint_template.jl
+++ b/src/core/constraint_template.jl
@@ -26,7 +26,7 @@ models.
 
 Note that model specific constraints should be problem agnostic and not make
 assuptions about the other constraints occuring in the rest of the problem
-specification
+specification.
 """
 function constraint_model_specific(pm::GenericPowerModel; nw::Int=pm.cnw, cnd::Int=pm.ccnd)
     constraint_model_specific(pm, nw, cnd)

--- a/src/form/acp.jl
+++ b/src/form/acp.jl
@@ -11,7 +11,7 @@ function variable_voltage_ne(pm::GenericPowerModel{T}; kwargs...) where T <: Abs
 end
 
 "do nothing, this model does not have complex voltage constraints"
-function constraint_voltage_ne(pm::GenericPowerModel{T}; kwargs...) where T <: AbstractACPForm
+function constraint_model_voltage_ne(pm::GenericPowerModel{T}; kwargs...) where T <: AbstractACPForm
 end
 
 
@@ -185,7 +185,7 @@ function variable_voltage_on_off(pm::GenericPowerModel{T}; kwargs...) where T <:
 end
 
 "do nothing, this model does not have complex voltage constraints"
-function constraint_voltage_on_off(pm::GenericPowerModel{T}; kwargs...) where T <: AbstractACPForm
+function constraint_model_voltage_on_off(pm::GenericPowerModel{T}; kwargs...) where T <: AbstractACPForm
 end
 
 """

--- a/src/form/acp.jl
+++ b/src/form/acp.jl
@@ -11,10 +11,6 @@ function variable_voltage_ne(pm::GenericPowerModel{T}; kwargs...) where T <: Abs
 end
 
 "do nothing, this model does not have complex voltage constraints"
-function constraint_model_specific(pm::GenericPowerModel{T}; kwargs...) where T <: AbstractACPForm
-end
-
-"do nothing, this model does not have complex voltage constraints"
 function constraint_voltage_ne(pm::GenericPowerModel{T}; kwargs...) where T <: AbstractACPForm
 end
 

--- a/src/form/acp.jl
+++ b/src/form/acp.jl
@@ -11,7 +11,7 @@ function variable_voltage_ne(pm::GenericPowerModel{T}; kwargs...) where T <: Abs
 end
 
 "do nothing, this model does not have complex voltage constraints"
-function constraint_voltage(pm::GenericPowerModel{T}; kwargs...) where T <: AbstractACPForm
+function constraint_model_specific(pm::GenericPowerModel{T}; kwargs...) where T <: AbstractACPForm
 end
 
 "do nothing, this model does not have complex voltage constraints"

--- a/src/form/act.jl
+++ b/src/form/act.jl
@@ -12,7 +12,7 @@ function variable_voltage(pm::GenericPowerModel{T}; kwargs...) where T <: Abstra
     variable_voltage_product(pm; kwargs...)
 end
 
-function constraint_voltage(pm::GenericPowerModel{T}, n::Int, c::Int) where T <: StandardACTForm
+function constraint_model_specific(pm::GenericPowerModel{T}, n::Int, c::Int) where T <: StandardACTForm
     t  = var(pm, n, c, :va)
     w  = var(pm, n, c,  :w)
     wr = var(pm, n, c, :wr)

--- a/src/form/act.jl
+++ b/src/form/act.jl
@@ -13,6 +13,8 @@ function variable_voltage(pm::GenericPowerModel{T}; kwargs...) where T <: Abstra
 end
 
 function constraint_model_specific(pm::GenericPowerModel{T}, n::Int, c::Int) where T <: StandardACTForm
+    check_missing_keys(var(pm, n, c), [:va,:w,:wr,:wi], T)
+
     t  = var(pm, n, c, :va)
     w  = var(pm, n, c,  :w)
     wr = var(pm, n, c, :wr)

--- a/src/form/act.jl
+++ b/src/form/act.jl
@@ -12,7 +12,7 @@ function variable_voltage(pm::GenericPowerModel{T}; kwargs...) where T <: Abstra
     variable_voltage_product(pm; kwargs...)
 end
 
-function constraint_model_specific(pm::GenericPowerModel{T}, n::Int, c::Int) where T <: StandardACTForm
+function constraint_model_voltage(pm::GenericPowerModel{T}, n::Int, c::Int) where T <: StandardACTForm
     check_missing_keys(var(pm, n, c), [:va,:w,:wr,:wi], T)
 
     t  = var(pm, n, c, :va)

--- a/src/form/bf.jl
+++ b/src/form/bf.jl
@@ -74,6 +74,8 @@ end
 Defines relationship between branch (series) power flow, branch (series) current and node voltage magnitude
 """
 function constraint_model_specific(pm::GenericPowerModel{T}, n::Int, c::Int) where T <: AbstractBFQPForm
+    check_missing_keys(var(pm, n, c), [:p,:q,:w,:cm], T)
+
     p  = var(pm, n, c, :p)
     q  = var(pm, n, c, :q)
     w  = var(pm, n, c, :w)
@@ -94,6 +96,8 @@ end
 Defines relationship between branch (series) power flow, branch (series) current and node voltage magnitude
 """
 function constraint_model_specific(pm::GenericPowerModel{T}, n::Int, c::Int) where T <: AbstractBFConicForm
+    check_missing_keys(var(pm, n, c), [:p,:q,:w,:cm], T)
+
     p  = var(pm, n, c, :p)
     q  = var(pm, n, c, :q)
     w  = var(pm, n, c, :w)

--- a/src/form/bf.jl
+++ b/src/form/bf.jl
@@ -73,7 +73,7 @@ end
 """
 Defines relationship between branch (series) power flow, branch (series) current and node voltage magnitude
 """
-function constraint_model_specific(pm::GenericPowerModel{T}, n::Int, c::Int) where T <: AbstractBFQPForm
+function constraint_model_current(pm::GenericPowerModel{T}, n::Int, c::Int) where T <: AbstractBFQPForm
     check_missing_keys(var(pm, n, c), [:p,:q,:w,:cm], T)
 
     p  = var(pm, n, c, :p)
@@ -95,7 +95,7 @@ end
 """
 Defines relationship between branch (series) power flow, branch (series) current and node voltage magnitude
 """
-function constraint_model_specific(pm::GenericPowerModel{T}, n::Int, c::Int) where T <: AbstractBFConicForm
+function constraint_model_current(pm::GenericPowerModel{T}, n::Int, c::Int) where T <: AbstractBFConicForm
     check_missing_keys(var(pm, n, c), [:p,:q,:w,:cm], T)
 
     p  = var(pm, n, c, :p)

--- a/src/form/dcp.jl
+++ b/src/form/dcp.jl
@@ -13,10 +13,6 @@ function variable_voltage_ne(pm::GenericPowerModel{T}; kwargs...) where T <: Abs
 end
 
 "do nothing, this model does not have complex voltage variables"
-function constraint_model_specific(pm::GenericPowerModel{T}; kwargs...) where T <: AbstractDCPForm
-end
-
-"do nothing, this model does not have complex voltage variables"
 function constraint_voltage_ne(pm::GenericPowerModel{T}; kwargs...) where T <: AbstractDCPForm
 end
 

--- a/src/form/dcp.jl
+++ b/src/form/dcp.jl
@@ -13,7 +13,7 @@ function variable_voltage_ne(pm::GenericPowerModel{T}; kwargs...) where T <: Abs
 end
 
 "do nothing, this model does not have complex voltage variables"
-function constraint_voltage_ne(pm::GenericPowerModel{T}; kwargs...) where T <: AbstractDCPForm
+function constraint_model_voltage_ne(pm::GenericPowerModel{T}; kwargs...) where T <: AbstractDCPForm
 end
 
 "do nothing, this model does not have voltage variables"
@@ -98,7 +98,7 @@ function variable_voltage_on_off(pm::GenericPowerModel{T}; kwargs...) where T <:
 end
 
 "do nothing, this model does not have complex voltage variables"
-function constraint_voltage_on_off(pm::GenericPowerModel{T}; kwargs...) where T <: AbstractDCPForm
+function constraint_model_voltage_on_off(pm::GenericPowerModel{T}; kwargs...) where T <: AbstractDCPForm
 end
 
 "`-b*(t[f_bus] - t[t_bus] + vad_min*(1-branch_z[i])) <= p[f_idx] <= -b*(t[f_bus] - t[t_bus] + vad_max*(1-branch_z[i]))`"

--- a/src/form/dcp.jl
+++ b/src/form/dcp.jl
@@ -13,7 +13,7 @@ function variable_voltage_ne(pm::GenericPowerModel{T}; kwargs...) where T <: Abs
 end
 
 "do nothing, this model does not have complex voltage variables"
-function constraint_voltage(pm::GenericPowerModel{T}; kwargs...) where T <: AbstractDCPForm
+function constraint_model_specific(pm::GenericPowerModel{T}; kwargs...) where T <: AbstractDCPForm
 end
 
 "do nothing, this model does not have complex voltage variables"

--- a/src/form/lpac.jl
+++ b/src/form/lpac.jl
@@ -27,6 +27,8 @@ end
 
 ""
 function constraint_model_specific(pm::GenericPowerModel{T}, n::Int, c::Int) where T <: AbstractLPACForm
+    check_missing_keys(var(pm, n, c), [:va,:cs], T)
+
     t = var(pm, n, c, :va)
     cs = var(pm, n, c, :cs)
 

--- a/src/form/lpac.jl
+++ b/src/form/lpac.jl
@@ -26,7 +26,7 @@ function variable_voltage_magnitude(pm::GenericPowerModel{T}; nw::Int=pm.cnw, cn
 end
 
 ""
-function constraint_model_specific(pm::GenericPowerModel{T}, n::Int, c::Int) where T <: AbstractLPACForm
+function constraint_model_voltage(pm::GenericPowerModel{T}, n::Int, c::Int) where T <: AbstractLPACForm
     check_missing_keys(var(pm, n, c), [:va,:cs], T)
 
     t = var(pm, n, c, :va)

--- a/src/form/lpac.jl
+++ b/src/form/lpac.jl
@@ -26,7 +26,7 @@ function variable_voltage_magnitude(pm::GenericPowerModel{T}; nw::Int=pm.cnw, cn
 end
 
 ""
-function constraint_voltage(pm::GenericPowerModel{T}, n::Int, c::Int) where T <: AbstractLPACForm
+function constraint_model_specific(pm::GenericPowerModel{T}, n::Int, c::Int) where T <: AbstractLPACForm
     t = var(pm, n, c, :va)
     cs = var(pm, n, c, :cs)
 

--- a/src/form/wr.jl
+++ b/src/form/wr.jl
@@ -14,7 +14,7 @@ function variable_voltage(pm::GenericPowerModel{T}; kwargs...) where T <: Abstra
 end
 
 ""
-function constraint_voltage(pm::GenericPowerModel{T}, n::Int, c::Int) where T <: AbstractWRForm
+function constraint_model_specific(pm::GenericPowerModel{T}, n::Int, c::Int) where T <: AbstractWRForm
     w  = var(pm, n, c,  :w)
     wr = var(pm, n, c, :wr)
     wi = var(pm, n, c, :wi)
@@ -25,7 +25,7 @@ function constraint_voltage(pm::GenericPowerModel{T}, n::Int, c::Int) where T <:
 end
 
 ""
-function constraint_voltage(pm::GenericPowerModel{T}, n::Int, c::Int) where T <: AbstractWRConicForm
+function constraint_model_specific(pm::GenericPowerModel{T}, n::Int, c::Int) where T <: AbstractWRConicForm
     w  = var(pm, n, c,  :w)
     wr = var(pm, n, c, :wr)
     wi = var(pm, n, c, :wi)
@@ -382,7 +382,7 @@ function variable_voltage(pm::GenericPowerModel{T}; kwargs...) where T <: QCWRFo
 end
 
 ""
-function constraint_voltage(pm::GenericPowerModel{T}, n::Int, c::Int) where T <: QCWRForm
+function constraint_model_specific(pm::GenericPowerModel{T}, n::Int, c::Int) where T <: QCWRForm
     v = var(pm, n, c, :vm)
     t = var(pm, n, c, :va)
 
@@ -704,7 +704,7 @@ function variable_voltage_magnitude_product(pm::GenericPowerModel{T}; nw::Int=pm
 end
 
 "creates lambda variables for convex combination model"
-function variable_multipliers(pm::GenericPowerModel{T}; nw::Int=pm.cnw, cnd::Int=pm.ccnd) where T <: QCWRTriForm
+function variable_voltage_magnitude_product_multipliers(pm::GenericPowerModel{T}; nw::Int=pm.cnw, cnd::Int=pm.ccnd) where T <: QCWRTriForm
     var(pm, nw, cnd)[:lambda_wr] = JuMP.@variable(pm.model,
         [bp in ids(pm, nw, :buspairs), i=1:8], base_name="$(nw)_$(cnd)_lambda",
         lower_bound = 0, upper_bound = 1, start = 0.0)
@@ -724,7 +724,7 @@ function variable_voltage(pm::GenericPowerModel{T}; kwargs...) where T <: QCWRTr
 
     variable_voltage_angle_difference(pm; kwargs...)
     variable_voltage_magnitude_product(pm; kwargs...)
-    variable_multipliers(pm; kwargs...)
+    variable_voltage_magnitude_product_multipliers(pm; kwargs...)
     variable_cosine(pm; kwargs...)
     variable_sine(pm; kwargs...)
     variable_current_magnitude_sqr(pm; kwargs...)
@@ -754,7 +754,7 @@ function relaxation_tighten_vv(m, x, y, lambda_a, lambda_b)
 end
 
 ""
-function constraint_voltage(pm::GenericPowerModel{T}, n::Int, c::Int) where T <: QCWRTriForm
+function constraint_model_specific(pm::GenericPowerModel{T}, n::Int, c::Int) where T <: QCWRTriForm
     v = var(pm, n, c, :vm)
     t = var(pm, n, c, :va)
 

--- a/src/form/wr.jl
+++ b/src/form/wr.jl
@@ -15,6 +15,8 @@ end
 
 ""
 function constraint_model_specific(pm::GenericPowerModel{T}, n::Int, c::Int) where T <: AbstractWRForm
+    check_missing_keys(var(pm, n, c), [:w,:wr,:wi], T)
+
     w  = var(pm, n, c,  :w)
     wr = var(pm, n, c, :wr)
     wi = var(pm, n, c, :wi)
@@ -26,6 +28,8 @@ end
 
 ""
 function constraint_model_specific(pm::GenericPowerModel{T}, n::Int, c::Int) where T <: AbstractWRConicForm
+    check_missing_keys(var(pm, n, c), [:w,:wr,:wi], T)
+
     w  = var(pm, n, c,  :w)
     wr = var(pm, n, c, :wr)
     wi = var(pm, n, c, :wi)
@@ -383,6 +387,8 @@ end
 
 ""
 function constraint_model_specific(pm::GenericPowerModel{T}, n::Int, c::Int) where T <: QCWRForm
+    check_missing_keys(var(pm, n, c), [:vm,:va,:td,:si,:cs,:vv,:w,:wr,:wi], T)
+
     v = var(pm, n, c, :vm)
     t = var(pm, n, c, :va)
 
@@ -755,6 +761,8 @@ end
 
 ""
 function constraint_model_specific(pm::GenericPowerModel{T}, n::Int, c::Int) where T <: QCWRTriForm
+    check_missing_keys(var(pm, n, c), [:vm,:va,:td,:si,:cs,:w,:wr,:wi,:lambda_wr,:lambda_wi], T)
+
     v = var(pm, n, c, :vm)
     t = var(pm, n, c, :va)
 

--- a/src/form/wr.jl
+++ b/src/form/wr.jl
@@ -14,7 +14,7 @@ function variable_voltage(pm::GenericPowerModel{T}; kwargs...) where T <: Abstra
 end
 
 ""
-function constraint_model_specific(pm::GenericPowerModel{T}, n::Int, c::Int) where T <: AbstractWRForm
+function constraint_model_voltage(pm::GenericPowerModel{T}, n::Int, c::Int) where T <: AbstractWRForm
     check_missing_keys(var(pm, n, c), [:w,:wr,:wi], T)
 
     w  = var(pm, n, c,  :w)
@@ -27,7 +27,7 @@ function constraint_model_specific(pm::GenericPowerModel{T}, n::Int, c::Int) whe
 end
 
 ""
-function constraint_model_specific(pm::GenericPowerModel{T}, n::Int, c::Int) where T <: AbstractWRConicForm
+function constraint_model_voltage(pm::GenericPowerModel{T}, n::Int, c::Int) where T <: AbstractWRConicForm
     check_missing_keys(var(pm, n, c), [:w,:wr,:wi], T)
 
     w  = var(pm, n, c,  :w)
@@ -87,7 +87,7 @@ function variable_voltage_on_off(pm::GenericPowerModel{T}; kwargs...) where T <:
 end
 
 ""
-function constraint_voltage_on_off(pm::GenericPowerModel{T}, n::Int, c::Int) where T <: AbstractWRForm
+function constraint_model_voltage_on_off(pm::GenericPowerModel{T}, n::Int, c::Int) where T <: AbstractWRForm
     w  = var(pm, n, c, :w)
     wr = var(pm, n, c, :wr)
     wi = var(pm, n, c, :wi)
@@ -108,7 +108,7 @@ function constraint_voltage_on_off(pm::GenericPowerModel{T}, n::Int, c::Int) whe
 end
 
 ""
-function constraint_voltage_ne(pm::GenericPowerModel{T}, n::Int, c::Int) where T <: AbstractWRForm
+function constraint_model_voltage_ne(pm::GenericPowerModel{T}, n::Int, c::Int) where T <: AbstractWRForm
     buses = ref(pm, n, :bus)
     branches = ref(pm, n, :ne_branch)
 
@@ -386,7 +386,7 @@ function variable_voltage(pm::GenericPowerModel{T}; kwargs...) where T <: QCWRFo
 end
 
 ""
-function constraint_model_specific(pm::GenericPowerModel{T}, n::Int, c::Int) where T <: QCWRForm
+function constraint_model_voltage(pm::GenericPowerModel{T}, n::Int, c::Int) where T <: QCWRForm
     check_missing_keys(var(pm, n, c), [:vm,:va,:td,:si,:cs,:vv,:w,:wr,:wi], T)
 
     v = var(pm, n, c, :vm)
@@ -604,7 +604,7 @@ end
 
 
 ""
-function constraint_voltage_on_off(pm::GenericPowerModel{T}, n::Int, c::Int) where T <: QCWRForm
+function constraint_model_voltage_on_off(pm::GenericPowerModel{T}, n::Int, c::Int) where T <: QCWRForm
     v = var(pm, n, c, :vm)
     t = var(pm, n, c, :va)
     vm_fr = var(pm, n, c, :vm_fr)
@@ -760,7 +760,7 @@ function relaxation_tighten_vv(m, x, y, lambda_a, lambda_b)
 end
 
 ""
-function constraint_model_specific(pm::GenericPowerModel{T}, n::Int, c::Int) where T <: QCWRTriForm
+function constraint_model_voltage(pm::GenericPowerModel{T}, n::Int, c::Int) where T <: QCWRTriForm
     check_missing_keys(var(pm, n, c), [:vm,:va,:td,:si,:cs,:w,:wr,:wi,:lambda_wr,:lambda_wi], T)
 
     v = var(pm, n, c, :vm)
@@ -788,7 +788,7 @@ function constraint_model_specific(pm::GenericPowerModel{T}, n::Int, c::Int) whe
         relaxation_cos(pm.model, td[bp], cs[bp])
         InfrastructureModels.relaxation_trilinear(pm.model, v[i], v[j], cs[bp], wr[bp], lambda_wr[bp,:])
         InfrastructureModels.relaxation_trilinear(pm.model, v[i], v[j], si[bp], wi[bp], lambda_wi[bp,:])
-		relaxation_tighten_vv(pm.model, v[i], v[j], lambda_wr[bp,:], lambda_wi[bp,:])
+        relaxation_tighten_vv(pm.model, v[i], v[j], lambda_wr[bp,:], lambda_wi[bp,:])
 
         # this constraint is redudant and useful for debugging
         #InfrastructureModels.relaxation_complex_product(pm.model, w[i], w[j], wr[bp], wi[bp])

--- a/src/form/wrm.jl
+++ b/src/form/wrm.jl
@@ -22,9 +22,11 @@ end
 
 
 ""
-function constraint_model_specific(pm::GenericPowerModel{T}, nw::Int, cnd::Int) where T <: SDPWRMForm
-    WR = var(pm, nw, cnd)[:WR]
-    WI = var(pm, nw, cnd)[:WI]
+function constraint_model_specific(pm::GenericPowerModel{T}, n::Int, c::Int) where T <: SDPWRMForm
+    check_missing_keys(var(pm, n, c), [:WR,:WI], T)
+
+    WR = var(pm, n, c)[:WR]
+    WI = var(pm, n, c)[:WI]
 
     JuMP.@constraint(pm.model, [WR WI; -WI WR] in JuMP.PSDCone())
 end
@@ -212,15 +214,19 @@ function variable_voltage(pm::GenericPowerModel{T}; nw::Int=pm.cnw, cnd::Int=pm.
 end
 
 
-function constraint_model_specific(pm::GenericPowerModel{T}, nw::Int, cnd::Int) where T <: SparseSDPWRMForm
+function constraint_model_specific(pm::GenericPowerModel{T}, n::Int, c::Int) where T <: SparseSDPWRMForm
+    check_missing_keys(var(pm, n, c), [:voltage_product_groups], T)
+
     pair_matrix(group) = [(i, j) for i in group, j in group]
 
     decomp = pm.ext[:SDconstraintDecomposition]
     groups = decomp.decomp
-    voltage_product_groups = var(pm, nw, cnd)[:voltage_product_groups]
+    voltage_product_groups = var(pm, n, c)[:voltage_product_groups]
 
     # semidefinite constraint for each group in clique grouping
     for (gidx, voltage_product_group) in enumerate(voltage_product_groups)
+        check_missing_keys(voltage_product_group, [:WR,:WI], T)
+
         group = groups[gidx]
         ng = length(group)
         WR = voltage_product_group[:WR]

--- a/src/form/wrm.jl
+++ b/src/form/wrm.jl
@@ -22,7 +22,7 @@ end
 
 
 ""
-function constraint_voltage(pm::GenericPowerModel{T}, nw::Int, cnd::Int) where T <: SDPWRMForm
+function constraint_model_specific(pm::GenericPowerModel{T}, nw::Int, cnd::Int) where T <: SDPWRMForm
     WR = var(pm, nw, cnd)[:WR]
     WI = var(pm, nw, cnd)[:WI]
 
@@ -212,7 +212,7 @@ function variable_voltage(pm::GenericPowerModel{T}; nw::Int=pm.cnw, cnd::Int=pm.
 end
 
 
-function constraint_voltage(pm::GenericPowerModel{T}, nw::Int, cnd::Int) where T <: SparseSDPWRMForm
+function constraint_model_specific(pm::GenericPowerModel{T}, nw::Int, cnd::Int) where T <: SparseSDPWRMForm
     pair_matrix(group) = [(i, j) for i in group, j in group]
 
     decomp = pm.ext[:SDconstraintDecomposition]

--- a/src/form/wrm.jl
+++ b/src/form/wrm.jl
@@ -22,7 +22,7 @@ end
 
 
 ""
-function constraint_model_specific(pm::GenericPowerModel{T}, n::Int, c::Int) where T <: SDPWRMForm
+function constraint_model_voltage(pm::GenericPowerModel{T}, n::Int, c::Int) where T <: SDPWRMForm
     check_missing_keys(var(pm, n, c), [:WR,:WI], T)
 
     WR = var(pm, n, c)[:WR]
@@ -214,7 +214,7 @@ function variable_voltage(pm::GenericPowerModel{T}; nw::Int=pm.cnw, cnd::Int=pm.
 end
 
 
-function constraint_model_specific(pm::GenericPowerModel{T}, n::Int, c::Int) where T <: SparseSDPWRMForm
+function constraint_model_voltage(pm::GenericPowerModel{T}, n::Int, c::Int) where T <: SparseSDPWRMForm
     check_missing_keys(var(pm, n, c), [:voltage_product_groups], T)
 
     pair_matrix(group) = [(i, j) for i in group, j in group]

--- a/src/prob/opf.jl
+++ b/src/prob/opf.jl
@@ -24,7 +24,7 @@ function post_opf(pm::GenericPowerModel)
 
     objective_min_fuel_and_flow_cost(pm)
 
-    constraint_model_specific(pm)
+    constraint_model_voltage(pm)
 
     for i in ids(pm, :ref_buses)
         constraint_theta_ref(pm, i)

--- a/src/prob/opf.jl
+++ b/src/prob/opf.jl
@@ -24,7 +24,7 @@ function post_opf(pm::GenericPowerModel)
 
     objective_min_fuel_and_flow_cost(pm)
 
-    constraint_voltage(pm)
+    constraint_model_specific(pm)
 
     for i in ids(pm, :ref_buses)
         constraint_theta_ref(pm, i)

--- a/src/prob/opf_bf.jl
+++ b/src/prob/opf_bf.jl
@@ -1,13 +1,8 @@
 export run_opf_bf, run_ac_opf_bf, run_dc_opf_bf
 
 ""
-function run_opf_bf(file, model_constructor::Type{GenericPowerModel{T}}, optimizer; kwargs...) where T <: AbstractBFForm
-    return run_generic_model(file, model_constructor, optimizer, post_opf_bf; kwargs...)
-end
-
-""
 function run_opf_bf(file, model_constructor, optimizer; kwargs...)
-    Memento.error(LOGGER, "The problem type opf_bf at the moment only supports subtypes of AbstractBFForm")
+    return run_generic_model(file, model_constructor, optimizer, post_opf_bf; kwargs...)
 end
 
 ""

--- a/src/prob/opf_bf.jl
+++ b/src/prob/opf_bf.jl
@@ -15,7 +15,7 @@ function post_opf_bf(pm::GenericPowerModel)
 
     objective_min_fuel_and_flow_cost(pm)
 
-    constraint_model_specific(pm)
+    constraint_model_current(pm)
 
     for i in ids(pm, :ref_buses)
         constraint_theta_ref(pm, i)

--- a/src/prob/opf_bf.jl
+++ b/src/prob/opf_bf.jl
@@ -20,6 +20,8 @@ function post_opf_bf(pm::GenericPowerModel)
 
     objective_min_fuel_and_flow_cost(pm)
 
+    constraint_model_specific(pm)
+
     for i in ids(pm, :ref_buses)
         constraint_theta_ref(pm, i)
     end
@@ -31,7 +33,6 @@ function post_opf_bf(pm::GenericPowerModel)
     for i in ids(pm, :branch)
         constraint_flow_losses(pm, i)
         constraint_voltage_magnitude_difference(pm, i)
-        constraint_branch_current(pm, i)
 
         constraint_voltage_angle_difference(pm, i)
 

--- a/src/prob/ots.jl
+++ b/src/prob/ots.jl
@@ -21,7 +21,7 @@ function post_ots(pm::GenericPowerModel)
 
     objective_min_fuel_and_flow_cost(pm)
 
-    constraint_voltage_on_off(pm)
+    constraint_model_voltage_on_off(pm)
 
     for i in ids(pm, :ref_buses)
         constraint_theta_ref(pm, i)

--- a/src/prob/pf.jl
+++ b/src/prob/pf.jl
@@ -22,7 +22,7 @@ function post_pf(pm::GenericPowerModel)
     variable_branch_flow(pm, bounded = false)
     variable_dcline_flow(pm, bounded = false)
 
-    constraint_model_specific(pm)
+    constraint_model_voltage(pm)
 
     for (i,bus) in ref(pm, :ref_buses)
         @assert bus["bus_type"] == 3

--- a/src/prob/pf.jl
+++ b/src/prob/pf.jl
@@ -22,7 +22,7 @@ function post_pf(pm::GenericPowerModel)
     variable_branch_flow(pm, bounded = false)
     variable_dcline_flow(pm, bounded = false)
 
-    constraint_voltage(pm)
+    constraint_model_specific(pm)
 
     for (i,bus) in ref(pm, :ref_buses)
         @assert bus["bus_type"] == 3

--- a/src/prob/pf_bf.jl
+++ b/src/prob/pf_bf.jl
@@ -13,7 +13,7 @@ function post_pf_bf(pm::GenericPowerModel)
     variable_branch_current(pm, bounded = false)
     variable_dcline_flow(pm, bounded = false)
 
-    constraint_model_specific(pm)
+    constraint_model_current(pm)
 
     for (i,bus) in ref(pm, :ref_buses)
         @assert bus["bus_type"] == 3

--- a/src/prob/pf_bf.jl
+++ b/src/prob/pf_bf.jl
@@ -2,9 +2,6 @@ export run_pf_bf, run_ac_pf_bf, run_dc_pf_bf
 
 ""
 function run_pf_bf(file, model_constructor, optimizer; kwargs...)
-    if model_constructor != SOCBFPowerModel
-        Memento.error(LOGGER, "The problem type pf_bf at the moment only supports the SOCBFForm formulation")
-    end
     return run_generic_model(file, model_constructor, optimizer, post_pf_bf; kwargs...)
 end
 

--- a/src/prob/pf_bf.jl
+++ b/src/prob/pf_bf.jl
@@ -16,6 +16,8 @@ function post_pf_bf(pm::GenericPowerModel)
     variable_branch_current(pm, bounded = false)
     variable_dcline_flow(pm, bounded = false)
 
+    constraint_model_specific(pm)
+
     for (i,bus) in ref(pm, :ref_buses)
         @assert bus["bus_type"] == 3
         constraint_theta_ref(pm, i)
@@ -40,7 +42,6 @@ function post_pf_bf(pm::GenericPowerModel)
     for i in ids(pm, :branch)
         constraint_flow_losses(pm, i)
         constraint_voltage_magnitude_difference(pm, i)
-        constraint_branch_current(pm, i)
     end
 
     for (i,dcline) in ref(pm, :dcline)

--- a/src/prob/test.jl
+++ b/src/prob/test.jl
@@ -20,7 +20,7 @@ function post_cl_opf(pm::GenericPowerModel)
 
     objective_min_fuel_and_flow_cost(pm)
 
-    constraint_voltage(pm)
+    constraint_model_specific(pm)
 
     for i in ids(pm, :ref_buses)
         constraint_theta_ref(pm, i)
@@ -62,7 +62,7 @@ function post_uc_opf(pm::GenericPowerModel)
 
     objective_min_fuel_and_flow_cost(pm)
 
-    constraint_voltage(pm)
+    constraint_model_specific(pm)
 
     for i in ids(pm, :ref_buses)
         constraint_theta_ref(pm, i)
@@ -110,7 +110,7 @@ function post_uc_mc_opf(pm::GenericPowerModel)
         variable_branch_flow(pm, cnd=c)
         variable_dcline_flow(pm, cnd=c)
 
-        constraint_voltage(pm, cnd=c)
+        constraint_model_specific(pm, cnd=c)
 
         for i in ids(pm, :ref_buses)
             constraint_theta_ref(pm, i, cnd=c)
@@ -188,7 +188,7 @@ function post_mn_opf(pm::GenericPowerModel)
         variable_branch_flow(pm, nw=n)
         variable_dcline_flow(pm, nw=n)
 
-        constraint_voltage(pm, nw=n)
+        constraint_model_specific(pm, nw=n)
 
         for i in ids(pm, :ref_buses, nw=n)
             constraint_theta_ref(pm, i, nw=n)
@@ -229,7 +229,7 @@ function post_mn_pf(pm::GenericPowerModel)
         variable_branch_flow(pm, nw=n, bounded = false)
         variable_dcline_flow(pm, nw=n, bounded = false)
 
-        constraint_voltage(pm, nw=n)
+        constraint_model_specific(pm, nw=n)
 
         for i in ids(pm, :ref_buses, nw=n)
             constraint_theta_ref(pm, i, nw=n)
@@ -286,7 +286,7 @@ function post_mc_opf(pm::GenericPowerModel)
         variable_branch_flow(pm, cnd=c)
         variable_dcline_flow(pm, cnd=c)
 
-        constraint_voltage(pm, cnd=c)
+        constraint_model_specific(pm, cnd=c)
 
         for i in ids(pm, :ref_buses)
             constraint_theta_ref(pm, i, cnd=c)
@@ -330,7 +330,7 @@ function post_mn_mc_opf(pm::GenericPowerModel)
             variable_branch_flow(pm, nw=n, cnd=c)
             variable_dcline_flow(pm, nw=n, cnd=c)
 
-            constraint_voltage(pm, nw=n, cnd=c)
+            constraint_model_specific(pm, nw=n, cnd=c)
 
             for i in ids(pm, :ref_buses, nw=n)
                 constraint_theta_ref(pm, i, nw=n, cnd=c)
@@ -376,7 +376,7 @@ function post_strg_opf(pm::GenericPowerModel)
 
     objective_min_fuel_and_flow_cost(pm)
 
-    constraint_voltage(pm)
+    constraint_model_specific(pm)
 
     for i in ids(pm, :ref_buses)
         constraint_theta_ref(pm, i)
@@ -423,7 +423,7 @@ function post_mn_strg_opf(pm::GenericPowerModel)
         variable_branch_flow(pm, nw=n)
         variable_dcline_flow(pm, nw=n)
 
-        constraint_voltage(pm, nw=n)
+        constraint_model_specific(pm, nw=n)
 
         for i in ids(pm, :ref_buses, nw=n)
             constraint_theta_ref(pm, i, nw=n)
@@ -492,7 +492,7 @@ function post_mn_mc_strg_opf(pm::GenericPowerModel)
             variable_branch_flow(pm, nw=n, cnd=c)
             variable_dcline_flow(pm, nw=n, cnd=c)
 
-            constraint_voltage(pm, nw=n, cnd=c)
+            constraint_model_specific(pm, nw=n, cnd=c)
 
             for i in ids(pm, :ref_buses, nw=n)
                 constraint_theta_ref(pm, i, nw=n, cnd=c)

--- a/src/prob/test.jl
+++ b/src/prob/test.jl
@@ -20,7 +20,7 @@ function post_cl_opf(pm::GenericPowerModel)
 
     objective_min_fuel_and_flow_cost(pm)
 
-    constraint_model_specific(pm)
+    constraint_model_voltage(pm)
 
     for i in ids(pm, :ref_buses)
         constraint_theta_ref(pm, i)
@@ -62,7 +62,7 @@ function post_uc_opf(pm::GenericPowerModel)
 
     objective_min_fuel_and_flow_cost(pm)
 
-    constraint_model_specific(pm)
+    constraint_model_voltage(pm)
 
     for i in ids(pm, :ref_buses)
         constraint_theta_ref(pm, i)
@@ -110,7 +110,7 @@ function post_uc_mc_opf(pm::GenericPowerModel)
         variable_branch_flow(pm, cnd=c)
         variable_dcline_flow(pm, cnd=c)
 
-        constraint_model_specific(pm, cnd=c)
+        constraint_model_voltage(pm, cnd=c)
 
         for i in ids(pm, :ref_buses)
             constraint_theta_ref(pm, i, cnd=c)
@@ -188,7 +188,7 @@ function post_mn_opf(pm::GenericPowerModel)
         variable_branch_flow(pm, nw=n)
         variable_dcline_flow(pm, nw=n)
 
-        constraint_model_specific(pm, nw=n)
+        constraint_model_voltage(pm, nw=n)
 
         for i in ids(pm, :ref_buses, nw=n)
             constraint_theta_ref(pm, i, nw=n)
@@ -229,7 +229,7 @@ function post_mn_pf(pm::GenericPowerModel)
         variable_branch_flow(pm, nw=n, bounded = false)
         variable_dcline_flow(pm, nw=n, bounded = false)
 
-        constraint_model_specific(pm, nw=n)
+        constraint_model_voltage(pm, nw=n)
 
         for i in ids(pm, :ref_buses, nw=n)
             constraint_theta_ref(pm, i, nw=n)
@@ -286,7 +286,7 @@ function post_mc_opf(pm::GenericPowerModel)
         variable_branch_flow(pm, cnd=c)
         variable_dcline_flow(pm, cnd=c)
 
-        constraint_model_specific(pm, cnd=c)
+        constraint_model_voltage(pm, cnd=c)
 
         for i in ids(pm, :ref_buses)
             constraint_theta_ref(pm, i, cnd=c)
@@ -330,7 +330,7 @@ function post_mn_mc_opf(pm::GenericPowerModel)
             variable_branch_flow(pm, nw=n, cnd=c)
             variable_dcline_flow(pm, nw=n, cnd=c)
 
-            constraint_model_specific(pm, nw=n, cnd=c)
+            constraint_model_voltage(pm, nw=n, cnd=c)
 
             for i in ids(pm, :ref_buses, nw=n)
                 constraint_theta_ref(pm, i, nw=n, cnd=c)
@@ -376,7 +376,7 @@ function post_strg_opf(pm::GenericPowerModel)
 
     objective_min_fuel_and_flow_cost(pm)
 
-    constraint_model_specific(pm)
+    constraint_model_voltage(pm)
 
     for i in ids(pm, :ref_buses)
         constraint_theta_ref(pm, i)
@@ -423,7 +423,7 @@ function post_mn_strg_opf(pm::GenericPowerModel)
         variable_branch_flow(pm, nw=n)
         variable_dcline_flow(pm, nw=n)
 
-        constraint_model_specific(pm, nw=n)
+        constraint_model_voltage(pm, nw=n)
 
         for i in ids(pm, :ref_buses, nw=n)
             constraint_theta_ref(pm, i, nw=n)
@@ -492,7 +492,7 @@ function post_mn_mc_strg_opf(pm::GenericPowerModel)
             variable_branch_flow(pm, nw=n, cnd=c)
             variable_dcline_flow(pm, nw=n, cnd=c)
 
-            constraint_model_specific(pm, nw=n, cnd=c)
+            constraint_model_voltage(pm, nw=n, cnd=c)
 
             for i in ids(pm, :ref_buses, nw=n)
                 constraint_theta_ref(pm, i, nw=n, cnd=c)

--- a/src/prob/tnep.jl
+++ b/src/prob/tnep.jl
@@ -21,8 +21,8 @@ function post_tnep(pm::GenericPowerModel)
 
     objective_tnep_cost(pm)
 
-    constraint_model_specific(pm)
-    constraint_voltage_ne(pm)
+    constraint_model_voltage(pm)
+    constraint_model_voltage_ne(pm)
 
     for i in ids(pm, :ref_buses)
         constraint_theta_ref(pm, i)

--- a/src/prob/tnep.jl
+++ b/src/prob/tnep.jl
@@ -21,7 +21,7 @@ function post_tnep(pm::GenericPowerModel)
 
     objective_tnep_cost(pm)
 
-    constraint_voltage(pm)
+    constraint_model_specific(pm)
     constraint_voltage_ne(pm)
 
     for i in ids(pm, :ref_buses)

--- a/test/multiconductor.jl
+++ b/test/multiconductor.jl
@@ -10,7 +10,7 @@ function post_tp_opf(pm::PowerModels.GenericPowerModel)
     end
 
     for c in PowerModels.conductor_ids(pm)
-        PowerModels.constraint_model_specific(pm, cnd=c)
+        PowerModels.constraint_model_voltage(pm, cnd=c)
 
         for i in ids(pm, :ref_buses)
             PowerModels.constraint_theta_ref(pm, i, cnd=c)

--- a/test/multiconductor.jl
+++ b/test/multiconductor.jl
@@ -10,7 +10,7 @@ function post_tp_opf(pm::PowerModels.GenericPowerModel)
     end
 
     for c in PowerModels.conductor_ids(pm)
-        PowerModels.constraint_voltage(pm, cnd=c)
+        PowerModels.constraint_model_specific(pm, cnd=c)
 
         for i in ids(pm, :ref_buses)
             PowerModels.constraint_theta_ref(pm, i, cnd=c)

--- a/test/opf-var.jl
+++ b/test/opf-var.jl
@@ -244,7 +244,7 @@ end
 
         PMs.objective_min_fuel_and_flow_cost(pm)
 
-        PMs.constraint_model_specific(pm)
+        PMs.constraint_model_voltage(pm)
 
         for i in ids(pm,:ref_buses)
             PMs.constraint_theta_ref(pm, i)

--- a/test/opf-var.jl
+++ b/test/opf-var.jl
@@ -244,7 +244,7 @@ end
 
         PMs.objective_min_fuel_and_flow_cost(pm)
 
-        PMs.constraint_voltage(pm)
+        PMs.constraint_model_specific(pm)
 
         for i in ids(pm,:ref_buses)
             PMs.constraint_theta_ref(pm, i)


### PR DESCRIPTION
@frederikgeth and @sanderclaeys, this update starts to work toward merging the SOCWR and SOCBF types and address #499.

I have renamed `constraint_voltage` to `constraint_model_voltage` and written some documentation about what its purpose is.  I also added `constraint_model_current` for the BFM formulations.  This constraint plays a similar role to`constraint_model_voltage` but in the BFM space.  For the moment `constraint_model_current` only includes the old `constraint_branch_current` constraint, but other formulations would include more constraints (e.g. the non-convex versions of the BFM that work on cyclic networks).

I also removed the errors of the form "the BFM model only works with ..." in favor of checking for the existence of variables in the `constraint_model_*` implementations.  I think the current error messages are consistent with other PowerModels messages.