### PR TITLE
Generic Power Balance

### DIFF
--- a/src/core/constraint.jl
+++ b/src/core/constraint.jl
@@ -4,6 +4,14 @@
 # for branches flows and bus flow conservation
 ###############################################################################
 
+"checks if a sufficient number of variables exist for the given keys collection"
+function _check_var_keys(vars, keys, var_name, comp_name)
+    if length(vars) < length(keys)
+        error(_LOGGER, "$(var_name) decision variables appear to be missing for $(comp_name) components")
+    end
+end
+
+
 # Generic thermal limit constraint
 "`p[f_idx]^2 + q[f_idx]^2 <= rate_a^2`"
 function constraint_thermal_limit_from(pm::AbstractPowerModel, n::Int, c::Int, f_idx, rate_a)

--- a/src/core/constraint_template.jl
+++ b/src/core/constraint_template.jl
@@ -175,14 +175,23 @@ end
 
 
 ""
-function constraint_power_balance_shunt_ne(pm::AbstractPowerModel, i::Int; nw::Int=pm.cnw, cnd::Int=pm.ccnd)
+function constraint_power_balance_ne(pm::AbstractPowerModel, i::Int; nw::Int=pm.cnw, cnd::Int=pm.ccnd)
+    if !haskey(con(pm, nw, cnd), :kcl_p)
+        con(pm, nw, cnd)[:kcl_p] = Dict{Int,JuMP.ConstraintRef}()
+    end
+    if !haskey(con(pm, nw, cnd), :kcl_q)
+        con(pm, nw, cnd)[:kcl_q] = Dict{Int,JuMP.ConstraintRef}()
+    end
+
     bus = ref(pm, nw, :bus, i)
     bus_arcs = ref(pm, nw, :bus_arcs, i)
     bus_arcs_dc = ref(pm, nw, :bus_arcs_dc, i)
     bus_arcs_ne = ref(pm, nw, :ne_bus_arcs, i)
+    bus_arcs_sw = ref(pm, nw, :bus_arcs_sw, i)
     bus_gens = ref(pm, nw, :bus_gens, i)
     bus_loads = ref(pm, nw, :bus_loads, i)
     bus_shunts = ref(pm, nw, :bus_shunts, i)
+    bus_storage = ref(pm, nw, :bus_storage, i)
 
     bus_pd = Dict(k => ref(pm, nw, :load, k, "pd", cnd) for k in bus_loads)
     bus_qd = Dict(k => ref(pm, nw, :load, k, "qd", cnd) for k in bus_loads)
