### PR TITLE
FIX: constraint_voltage_angle_difference <: AbstractBFForm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ PowerModels.jl Change Log
 - Add pwl objective variable functions
 - Add check_status to standard data reading checks (#547)
 - Fixed a bug in branch status reporting (#553)
+- Fixed a bug in `AbstractBFForm` version of `constraint_voltage_angle_difference` (#557)
 
 ### v0.12.1
 - Fixed a bug in add_setpoint! in the multiconductor case

--- a/src/form/bf.jl
+++ b/src/form/bf.jl
@@ -120,8 +120,6 @@ function constraint_voltage_angle_difference(pm::GenericPowerModel{T}, n::Int, c
 
     branch = ref(pm, n, :branch, i)
     tm = branch["tap"][c]
-    g, b = calc_branch_y(branch)
-    g, b = g[c,c], b[c,c]
     g_fr = branch["g_fr"][c]
     g_to = branch["g_to"][c]
     b_fr = branch["b_fr"][c]
@@ -130,10 +128,8 @@ function constraint_voltage_angle_difference(pm::GenericPowerModel{T}, n::Int, c
     tr, ti = calc_branch_t(branch)
     tr, ti = tr[c], ti[c]
 
-    # convert series admittance to impedance
-    z = 1/(g + im*b)
-    r = real(z)
-    x = imag(z)
+    r = branch["br_r"][c,c]
+    x = branch["br_x"][c,c]
 
     # getting the variables
     w_fr = var(pm, n, c, :w, f_bus)

--- a/test/opf.jl
+++ b/test/opf.jl
@@ -590,6 +590,12 @@ end
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 70690.7; atol = 1e0)
     end
+    @testset "3-bus case w/ r,x=0 on branch" begin
+        mp_data = PowerModels.parse_file("../test/data/matpower/case3.m")
+        mp_data["branch"]["1"]["br_r"] = mp_data["branch"]["1"]["br_x"] = 0.0
+        result = run_opf_bf(mp_data, SOCBFPowerModel, ipopt_solver)
+        @test result["termination_status"] == LOCALLY_SOLVED
+    end
 end
 
 @testset "test soc conic distflow opf_bf" begin


### PR DESCRIPTION
impedance `z` was calculated as `1/(g+im*b)`, which would result in `Inf` if `g` & `b` are zero.

Instead, `r` and `x` can be used directly from the data without using `calc_branch_y` first.

Adds unit test, and updates change log.