### PR TITLE
Branch Status Setpoint Fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ PowerModels.jl Change Log
 
 ### Staged
 - Add check_status to standard data reading checks (#547)
+- Fixed a bug in branch status reporting (#553)
 
 ### v0.12.1
 - Fixed a bug in add_setpoint! in the multiconductor case

--- a/src/core/solution.jl
+++ b/src/core/solution.jl
@@ -135,12 +135,12 @@ end
 
 ""
 function add_setpoint_branch_status!(sol, pm::GenericPowerModel)
-    add_setpoint!(sol, pm, "branch", "br_status", :branch_z, status_name="br_status", default_value = (item) -> 1)
+    add_setpoint!(sol, pm, "branch", "br_status", :branch_z, status_name="br_status", default_value = (item) -> item["br_status"]*1.0)
 end
 
 ""
 function add_setpoint_dcline_status!(sol, pm::GenericPowerModel)
-    add_setpoint!(sol, pm, "dcline", "br_status", :dcline_z, status_name="br_status", default_value = (item) -> 1)
+    add_setpoint!(sol, pm, "dcline", "br_status", :dcline_z, status_name="br_status", default_value = (item) -> item["br_status"]*1.0)
 end
 
 


### PR DESCRIPTION
@noahrhodes, this should address #553.  

However, the issue you reported was not captured by any test, which means the problem could possibly crop up later.  Could you make a PR for a suitable test?  Most likely the issue can be elicited by running the OTS model on a network with at least one inactive branch and then checking the status value of that branch in the solution.