@@ -190,7 +199,7 @@ function constraint_power_balance_shunt_ne(pm::AbstractPowerModel, i::Int; nw::I
     bus_gs = Dict(k => ref(pm, nw, :shunt, k, "gs", cnd) for k in bus_shunts)
     bus_bs = Dict(k => ref(pm, nw, :shunt, k, "bs", cnd) for k in bus_shunts)
 
-    constraint_power_balance_shunt_ne(pm, nw, cnd, i, bus_arcs, bus_arcs_dc, bus_arcs_ne, bus_gens, bus_pd, bus_qd, bus_gs, bus_bs)
+    constraint_power_balance_ne(pm, nw, cnd, i, bus_arcs, bus_arcs_dc, bus_arcs_sw, bus_arcs_ne, bus_gens, bus_storage, bus_pd, bus_qd, bus_gs, bus_bs)
 end
 
 

--- a/src/core/constraint_template.jl
+++ b/src/core/constraint_template.jl
@@ -147,32 +147,7 @@ end
 ### Bus - KCL Constraints ###
 
 ""
-function constraint_power_balance_shunt(pm::AbstractPowerModel, i::Int; nw::Int=pm.cnw, cnd::Int=pm.ccnd)
-    if !haskey(con(pm, nw, cnd), :kcl_p)
-        con(pm, nw, cnd)[:kcl_p] = Dict{Int,JuMP.ConstraintRef}()
-    end
-    if !haskey(con(pm, nw, cnd), :kcl_q)
-        con(pm, nw, cnd)[:kcl_q] = Dict{Int,JuMP.ConstraintRef}()
-    end
-
-    bus = ref(pm, nw, :bus, i)
-    bus_arcs = ref(pm, nw, :bus_arcs, i)
-    bus_arcs_dc = ref(pm, nw, :bus_arcs_dc, i)
-    bus_gens = ref(pm, nw, :bus_gens, i)
-    bus_loads = ref(pm, nw, :bus_loads, i)
-    bus_shunts = ref(pm, nw, :bus_shunts, i)
-
-    bus_pd = Dict(k => ref(pm, nw, :load, k, "pd", cnd) for k in bus_loads)
-    bus_qd = Dict(k => ref(pm, nw, :load, k, "qd", cnd) for k in bus_loads)
-
-    bus_gs = Dict(k => ref(pm, nw, :shunt, k, "gs", cnd) for k in bus_shunts)
-    bus_bs = Dict(k => ref(pm, nw, :shunt, k, "bs", cnd) for k in bus_shunts)
-
-    constraint_power_balance_shunt(pm, nw, cnd, i, bus_arcs, bus_arcs_dc, bus_gens, bus_pd, bus_qd, bus_gs, bus_bs)
-end
-
-""
-function constraint_power_balance_shunt_switch(pm::AbstractPowerModel, i::Int; nw::Int=pm.cnw, cnd::Int=pm.ccnd)
+function constraint_power_balance(pm::AbstractPowerModel, i::Int; nw::Int=pm.cnw, cnd::Int=pm.ccnd)
     if !haskey(con(pm, nw, cnd), :kcl_p)
         con(pm, nw, cnd)[:kcl_p] = Dict{Int,JuMP.ConstraintRef}()
     end
@@ -187,31 +162,6 @@ function constraint_power_balance_shunt_switch(pm::AbstractPowerModel, i::Int; n
     bus_gens = ref(pm, nw, :bus_gens, i)
     bus_loads = ref(pm, nw, :bus_loads, i)
     bus_shunts = ref(pm, nw, :bus_shunts, i)
-
-    bus_pd = Dict(k => ref(pm, nw, :load, k, "pd", cnd) for k in bus_loads)
-    bus_qd = Dict(k => ref(pm, nw, :load, k, "qd", cnd) for k in bus_loads)
-
-    bus_gs = Dict(k => ref(pm, nw, :shunt, k, "gs", cnd) for k in bus_shunts)
-    bus_bs = Dict(k => ref(pm, nw, :shunt, k, "bs", cnd) for k in bus_shunts)
-
-    constraint_power_balance_shunt_switch(pm, nw, cnd, i, bus_arcs, bus_arcs_dc, bus_arcs_sw, bus_gens, bus_pd, bus_qd, bus_gs, bus_bs)
-end
-
-""
-function constraint_power_balance_shunt_storage(pm::AbstractPowerModel, i::Int; nw::Int=pm.cnw, cnd::Int=pm.ccnd)
-    if !haskey(con(pm, nw, cnd), :kcl_p)
-        con(pm, nw, cnd)[:kcl_p] = Dict{Int,JuMP.ConstraintRef}()
-    end
-    if !haskey(con(pm, nw, cnd), :kcl_q)
-        con(pm, nw, cnd)[:kcl_q] = Dict{Int,JuMP.ConstraintRef}()
-    end
-
-    bus = ref(pm, nw, :bus, i)
-    bus_arcs = ref(pm, nw, :bus_arcs, i)
-    bus_arcs_dc = ref(pm, nw, :bus_arcs_dc, i)
-    bus_gens = ref(pm, nw, :bus_gens, i)
-    bus_loads = ref(pm, nw, :bus_loads, i)
-    bus_shunts = ref(pm, nw, :bus_shunts, i)
     bus_storage = ref(pm, nw, :bus_storage, i)
 
     bus_pd = Dict(k => ref(pm, nw, :load, k, "pd", cnd) for k in bus_loads)
@@ -220,8 +170,9 @@ function constraint_power_balance_shunt_storage(pm::AbstractPowerModel, i::Int; 
     bus_gs = Dict(k => ref(pm, nw, :shunt, k, "gs", cnd) for k in bus_shunts)
     bus_bs = Dict(k => ref(pm, nw, :shunt, k, "bs", cnd) for k in bus_shunts)
 
-    constraint_power_balance_shunt_storage(pm, nw, cnd, i, bus_arcs, bus_arcs_dc, bus_gens, bus_storage, bus_pd, bus_qd, bus_gs, bus_bs)
+    constraint_power_balance(pm, nw, cnd, i, bus_arcs, bus_arcs_dc, bus_arcs_sw, bus_gens, bus_storage, bus_pd, bus_qd, bus_gs, bus_bs)
 end
+
 
 ""
 function constraint_power_balance_shunt_ne(pm::AbstractPowerModel, i::Int; nw::Int=pm.cnw, cnd::Int=pm.ccnd)

--- a/src/form/acp.jl
+++ b/src/form/acp.jl
@@ -39,57 +39,41 @@ function constraint_current_limit(pm::AbstractACPModel, n::Int, c::Int, f_idx, c
 end
 
 
-"""
-```
-sum(p[a] for a in bus_arcs) + sum(p_dc[a_dc] for a_dc in bus_arcs_dc) == sum(pg[g] for g in bus_gens) - sum(pd[d] for d in bus_loads) - sum(gs[s] for s in bus_shunts)*v^2
-sum(q[a] for a in bus_arcs) + sum(q_dc[a_dc] for a_dc in bus_arcs_dc) == sum(qg[g] for g in bus_gens) - sum(qd[d] for d in bus_loads) + sum(bs[s] for s in bus_shunts)*v^2
-```
-"""
-function constraint_power_balance_shunt(pm::AbstractACPModel, n::Int, c::Int, i::Int, bus_arcs, bus_arcs_dc, bus_gens, bus_pd, bus_qd, bus_gs, bus_bs)
-    vm = var(pm, n, c, :vm, i)
-    p = var(pm, n, c, :p)
-    q = var(pm, n, c, :q)
-    pg = var(pm, n, c, :pg)
-    qg = var(pm, n, c, :qg)
-    p_dc = var(pm, n, c, :p_dc)
-    q_dc = var(pm, n, c, :q_dc)
-
-    con(pm, n, c, :kcl_p)[i] = JuMP.@constraint(pm.model, sum(p[a] for a in bus_arcs) + sum(p_dc[a_dc] for a_dc in bus_arcs_dc) == sum(pg[g] for g in bus_gens) - sum(pd for pd in values(bus_pd)) - sum(gs for gs in values(bus_gs))*vm^2)
-    con(pm, n, c, :kcl_q)[i] = JuMP.@constraint(pm.model, sum(q[a] for a in bus_arcs) + sum(q_dc[a_dc] for a_dc in bus_arcs_dc) == sum(qg[g] for g in bus_gens) - sum(qd for qd in values(bus_qd)) + sum(bs for bs in values(bus_bs))*vm^2)
-end
-
-
 ""
-function constraint_power_balance_shunt_switch(pm::AbstractACPModel, n::Int, c::Int, i::Int, bus_arcs, bus_arcs_dc, bus_arcs_sw, bus_gens, bus_pd, bus_qd, bus_gs, bus_bs)
-    vm = var(pm, n, c, :vm, i)
-    p = var(pm, n, c, :p)
-    q = var(pm, n, c, :q)
-    pg = var(pm, n, c, :pg)
-    qg = var(pm, n, c, :qg)
-    psw = var(pm, n, c, :psw)
-    qsw = var(pm, n, c, :qsw)
-    p_dc = var(pm, n, c, :p_dc)
-    q_dc = var(pm, n, c, :q_dc)
-
-    con(pm, n, c, :kcl_p)[i] = JuMP.@constraint(pm.model, sum(p[a] for a in bus_arcs) + sum(p_dc[a_dc] for a_dc in bus_arcs_dc) + sum(psw[a_sw] for a_sw in bus_arcs_sw) == sum(pg[g] for g in bus_gens) - sum(pd for pd in values(bus_pd)) - sum(gs for gs in values(bus_gs))*vm^2)
-    con(pm, n, c, :kcl_q)[i] = JuMP.@constraint(pm.model, sum(q[a] for a in bus_arcs) + sum(q_dc[a_dc] for a_dc in bus_arcs_dc) + sum(qsw[a_sw] for a_sw in bus_arcs_sw) == sum(qg[g] for g in bus_gens) - sum(qd for qd in values(bus_qd)) + sum(bs for bs in values(bus_bs))*vm^2)
-end
+function constraint_power_balance(pm::AbstractACPModel, n::Int, c::Int, i::Int, bus_arcs, bus_arcs_dc, bus_arcs_sw, bus_gens, bus_storage, bus_pd, bus_qd, bus_gs, bus_bs)
+    vm   = var(pm, n, c, :vm, i)
+    p    = get(var(pm, n, c),    :p, Dict()); _check_var_keys(p, bus_arcs, "active power", "branch")
+    q    = get(var(pm, n, c),    :q, Dict()); _check_var_keys(q, bus_arcs, "reactive power", "branch")
+    pg   = get(var(pm, n, c),   :pg, Dict()); _check_var_keys(pg, bus_gens, "active power", "generator")
+    qg   = get(var(pm, n, c),   :qg, Dict()); _check_var_keys(qg, bus_gens, "reactive power", "generator")
+    ps   = get(var(pm, n, c),   :ps, Dict()); _check_var_keys(ps, bus_storage, "active power", "storage")
+    qs   = get(var(pm, n, c),   :qs, Dict()); _check_var_keys(qs, bus_storage, "reactive power", "storage")
+    psw  = get(var(pm, n, c),  :psw, Dict()); _check_var_keys(psw, bus_arcs_sw, "active power", "switch")
+    qsw  = get(var(pm, n, c),  :qsw, Dict()); _check_var_keys(qsw, bus_arcs_sw, "reactive power", "switch")
+    p_dc = get(var(pm, n, c), :p_dc, Dict()); _check_var_keys(p_dc, bus_arcs_dc, "active power", "dcline")
+    q_dc = get(var(pm, n, c), :q_dc, Dict()); _check_var_keys(q_dc, bus_arcs_dc, "reactive power", "dcline")
 
 
-""
-function constraint_power_balance_shunt_storage(pm::AbstractACPModel, n::Int, c::Int, i::Int, bus_arcs, bus_arcs_dc, bus_gens, bus_storage, bus_pd, bus_qd, bus_gs, bus_bs)
-    vm = var(pm, n, c, :vm, i)
-    p = var(pm, n, c, :p)
-    q = var(pm, n, c, :q)
-    pg = var(pm, n, c, :pg)
-    qg = var(pm, n, c, :qg)
-    ps = var(pm, n, c, :ps)
-    qs = var(pm, n, c, :qs)
-    p_dc = var(pm, n, c, :p_dc)
-    q_dc = var(pm, n, c, :q_dc)
-
-    con(pm, n, c, :kcl_p)[i] = JuMP.@constraint(pm.model, sum(p[a] for a in bus_arcs) + sum(p_dc[a_dc] for a_dc in bus_arcs_dc) == sum(pg[g] for g in bus_gens) - sum(ps[s] for s in bus_storage) - sum(pd for pd in values(bus_pd)) - sum(gs for gs in values(bus_gs))*vm^2)
-    con(pm, n, c, :kcl_q)[i] = JuMP.@constraint(pm.model, sum(q[a] for a in bus_arcs) + sum(q_dc[a_dc] for a_dc in bus_arcs_dc) == sum(qg[g] for g in bus_gens) - sum(qs[s] for s in bus_storage) - sum(qd for qd in values(bus_qd)) + sum(bs for bs in values(bus_bs))*vm^2)
+    con(pm, n, c, :kcl_p)[i] = JuMP.@constraint(pm.model,
+        sum(p[a] for a in bus_arcs)
+        + sum(p_dc[a_dc] for a_dc in bus_arcs_dc)
+        + sum(psw[a_sw] for a_sw in bus_arcs_sw)
+        ==
+        sum(pg[g] for g in bus_gens)
+        - sum(ps[s] for s in bus_storage)
+        - sum(pd for pd in values(bus_pd))
+        - sum(gs for gs in values(bus_gs))*vm^2
+    )
+    con(pm, n, c, :kcl_q)[i] = JuMP.@constraint(pm.model,
+        sum(q[a] for a in bus_arcs)
+        + sum(q_dc[a_dc] for a_dc in bus_arcs_dc)
+        + sum(qsw[a_sw] for a_sw in bus_arcs_sw)
+        ==
+        sum(qg[g] for g in bus_gens)
+        - sum(qs[s] for s in bus_storage)
+        - sum(qd for qd in values(bus_qd))
+        + sum(bs for bs in values(bus_bs))*vm^2
+    )
 end
 
 

--- a/src/form/acp.jl
+++ b/src/form/acp.jl
@@ -77,26 +77,46 @@ function constraint_power_balance(pm::AbstractACPModel, n::Int, c::Int, i::Int, 
 end
 
 
-"""
-```
-sum(p[a] for a in bus_arcs) + sum(p_dc[a_dc] for a_dc in bus_arcs_dc) + sum(p_ne[a] for a in bus_arcs_ne) == sum(pg[g] for g in bus_gens) - sum(pd[d] for d in bus_loads) - sum(gs[s] for s in bus_shunts)*vm^2
-sum(q[a] for a in bus_arcs) + sum(p_dc[a_dc] for a_dc in bus_arcs_dc) + sum(q_ne[a] for a in bus_arcs_ne) == sum(qg[g] for g in bus_gens) - sum(qd[d] for d in bus_loads) + sum(bs[s] for s in bus_shunts)*vm^2
-```
-"""
-function constraint_power_balance_shunt_ne(pm::AbstractACPModel, n::Int, c::Int, i, bus_arcs, bus_arcs_dc, bus_arcs_ne, bus_gens, bus_pd, bus_qd, bus_gs, bus_bs)
+""
+function constraint_power_balance_ne(pm::AbstractACPModel, n::Int, c::Int, i::Int, bus_arcs, bus_arcs_dc, bus_arcs_sw, bus_arcs_ne, bus_gens, bus_storage, bus_pd, bus_qd, bus_gs, bus_bs)
     vm   = var(pm, n, c, :vm, i)
-    p    = var(pm, n, c, :p)
-    q    = var(pm, n, c, :q)
-    p_ne = var(pm, n, c, :p_ne)
-    q_ne = var(pm, n, c, :q_ne)
-    pg   = var(pm, n, c, :pg)
-    qg   = var(pm, n, c, :qg)
-    p_dc = var(pm, n, c, :p_dc)
-    q_dc = var(pm, n, c, :q_dc)
+    p    = get(var(pm, n, c),    :p, Dict()); _check_var_keys(p, bus_arcs, "active power", "branch")
+    q    = get(var(pm, n, c),    :q, Dict()); _check_var_keys(q, bus_arcs, "reactive power", "branch")
+    pg   = get(var(pm, n, c),   :pg, Dict()); _check_var_keys(pg, bus_gens, "active power", "generator")
+    qg   = get(var(pm, n, c),   :qg, Dict()); _check_var_keys(qg, bus_gens, "reactive power", "generator")
+    ps   = get(var(pm, n, c),   :ps, Dict()); _check_var_keys(ps, bus_storage, "active power", "storage")
+    qs   = get(var(pm, n, c),   :qs, Dict()); _check_var_keys(qs, bus_storage, "reactive power", "storage")
+    psw  = get(var(pm, n, c),  :psw, Dict()); _check_var_keys(psw, bus_arcs_sw, "active power", "switch")
+    qsw  = get(var(pm, n, c),  :qsw, Dict()); _check_var_keys(qsw, bus_arcs_sw, "reactive power", "switch")
+    p_dc = get(var(pm, n, c), :p_dc, Dict()); _check_var_keys(p_dc, bus_arcs_dc, "active power", "dcline")
+    q_dc = get(var(pm, n, c), :q_dc, Dict()); _check_var_keys(q_dc, bus_arcs_dc, "reactive power", "dcline")
+    p_ne = get(var(pm, n, c), :p_ne, Dict()); _check_var_keys(p_ne, bus_arcs_ne, "active power", "ne_branch")
+    q_ne = get(var(pm, n, c), :q_ne, Dict()); _check_var_keys(q_ne, bus_arcs_ne, "reactive power", "ne_branch")
 
-    JuMP.@constraint(pm.model, sum(p[a] for a in bus_arcs) + sum(p_dc[a_dc] for a_dc in bus_arcs_dc)  + sum(p_ne[a] for a in bus_arcs_ne) == sum(pg[g] for g in bus_gens) - sum(pd for pd in values(bus_pd)) - sum(gs for gs in values(bus_gs))*vm^2)
-    JuMP.@constraint(pm.model, sum(q[a] for a in bus_arcs) + sum(q_dc[a_dc] for a_dc in bus_arcs_dc)  + sum(q_ne[a] for a in bus_arcs_ne) == sum(qg[g] for g in bus_gens) - sum(qd for qd in values(bus_qd)) + sum(bs for bs in values(bus_bs))*vm^2)
+    con(pm, n, c, :kcl_p)[i] = JuMP.@constraint(pm.model,
+        sum(p[a] for a in bus_arcs)
+        + sum(p_dc[a_dc] for a_dc in bus_arcs_dc)
+        + sum(psw[a_sw] for a_sw in bus_arcs_sw)
+        + sum(p_ne[a] for a in bus_arcs_ne)
+        ==
+        sum(pg[g] for g in bus_gens)
+        - sum(ps[s] for s in bus_storage)
+        - sum(pd for pd in values(bus_pd))
+        - sum(gs for gs in values(bus_gs))*vm^2
+    )
+    con(pm, n, c, :kcl_q)[i] = JuMP.@constraint(pm.model,
+        sum(q[a] for a in bus_arcs)
+        + sum(q_dc[a_dc] for a_dc in bus_arcs_dc)
+        + sum(qsw[a_sw] for a_sw in bus_arcs_sw)
+        + sum(q_ne[a] for a in bus_arcs_ne)
+        ==
+        sum(qg[g] for g in bus_gens)
+        - sum(qs[s] for s in bus_storage)
+        - sum(qd for qd in values(bus_qd))
+        + sum(bs for bs in values(bus_bs))*vm^2
+    )
 end
+
 
 """
 Creates Ohms constraints (yt post fix indicates that Y and T values are in rectangular form)

--- a/src/form/acr.jl
+++ b/src/form/acr.jl
@@ -42,7 +42,7 @@ function constraint_theta_ref(pm::AbstractACRModel, n::Int, c::Int, i::Int)
 end
 
 
-function constraint_power_balance(pm::AbstractACRModel, n::Int, c::Int, i, bus_arcs, bus_arcs_dc, bus_gens, bus_pd, bus_qd, bus_gs, bus_bs)
+function constraint_power_balance(pm::AbstractACRModel, n::Int, c::Int, i::Int, bus_arcs, bus_arcs_dc, bus_arcs_sw, bus_gens, bus_storage, bus_pd, bus_qd, bus_gs, bus_bs)
     vr = var(pm, n, c, :vr, i)
     vi = var(pm, n, c, :vi, i)
     p    = get(var(pm, n, c),    :p, Dict()); _check_var_keys(p, bus_arcs, "active power", "branch")

--- a/src/form/acr.jl
+++ b/src/form/acr.jl
@@ -42,18 +42,41 @@ function constraint_theta_ref(pm::AbstractACRModel, n::Int, c::Int, i::Int)
 end
 
 
-function constraint_power_balance_shunt(pm::AbstractACRModel, n::Int, c::Int, i, bus_arcs, bus_arcs_dc, bus_gens, bus_pd, bus_qd, bus_gs, bus_bs)
+function constraint_power_balance(pm::AbstractACRModel, n::Int, c::Int, i, bus_arcs, bus_arcs_dc, bus_gens, bus_pd, bus_qd, bus_gs, bus_bs)
     vr = var(pm, n, c, :vr, i)
     vi = var(pm, n, c, :vi, i)
-    p  = var(pm, n, c, :p)
-    q  = var(pm, n, c, :q)
-    pg = var(pm, n, c, :pg)
-    qg = var(pm, n, c, :qg)
-    p_dc = var(pm, n, c, :p_dc)
-    q_dc = var(pm, n, c, :q_dc)
+    p    = get(var(pm, n, c),    :p, Dict()); _check_var_keys(p, bus_arcs, "active power", "branch")
+    q    = get(var(pm, n, c),    :q, Dict()); _check_var_keys(q, bus_arcs, "reactive power", "branch")
+    pg   = get(var(pm, n, c),   :pg, Dict()); _check_var_keys(pg, bus_gens, "active power", "generator")
+    qg   = get(var(pm, n, c),   :qg, Dict()); _check_var_keys(qg, bus_gens, "reactive power", "generator")
+    ps   = get(var(pm, n, c),   :ps, Dict()); _check_var_keys(ps, bus_storage, "active power", "storage")
+    qs   = get(var(pm, n, c),   :qs, Dict()); _check_var_keys(qs, bus_storage, "reactive power", "storage")
+    psw  = get(var(pm, n, c),  :psw, Dict()); _check_var_keys(psw, bus_arcs_sw, "active power", "switch")
+    qsw  = get(var(pm, n, c),  :qsw, Dict()); _check_var_keys(qsw, bus_arcs_sw, "reactive power", "switch")
+    p_dc = get(var(pm, n, c), :p_dc, Dict()); _check_var_keys(p_dc, bus_arcs_dc, "active power", "dcline")
+    q_dc = get(var(pm, n, c), :q_dc, Dict()); _check_var_keys(q_dc, bus_arcs_dc, "reactive power", "dcline")
 
-    JuMP.@constraint(pm.model, sum(p[a] for a in bus_arcs) + sum(p_dc[a_dc] for a_dc in bus_arcs_dc) == sum(pg[g] for g in bus_gens) - sum(pd for pd in values(bus_pd)) - sum(gs for gs in values(bus_gs))*(vr^2 + vi^2))
-    JuMP.@constraint(pm.model, sum(q[a] for a in bus_arcs) + sum(q_dc[a_dc] for a_dc in bus_arcs_dc) == sum(qg[g] for g in bus_gens) - sum(qd for qd in values(bus_qd)) + sum(bs for bs in values(bus_bs))*(vr^2 + vi^2))
+
+    con(pm, n, c, :kcl_p)[i] = JuMP.@constraint(pm.model,
+        sum(p[a] for a in bus_arcs)
+        + sum(p_dc[a_dc] for a_dc in bus_arcs_dc)
+        + sum(psw[a_sw] for a_sw in bus_arcs_sw)
+        ==
+        sum(pg[g] for g in bus_gens)
+        - sum(ps[s] for s in bus_storage)
+        - sum(pd for pd in values(bus_pd))
+        - sum(gs for gs in values(bus_gs))*(vr^2 + vi^2)
+    )
+    con(pm, n, c, :kcl_q)[i] = JuMP.@constraint(pm.model,
+        sum(q[a] for a in bus_arcs)
+        + sum(q_dc[a_dc] for a_dc in bus_arcs_dc)
+        + sum(qsw[a_sw] for a_sw in bus_arcs_sw)
+        ==
+        sum(qg[g] for g in bus_gens)
+        - sum(qs[s] for s in bus_storage)
+        - sum(qd for qd in values(bus_qd))
+        + sum(bs for bs in values(bus_bs))*(vr^2 + vi^2)
+    )
 end
 
 

--- a/src/form/apo.jl
+++ b/src/form/apo.jl
@@ -36,6 +36,30 @@ function constraint_generation_on_off(pm::AbstractActivePowerModel, n::Int, c::I
 end
 
 
+
+""
+function constraint_power_balance(pm::AbstractActivePowerModel, n::Int, c::Int, i::Int, bus_arcs, bus_arcs_dc, bus_arcs_sw, bus_gens, bus_storage, bus_pd, bus_qd, bus_gs, bus_bs)
+    p    = get(var(pm, n, c),    :p, Dict()); _check_var_keys(p, bus_arcs, "active power", "branch")
+    pg   = get(var(pm, n, c),   :pg, Dict()); _check_var_keys(pg, bus_gens, "active power", "generator")
+    ps   = get(var(pm, n, c),   :ps, Dict()); _check_var_keys(ps, bus_storage, "active power", "storage")
+    psw  = get(var(pm, n, c),  :psw, Dict()); _check_var_keys(psw, bus_arcs_sw, "active power", "switch")
+    p_dc = get(var(pm, n, c), :p_dc, Dict()); _check_var_keys(p_dc, bus_arcs_dc, "active power", "dcline")
+
+
+    con(pm, n, c, :kcl_p)[i] = JuMP.@constraint(pm.model,
+        sum(p[a] for a in bus_arcs)
+        + sum(p_dc[a_dc] for a_dc in bus_arcs_dc)
+        + sum(psw[a_sw] for a_sw in bus_arcs_sw)
+        ==
+        sum(pg[g] for g in bus_gens)
+        - sum(ps[s] for s in bus_storage)
+        - sum(pd for pd in values(bus_pd))
+        - sum(gs for gs in values(bus_gs))*1.0^2
+    )
+end
+
+
+
 "`-rate_a <= p[f_idx] <= rate_a`"
 function constraint_thermal_limit_from(pm::AbstractActivePowerModel, n::Int, c::Int, f_idx, rate_a)
     p_fr = var(pm, n, c, :p, f_idx)
@@ -99,7 +123,6 @@ end
 
 
 
-
 ""
 function constraint_switch_thermal_limit(pm::AbstractActivePowerModel, n::Int, c::Int, f_idx, rating)
     psw = var(pm, n, c, :psw, f_idx)
@@ -107,7 +130,6 @@ function constraint_switch_thermal_limit(pm::AbstractActivePowerModel, n::Int, c
     JuMP.lower_bound(psw) < -rating && JuMP.set_lower_bound(psw, -rating)
     JuMP.upper_bound(psw) >  rating && JuMP.set_upper_bound(psw,  rating)
 end
-
 
 
 

--- a/src/form/dcp.jl
+++ b/src/form/dcp.jl
@@ -26,16 +26,6 @@ function variable_bus_voltage(pm::AbstractDCPModel; kwargs...)
 end
 
 
-""
-function constraint_power_balance_shunt_ne(pm::AbstractDCPModel, n::Int, c::Int, i, bus_arcs, bus_arcs_dc, bus_arcs_ne, bus_gens, bus_pd, bus_qd, bus_gs, bus_bs)
-    pg   = var(pm, n, c, :pg)
-    p    = var(pm, n, c, :p)
-    p_ne = var(pm, n, c, :p_ne)
-    p_dc = var(pm, n, c, :p_dc)
-
-    JuMP.@constraint(pm.model, sum(p[a] for a in bus_arcs) + sum(p_ne[a] for a in bus_arcs_ne) + sum(p_dc[a_dc] for a_dc in bus_arcs_dc) == sum(pg[g] for g in bus_gens) - sum(pd for pd in values(bus_pd)) - sum(gs for gs in values(bus_gs))*1.0^2)
-end
-
 """
 Creates Ohms constraints (yt post fix indicates that Y and T values are in rectangular form)
 

--- a/src/form/dcp.jl
+++ b/src/form/dcp.jl
@@ -27,38 +27,6 @@ end
 
 
 ""
-function constraint_power_balance_shunt(pm::AbstractDCPModel, n::Int, c::Int, i, bus_arcs, bus_arcs_dc, bus_gens, bus_pd, bus_qd, bus_gs, bus_bs)
-    pg   = var(pm, n, c, :pg)
-    p    = var(pm, n, c, :p)
-    p_dc = var(pm, n, c, :p_dc)
-
-    con(pm, n, c, :kcl_p)[i] = JuMP.@constraint(pm.model, sum(p[a] for a in bus_arcs) + sum(p_dc[a_dc] for a_dc in bus_arcs_dc) == sum(pg[g] for g in bus_gens) - sum(pd for pd in values(bus_pd)) - sum(gs for gs in values(bus_gs))*1.0^2)
-    # omit reactive constraint
-end
-
-""
-function constraint_power_balance_shunt_storage(pm::AbstractDCPModel, n::Int, c::Int, i::Int, bus_arcs, bus_arcs_dc, bus_gens, bus_storage, bus_pd, bus_qd, bus_gs, bus_bs)
-    p = var(pm, n, c, :p)
-    pg = var(pm, n, c, :pg)
-    ps = var(pm, n, c, :ps)
-    p_dc = var(pm, n, c, :p_dc)
-
-    con(pm, n, c, :kcl_p)[i] = JuMP.@constraint(pm.model, sum(p[a] for a in bus_arcs) + sum(p_dc[a_dc] for a_dc in bus_arcs_dc) == sum(pg[g] for g in bus_gens) - sum(ps[s] for s in bus_storage) - sum(pd for pd in values(bus_pd)) - sum(gs for gs in values(bus_gs))*1.0^2)
-    # omit reactive constraint
-end
-
-""
-function constraint_power_balance_shunt_switch(pm::AbstractDCPModel, n::Int, c::Int, i::Int, bus_arcs, bus_arcs_dc, bus_arcs_sw, bus_gens, bus_pd, bus_qd, bus_gs, bus_bs)
-    p = var(pm, n, c, :p)
-    pg = var(pm, n, c, :pg)
-    psw = var(pm, n, c, :psw)
-    p_dc = var(pm, n, c, :p_dc)
-
-    con(pm, n, c, :kcl_p)[i] = JuMP.@constraint(pm.model, sum(p[a] for a in bus_arcs) + sum(p_dc[a_dc] for a_dc in bus_arcs_dc) + sum(psw[a_sw] for a_sw in bus_arcs_sw) == sum(pg[g] for g in bus_gens) - sum(pd for pd in values(bus_pd)) - sum(gs for gs in values(bus_gs))*1.0^2)
-end
-
-
-""
 function constraint_power_balance_shunt_ne(pm::AbstractDCPModel, n::Int, c::Int, i, bus_arcs, bus_arcs_dc, bus_arcs_ne, bus_gens, bus_pd, bus_qd, bus_gs, bus_bs)
     pg   = var(pm, n, c, :pg)
     p    = var(pm, n, c, :p)

--- a/src/form/lpac.jl
+++ b/src/form/lpac.jl
@@ -40,17 +40,40 @@ end
 
 
 ""
-function constraint_power_balance_shunt(pm::AbstractLPACCModel, n::Int, c::Int, i, bus_arcs, bus_arcs_dc, bus_gens, bus_pd, bus_qd, bus_gs, bus_bs)
+function constraint_power_balance(pm::AbstractLPACCModel, n::Int, c::Int, i, bus_arcs, bus_arcs_dc, bus_gens, bus_pd, bus_qd, bus_gs, bus_bs)
     phi  = var(pm, n, c, :phi, i)
-    pg   = var(pm, n, c, :pg)
-    qg   = var(pm, n, c, :qg)
-    p    = var(pm, n, c, :p)
-    q    = var(pm, n, c, :q)
-    p_dc = var(pm, n, c, :p_dc)
-    q_dc = var(pm, n, c, :q_dc)
+    p    = get(var(pm, n, c),    :p, Dict()); _check_var_keys(p, bus_arcs, "active power", "branch")
+    q    = get(var(pm, n, c),    :q, Dict()); _check_var_keys(q, bus_arcs, "reactive power", "branch")
+    pg   = get(var(pm, n, c),   :pg, Dict()); _check_var_keys(pg, bus_gens, "active power", "generator")
+    qg   = get(var(pm, n, c),   :qg, Dict()); _check_var_keys(qg, bus_gens, "reactive power", "generator")
+    ps   = get(var(pm, n, c),   :ps, Dict()); _check_var_keys(ps, bus_storage, "active power", "storage")
+    qs   = get(var(pm, n, c),   :qs, Dict()); _check_var_keys(qs, bus_storage, "reactive power", "storage")
+    psw  = get(var(pm, n, c),  :psw, Dict()); _check_var_keys(psw, bus_arcs_sw, "active power", "switch")
+    qsw  = get(var(pm, n, c),  :qsw, Dict()); _check_var_keys(qsw, bus_arcs_sw, "reactive power", "switch")
+    p_dc = get(var(pm, n, c), :p_dc, Dict()); _check_var_keys(p_dc, bus_arcs_dc, "active power", "dcline")
+    q_dc = get(var(pm, n, c), :q_dc, Dict()); _check_var_keys(q_dc, bus_arcs_dc, "reactive power", "dcline")
 
-    JuMP.@constraint(pm.model, sum(p[a] for a in bus_arcs) + sum(p_dc[a_dc] for a_dc in bus_arcs_dc) == sum(pg[g] for g in bus_gens) - sum(pd for pd in values(bus_pd)) - sum(gs for gs in values(bus_gs))*(1.0 + 2*phi))
-    JuMP.@constraint(pm.model, sum(q[a] for a in bus_arcs) + sum(q_dc[a_dc] for a_dc in bus_arcs_dc) == sum(qg[g] for g in bus_gens) - sum(qd for qd in values(bus_qd)) + sum(bs for bs in values(bus_bs))*(1.0 + 2*phi))
+
+    con(pm, n, c, :kcl_p)[i] = JuMP.@constraint(pm.model,
+        sum(p[a] for a in bus_arcs)
+        + sum(p_dc[a_dc] for a_dc in bus_arcs_dc)
+        + sum(psw[a_sw] for a_sw in bus_arcs_sw)
+        ==
+        sum(pg[g] for g in bus_gens)
+        - sum(ps[s] for s in bus_storage)
+        - sum(pd for pd in values(bus_pd))
+        - sum(gs for gs in values(bus_gs))*(1.0 + 2*phi)
+    )
+    con(pm, n, c, :kcl_q)[i] = JuMP.@constraint(pm.model,
+        sum(q[a] for a in bus_arcs)
+        + sum(q_dc[a_dc] for a_dc in bus_arcs_dc)
+        + sum(qsw[a_sw] for a_sw in bus_arcs_sw)
+        ==
+        sum(qg[g] for g in bus_gens)
+        - sum(qs[s] for s in bus_storage)
+        - sum(qd for qd in values(bus_qd))
+        + sum(bs for bs in values(bus_bs))*(1.0 + 2*phi)
+    )
 end
 
 

--- a/src/form/lpac.jl
+++ b/src/form/lpac.jl
@@ -40,7 +40,7 @@ end
 
 
 ""
-function constraint_power_balance(pm::AbstractLPACCModel, n::Int, c::Int, i, bus_arcs, bus_arcs_dc, bus_gens, bus_pd, bus_qd, bus_gs, bus_bs)
+function constraint_power_balance(pm::AbstractLPACModel, n::Int, c::Int, i::Int, bus_arcs, bus_arcs_dc, bus_arcs_sw, bus_gens, bus_storage, bus_pd, bus_qd, bus_gs, bus_bs)
     phi  = var(pm, n, c, :phi, i)
     p    = get(var(pm, n, c),    :p, Dict()); _check_var_keys(p, bus_arcs, "active power", "branch")
     q    = get(var(pm, n, c),    :q, Dict()); _check_var_keys(q, bus_arcs, "reactive power", "branch")

--- a/src/form/shared.jl
+++ b/src/form/shared.jl
@@ -55,35 +55,42 @@ sum(p[a] for a in bus_arcs) + sum(p_dc[a_dc] for a_dc in bus_arcs_dc) == sum(pg[
 sum(q[a] for a in bus_arcs) + sum(q_dc[a_dc] for a_dc in bus_arcs_dc) == sum(qg[g] for g in bus_gens) - sum(qd[d] for d in bus_loads) + sum(bs[s] for d in bus_shunts)*w[i]
 ```
 """
-function constraint_power_balance_shunt(pm::AbstractWModels, n::Int, c::Int, i, bus_arcs, bus_arcs_dc, bus_gens, bus_pd, bus_qd, bus_gs, bus_bs)
+function constraint_power_balance(pm::AbstractWModels, n::Int, c::Int, i, bus_arcs, bus_arcs_dc, bus_gens, bus_pd, bus_qd, bus_gs, bus_bs)
     w    = var(pm, n, c, :w, i)
-    pg   = var(pm, n, c, :pg)
-    qg   = var(pm, n, c, :qg)
-    p    = var(pm, n, c, :p)
-    q    = var(pm, n, c, :q)
-    p_dc = var(pm, n, c, :p_dc)
-    q_dc = var(pm, n, c, :q_dc)
+    p    = get(var(pm, n, c),    :p, Dict()); _check_var_keys(p, bus_arcs, "active power", "branch")
+    q    = get(var(pm, n, c),    :q, Dict()); _check_var_keys(q, bus_arcs, "reactive power", "branch")
+    pg   = get(var(pm, n, c),   :pg, Dict()); _check_var_keys(pg, bus_gens, "active power", "generator")
+    qg   = get(var(pm, n, c),   :qg, Dict()); _check_var_keys(qg, bus_gens, "reactive power", "generator")
+    ps   = get(var(pm, n, c),   :ps, Dict()); _check_var_keys(ps, bus_storage, "active power", "storage")
+    qs   = get(var(pm, n, c),   :qs, Dict()); _check_var_keys(qs, bus_storage, "reactive power", "storage")
+    psw  = get(var(pm, n, c),  :psw, Dict()); _check_var_keys(psw, bus_arcs_sw, "active power", "switch")
+    qsw  = get(var(pm, n, c),  :qsw, Dict()); _check_var_keys(qsw, bus_arcs_sw, "reactive power", "switch")
+    p_dc = get(var(pm, n, c), :p_dc, Dict()); _check_var_keys(p_dc, bus_arcs_dc, "active power", "dcline")
+    q_dc = get(var(pm, n, c), :q_dc, Dict()); _check_var_keys(q_dc, bus_arcs_dc, "reactive power", "dcline")
 
-    JuMP.@constraint(pm.model, sum(p[a] for a in bus_arcs) + sum(p_dc[a_dc] for a_dc in bus_arcs_dc) == sum(pg[g] for g in bus_gens) - sum(pd for pd in values(bus_pd)) - sum(gs for gs in values(bus_gs))*w)
-    JuMP.@constraint(pm.model, sum(q[a] for a in bus_arcs) + sum(q_dc[a_dc] for a_dc in bus_arcs_dc) == sum(qg[g] for g in bus_gens) - sum(qd for qd in values(bus_qd)) + sum(bs for bs in values(bus_bs))*w)
+
+    con(pm, n, c, :kcl_p)[i] = JuMP.@constraint(pm.model,
+        sum(p[a] for a in bus_arcs)
+        + sum(p_dc[a_dc] for a_dc in bus_arcs_dc)
+        + sum(psw[a_sw] for a_sw in bus_arcs_sw)
+        ==
+        sum(pg[g] for g in bus_gens)
+        - sum(ps[s] for s in bus_storage)
+        - sum(pd for pd in values(bus_pd))
+        - sum(gs for gs in values(bus_gs))*w
+    )
+    con(pm, n, c, :kcl_q)[i] = JuMP.@constraint(pm.model,
+        sum(q[a] for a in bus_arcs)
+        + sum(q_dc[a_dc] for a_dc in bus_arcs_dc)
+        + sum(qsw[a_sw] for a_sw in bus_arcs_sw)
+        ==
+        sum(qg[g] for g in bus_gens)
+        - sum(qs[s] for s in bus_storage)
+        - sum(qd for qd in values(bus_qd))
+        + sum(bs for bs in values(bus_bs))*w
+    )
 end
 
-
-""
-function constraint_power_balance_shunt_switch(pm::AbstractWModels, n::Int, c::Int, i::Int, bus_arcs, bus_arcs_dc, bus_arcs_sw, bus_gens, bus_pd, bus_qd, bus_gs, bus_bs)
-    w    = var(pm, n, c, :w, i)
-    p    = var(pm, n, c, :p)
-    q    = var(pm, n, c, :q)
-    pg   = var(pm, n, c, :pg)
-    qg   = var(pm, n, c, :qg)
-    psw  = var(pm, n, c, :psw)
-    qsw  = var(pm, n, c, :qsw)
-    p_dc = var(pm, n, c, :p_dc)
-    q_dc = var(pm, n, c, :q_dc)
-
-    con(pm, n, c, :kcl_p)[i] = JuMP.@constraint(pm.model, sum(p[a] for a in bus_arcs) + sum(p_dc[a_dc] for a_dc in bus_arcs_dc) + sum(psw[a_sw] for a_sw in bus_arcs_sw) == sum(pg[g] for g in bus_gens) - sum(pd for pd in values(bus_pd)) - sum(gs for gs in values(bus_gs))*w)
-    con(pm, n, c, :kcl_q)[i] = JuMP.@constraint(pm.model, sum(q[a] for a in bus_arcs) + sum(q_dc[a_dc] for a_dc in bus_arcs_dc) + sum(qsw[a_sw] for a_sw in bus_arcs_sw) == sum(qg[g] for g in bus_gens) - sum(qd for qd in values(bus_qd)) + sum(bs for bs in values(bus_bs))*w)
-end
 
 """
 ```

--- a/src/form/shared.jl
+++ b/src/form/shared.jl
@@ -49,13 +49,8 @@ function constraint_theta_ref(pm::AbstractWModels, n::Int, c::Int, ref_bus::Int)
 end
 
 
-"""
-```
-sum(p[a] for a in bus_arcs) + sum(p_dc[a_dc] for a_dc in bus_arcs_dc) == sum(pg[g] for g in bus_gens) - sum(pd[d] for d in bus_loads) - sum(gs[s] for d in bus_shunts)*w[i]
-sum(q[a] for a in bus_arcs) + sum(q_dc[a_dc] for a_dc in bus_arcs_dc) == sum(qg[g] for g in bus_gens) - sum(qd[d] for d in bus_loads) + sum(bs[s] for d in bus_shunts)*w[i]
-```
-"""
-function constraint_power_balance(pm::AbstractWModels, n::Int, c::Int, i, bus_arcs, bus_arcs_dc, bus_gens, bus_pd, bus_qd, bus_gs, bus_bs)
+""
+function constraint_power_balance(pm::AbstractWModels, n::Int, c::Int, i, bus_arcs, bus_arcs_dc, bus_arcs_sw, bus_gens, bus_storage, bus_pd, bus_qd, bus_gs, bus_bs)
     w    = var(pm, n, c, :w, i)
     p    = get(var(pm, n, c),    :p, Dict()); _check_var_keys(p, bus_arcs, "active power", "branch")
     q    = get(var(pm, n, c),    :q, Dict()); _check_var_keys(q, bus_arcs, "reactive power", "branch")
@@ -92,25 +87,45 @@ function constraint_power_balance(pm::AbstractWModels, n::Int, c::Int, i, bus_ar
 end
 
 
-"""
-```
-sum(p[a] for a in bus_arcs) + sum(p_ne[a] for a in bus_arcs_ne) + sum(p_dc[a_dc] for a_dc in bus_arcs_dc) == sum(pg[g] for g in bus_gens) - sum(pd[d] for d in bus_loads) - sum(gs[s] for s in bus_shunts)*w[i]
-sum(q[a] for a in bus_arcs) + sum(q_ne[a] for a in bus_arcs_ne) + sum(q_dc[a_dc] for a_dc in bus_arcs_dc) == sum(qg[g] for g in bus_gens) - sum(qd[d] for d in bus_loads) + sum(bs[s] for s in bus_shunts)*w[i]
-```
-"""
-function constraint_power_balance_shunt_ne(pm::AbstractWRModels, n::Int, c::Int, i, bus_arcs, bus_arcs_dc, bus_arcs_ne, bus_gens, bus_pd, bus_qd, bus_gs, bus_bs)
+""
+function constraint_power_balance_ne(pm::AbstractWModels, n::Int, c::Int, i::Int, bus_arcs, bus_arcs_dc, bus_arcs_sw, bus_arcs_ne, bus_gens, bus_storage, bus_pd, bus_qd, bus_gs, bus_bs)
     w    = var(pm, n, c, :w, i)
-    pg   = var(pm, n, c, :pg)
-    qg   = var(pm, n, c, :qg)
-    p    = var(pm, n, c, :p)
-    q    = var(pm, n, c, :q)
-    p_ne = var(pm, n, c, :p_ne)
-    q_ne = var(pm, n, c, :q_ne)
-    p_dc = var(pm, n, c, :p_dc)
-    q_dc = var(pm, n, c, :q_dc)
+    p    = get(var(pm, n, c),    :p, Dict()); _check_var_keys(p, bus_arcs, "active power", "branch")
+    q    = get(var(pm, n, c),    :q, Dict()); _check_var_keys(q, bus_arcs, "reactive power", "branch")
+    pg   = get(var(pm, n, c),   :pg, Dict()); _check_var_keys(pg, bus_gens, "active power", "generator")
+    qg   = get(var(pm, n, c),   :qg, Dict()); _check_var_keys(qg, bus_gens, "reactive power", "generator")
+    ps   = get(var(pm, n, c),   :ps, Dict()); _check_var_keys(ps, bus_storage, "active power", "storage")
+    qs   = get(var(pm, n, c),   :qs, Dict()); _check_var_keys(qs, bus_storage, "reactive power", "storage")
+    psw  = get(var(pm, n, c),  :psw, Dict()); _check_var_keys(psw, bus_arcs_sw, "active power", "switch")
+    qsw  = get(var(pm, n, c),  :qsw, Dict()); _check_var_keys(qsw, bus_arcs_sw, "reactive power", "switch")
+    p_dc = get(var(pm, n, c), :p_dc, Dict()); _check_var_keys(p_dc, bus_arcs_dc, "active power", "dcline")
+    q_dc = get(var(pm, n, c), :q_dc, Dict()); _check_var_keys(q_dc, bus_arcs_dc, "reactive power", "dcline")
+    p_ne = get(var(pm, n, c), :p_ne, Dict()); _check_var_keys(p_ne, bus_arcs_ne, "active power", "ne_branch")
+    q_ne = get(var(pm, n, c), :q_ne, Dict()); _check_var_keys(q_ne, bus_arcs_ne, "reactive power", "ne_branch")
 
-    JuMP.@constraint(pm.model, sum(p[a] for a in bus_arcs) + sum(p_ne[a] for a in bus_arcs_ne) + sum(p_dc[a_dc] for a_dc in bus_arcs_dc) == sum(pg[g] for g in bus_gens) - sum(pd for pd in values(bus_pd)) - sum(gs for gs in values(bus_gs))*w)
-    JuMP.@constraint(pm.model, sum(q[a] for a in bus_arcs) + sum(q_ne[a] for a in bus_arcs_ne) + sum(q_dc[a_dc] for a_dc in bus_arcs_dc) == sum(qg[g] for g in bus_gens) - sum(qd for qd in values(bus_qd)) + sum(bs for bs in values(bus_bs))*w)
+
+    con(pm, n, c, :kcl_p)[i] = JuMP.@constraint(pm.model,
+        sum(p[a] for a in bus_arcs)
+        + sum(p_dc[a_dc] for a_dc in bus_arcs_dc)
+        + sum(psw[a_sw] for a_sw in bus_arcs_sw)
+        + sum(p_ne[a] for a in bus_arcs_ne)
+        ==
+        sum(pg[g] for g in bus_gens)
+        - sum(ps[s] for s in bus_storage)
+        - sum(pd for pd in values(bus_pd))
+        - sum(gs for gs in values(bus_gs))*w
+    )
+    con(pm, n, c, :kcl_q)[i] = JuMP.@constraint(pm.model,
+        sum(q[a] for a in bus_arcs)
+        + sum(q_dc[a_dc] for a_dc in bus_arcs_dc)
+        + sum(qsw[a_sw] for a_sw in bus_arcs_sw)
+        + sum(q_ne[a] for a in bus_arcs_ne)
+        ==
+        sum(qg[g] for g in bus_gens)
+        - sum(qs[s] for s in bus_storage)
+        - sum(qd for qd in values(bus_qd))
+        + sum(bs for bs in values(bus_bs))*w
+    )
 end
 
 

--- a/src/prob/opf.jl
+++ b/src/prob/opf.jl
@@ -29,7 +29,7 @@ function post_opf(pm::AbstractPowerModel)
     end
 
     for i in ids(pm, :bus)
-        constraint_power_balance_shunt(pm, i)
+        constraint_power_balance(pm, i)
     end
 
     for i in ids(pm, :branch)
@@ -69,7 +69,7 @@ function post_mn_opf(pm::AbstractPowerModel)
         end
 
         for i in ids(pm, :bus, nw=n)
-            constraint_power_balance_shunt(pm, i, nw=n)
+            constraint_power_balance(pm, i, nw=n)
         end
 
         for i in ids(pm, :branch, nw=n)

--- a/src/prob/opf_bf.jl
+++ b/src/prob/opf_bf.jl
@@ -20,7 +20,7 @@ function post_opf_bf(pm::AbstractPowerModel)
     end
 
     for i in ids(pm, :bus)
-        constraint_power_balance_shunt(pm, i)
+        constraint_power_balance(pm, i)
     end
 
     for i in ids(pm, :branch)

--- a/src/prob/ots.jl
+++ b/src/prob/ots.jl
@@ -26,7 +26,7 @@ function post_ots(pm::AbstractPowerModel)
     end
 
     for i in ids(pm, :bus)
-        constraint_power_balance_shunt(pm, i)
+        constraint_power_balance(pm, i)
     end
 
     for i in ids(pm, :branch)

--- a/src/prob/pf.jl
+++ b/src/prob/pf.jl
@@ -29,7 +29,7 @@ function post_pf(pm::AbstractPowerModel)
     end
 
     for (i,bus) in ref(pm, :bus)
-        constraint_power_balance_shunt(pm, i)
+        constraint_power_balance(pm, i)
 
         # PV Bus Constraints
         if length(ref(pm, :bus_gens, i)) > 0 && !(i in ids(pm,:ref_buses))

--- a/src/prob/pf_bf.jl
+++ b/src/prob/pf_bf.jl
@@ -20,7 +20,7 @@ function post_pf_bf(pm::AbstractPowerModel)
     end
 
     for (i,bus) in ref(pm, :bus)
-        constraint_power_balance_shunt(pm, i)
+        constraint_power_balance(pm, i)
 
         # PV Bus Constraints
         if length(ref(pm, :bus_gens, i)) > 0 && !(i in ids(pm,:ref_buses))

--- a/src/prob/test.jl
+++ b/src/prob/test.jl
@@ -27,7 +27,7 @@ function _post_cl_opf(pm::AbstractPowerModel)
     end
 
     for i in ids(pm, :bus)
-        constraint_power_balance_shunt(pm, i)
+        constraint_power_balance(pm, i)
     end
 
     for i in ids(pm, :branch)
@@ -67,7 +67,7 @@ function _post_sw_opf(pm::AbstractPowerModel)
     end
 
     for i in ids(pm, :bus)
-        constraint_power_balance_shunt_switch(pm, i)
+        constraint_power_balance(pm, i)
     end
 
     for i in ids(pm, :switch)
@@ -116,7 +116,7 @@ function _post_oswpf(pm::AbstractPowerModel)
     end
 
     for i in ids(pm, :bus)
-        constraint_power_balance_shunt_switch(pm, i)
+        constraint_power_balance(pm, i)
     end
 
     for i in ids(pm, :switch)
@@ -181,7 +181,7 @@ function _post_oswpf_nb(pm::AbstractPowerModel)
     end
 
     for i in ids(pm, :bus)
-        constraint_power_balance_shunt_switch(pm, i)
+        constraint_power_balance(pm, i)
     end
 
     for i in ids(pm, :switch)
@@ -285,7 +285,7 @@ function _post_uc_opf(pm::AbstractPowerModel)
     end
 
     for i in ids(pm, :bus)
-        constraint_power_balance_shunt_storage(pm, i)
+        constraint_power_balance(pm, i)
     end
     
     for i in ids(pm, :storage)
@@ -351,7 +351,7 @@ function _post_uc_mc_opf(pm::AbstractPowerModel)
         end
 
         for i in ids(pm, :bus)
-            constraint_power_balance_shunt_storage(pm, i, cnd=c)
+            constraint_power_balance(pm, i, cnd=c)
         end
 
         for i in ids(pm, :branch)
@@ -434,7 +434,7 @@ function _post_mn_pf(pm::AbstractPowerModel)
         end
 
         for (i,bus) in ref(pm, :bus, nw=n)
-            constraint_power_balance_shunt(pm, i, nw=n)
+            constraint_power_balance(pm, i, nw=n)
 
             # PV Bus Constraints
             if length(ref(pm, :bus_gens, i, nw=n)) > 0 && !(i in ids(pm, :ref_buses, nw=n))
@@ -490,7 +490,7 @@ function _post_mc_opf(pm::AbstractPowerModel)
         end
 
         for i in ids(pm, :bus)
-            constraint_power_balance_shunt(pm, i, cnd=c)
+            constraint_power_balance(pm, i, cnd=c)
         end
 
         for i in ids(pm, :branch)
@@ -534,7 +534,7 @@ function _post_mn_mc_opf(pm::AbstractPowerModel)
             end
 
             for i in ids(pm, :bus, nw=n)
-                constraint_power_balance_shunt(pm, i, nw=n, cnd=c)
+                constraint_power_balance(pm, i, nw=n, cnd=c)
             end
 
             for i in ids(pm, :branch, nw=n)
@@ -580,7 +580,7 @@ function _post_strg_opf(pm::AbstractPowerModel)
     end
 
     for i in ids(pm, :bus)
-        constraint_power_balance_shunt_storage(pm, i)
+        constraint_power_balance(pm, i)
     end
 
     for i in ids(pm, :storage)
@@ -627,7 +627,7 @@ function _post_mn_strg_opf(pm::AbstractPowerModel)
         end
 
         for i in ids(pm, :bus, nw=n)
-            constraint_power_balance_shunt_storage(pm, i, nw=n)
+            constraint_power_balance(pm, i, nw=n)
         end
 
         for i in ids(pm, :storage, nw=n)
@@ -692,7 +692,7 @@ function _post_strg_mi_opf(pm::AbstractPowerModel)
     end
 
     for i in ids(pm, :bus)
-        constraint_power_balance_shunt_storage(pm, i)
+        constraint_power_balance(pm, i)
     end
 
     for i in ids(pm, :storage)
@@ -745,7 +745,7 @@ function _post_mn_mc_strg_opf(pm::AbstractPowerModel)
             end
 
             for i in ids(pm, :bus, nw=n)
-                constraint_power_balance_shunt_storage(pm, i, nw=n, cnd=c)
+                constraint_power_balance(pm, i, nw=n, cnd=c)
             end
 
             for i in ids(pm, :storage, nw=n)

--- a/src/prob/tnep.jl
+++ b/src/prob/tnep.jl
@@ -27,7 +27,7 @@ function post_tnep(pm::AbstractPowerModel)
     end
 
     for i in ids(pm, :bus)
-        constraint_power_balance_shunt_ne(pm, i)
+        constraint_power_balance_ne(pm, i)
     end
 
     for i in ids(pm, :branch)

--- a/test/multi-nw-cnd.jl
+++ b/test/multi-nw-cnd.jl
@@ -232,16 +232,16 @@
         end
 
         @testset "dc 5-bus storage case" begin
-            result = PowerModels._run_mn_mc_opf(mn_mc_data, PowerModels.DCPPowerModel, ipopt_solver)
+            result = PowerModels._run_mn_mc_strg_opf(mn_mc_data, PowerModels.DCPPowerModel, ipopt_solver)
 
             @test result["termination_status"] == LOCALLY_SOLVED
-            @test isapprox(result["objective"], 1.58593e5; atol = 1e2)
+            @test isapprox(result["objective"], 1.33804e5; atol = 1e2)
         end
 
         #=
         # base case not yet implemented
         @testset "soc 5-bus storage case" begin
-            result = PowerModels._run_mn_mc_opf(mn_mc_data, SOCWRPowerModel, ipopt_solver)
+            result = PowerModels._run_mn_mc_strg_opf(mn_mc_data, SOCWRPowerModel, ipopt_solver)
 
             @test result["termination_status"] == LOCALLY_SOLVED
             @test isapprox(result["objective"], 69827.3; atol = 1e-1)
@@ -249,10 +249,10 @@
         =#
 
         @testset "nfa 5 bus storage case" begin
-            result = PowerModels._run_mn_mc_opf(mn_mc_data, PowerModels.NFAPowerModel, ipopt_solver)
+            result = PowerModels._run_mn_mc_strg_opf(mn_mc_data, PowerModels.NFAPowerModel, ipopt_solver)
 
             @test result["termination_status"] == LOCALLY_SOLVED
-            @test isapprox(result["objective"], 1.33302e5; atol = 1e2)
+            @test isapprox(result["objective"], 100110.0; atol = 1e2)
         end
     end
 

--- a/test/multiconductor.jl
+++ b/test/multiconductor.jl
@@ -17,7 +17,7 @@ function post_tp_opf(pm::AbstractPowerModel)
         end
 
         for i in ids(pm, :bus)
-            PowerModels.constraint_power_balance_shunt(pm, i, cnd=c)
+            PowerModels.constraint_power_balance(pm, i, cnd=c)
         end
 
         for i in ids(pm, :branch)

--- a/test/opf-var.jl
+++ b/test/opf-var.jl
@@ -491,7 +491,7 @@ end
         end
 
         for i in ids(pm,:bus)
-            PMs.constraint_power_balance_shunt(pm, i)
+            PMs.constraint_power_balance(pm, i)
         end
 
         for i in ids(pm,:branch)


### PR DESCRIPTION
Add one power balance constraint to support models with any combination of the standard components.  Also throws clear errors when variables have not been setup properly for a component type in a given dataset (e.g. when trying to use data on a model that does not support it)