### PR TITLE
Optional Flow Limits

### DIFF
--- a/src/core/constraint_template.jl
+++ b/src/core/constraint_template.jl
@@ -451,7 +451,9 @@ function constraint_thermal_limit_from(pm::AbstractPowerModel, i::Int; nw::Int=p
     t_bus = branch["t_bus"]
     f_idx = (i, f_bus, t_bus)
 
-    constraint_thermal_limit_from(pm, nw, cnd, f_idx, branch["rate_a"][cnd])
+    if haskey(branch, "rate_a")
+        constraint_thermal_limit_from(pm, nw, cnd, f_idx, branch["rate_a"][cnd])
+    end
 end
 
 
@@ -466,7 +468,9 @@ function constraint_thermal_limit_to(pm::AbstractPowerModel, i::Int; nw::Int=pm.
     t_bus = branch["t_bus"]
     t_idx = (i, t_bus, f_bus)
 
-    constraint_thermal_limit_to(pm, nw, cnd, t_idx, branch["rate_a"][cnd])
+    if haskey(branch, "rate_a")
+        constraint_thermal_limit_to(pm, nw, cnd, t_idx, branch["rate_a"][cnd])
+    end
 end
 
 
@@ -476,6 +480,10 @@ function constraint_thermal_limit_from_on_off(pm::AbstractPowerModel, i::Int; nw
     f_bus = branch["f_bus"]
     t_bus = branch["t_bus"]
     f_idx = (i, f_bus, t_bus)
+
+    if !haskey(branch, "rate_a")
+        Memento.error(_LOGGER, "constraint_thermal_limit_from_on_off requires a rate_a value on all branches, calc_thermal_limits! can be used to generate reasonable values")
+    end
 
     constraint_thermal_limit_from_on_off(pm, nw, cnd, i, f_idx, branch["rate_a"][cnd])
 end
@@ -488,6 +496,10 @@ function constraint_thermal_limit_to_on_off(pm::AbstractPowerModel, i::Int; nw::
     t_bus = branch["t_bus"]
     t_idx = (i, t_bus, f_bus)
 
+    if !haskey(branch, "rate_a")
+        Memento.error(_LOGGER, "constraint_thermal_limit_to_on_off requires a rate_a value on all branches, calc_thermal_limits! can be used to generate reasonable values")
+    end
+
     constraint_thermal_limit_to_on_off(pm, nw, cnd, i, t_idx, branch["rate_a"][cnd])
 end
 
@@ -499,6 +511,10 @@ function constraint_thermal_limit_from_ne(pm::AbstractPowerModel, i::Int; nw::In
     t_bus = branch["t_bus"]
     f_idx = (i, f_bus, t_bus)
 
+    if !haskey(branch, "rate_a")
+        Memento.error(_LOGGER, "constraint_thermal_limit_from_ne requires a rate_a value on all branches, calc_thermal_limits! can be used to generate reasonable values")
+    end
+
     constraint_thermal_limit_from_ne(pm, nw, cnd, i, f_idx, branch["rate_a"][cnd])
 end
 
@@ -509,6 +525,10 @@ function constraint_thermal_limit_to_ne(pm::AbstractPowerModel, i::Int; nw::Int=
     f_bus = branch["f_bus"]
     t_bus = branch["t_bus"]
     t_idx = (i, t_bus, f_bus)
+
+    if !haskey(branch, "rate_a")
+        Memento.error(_LOGGER, "constraint_thermal_limit_to_ne requires a rate_a value on all branches, calc_thermal_limits! can be used to generate reasonable values")
+    end
 
     constraint_thermal_limit_to_ne(pm, nw, cnd, i, t_idx, branch["rate_a"][cnd])
 end
@@ -525,7 +545,9 @@ function constraint_current_limit(pm::AbstractPowerModel, i::Int; nw::Int=pm.cnw
     t_bus = branch["t_bus"]
     f_idx = (i, f_bus, t_bus)
 
-    constraint_current_limit(pm, nw, cnd, f_idx, branch["c_rating_a"][cnd])
+    if haskey(branch, "c_rating_a")
+        constraint_current_limit(pm, nw, cnd, f_idx, branch["c_rating_a"][cnd])
+    end
 end
 
 

--- a/src/core/data.jl
+++ b/src/core/data.jl
@@ -1069,10 +1069,47 @@ function correct_voltage_angle_differences!(data::Dict{String,<:Any}, default_pa
 end
 
 
-"checks that each branch has a reasonable thermal rating-a, if not computes one"
+"checks that each branch has non-negative thermal ratings and removes zero thermal ratings"
 function correct_thermal_limits!(data::Dict{String,<:Any})
     if InfrastructureModels.ismultinetwork(data)
         Memento.error(_LOGGER, "correct_thermal_limits! does not yet support multinetwork data")
+    end
+
+    modified = Set{Int}()
+
+    branches = [branch for branch in values(data["branch"])]
+    if haskey(data, "ne_branch")
+        append!(branches, values(data["ne_branch"]))
+    end
+
+    conductors = 1:get(data, "conductors", 1)
+
+    for branch in branches
+        for rate_key in ["rate_a", "rate_b", "rate_c"]
+            if haskey(branch, rate_key)
+                rate_value = branch[rate_key]
+                for c in conductors
+                    if rate_value[c] < 0.0
+                        Memento.error(_LOGGER, "negative $(rate_key) value on branch $(branch["index"]), this code only supports non-negative $(rate_key) values")
+                    end
+                end
+                if all(isapprox(rate_value[c], 0.0) for c in conductors)
+                    delete!(branch, rate_key)
+                    Memento.warn(_LOGGER, "removing zero $(rate_key) limit on branch $(branch["index"])")
+                    push!(modified, branch["index"])
+                end
+            end
+        end
+    end
+
+    return modified
+end
+
+
+"checks that each branch has a reasonable thermal rating-a, if not computes one"
+function calc_thermal_limits!(data::Dict{String,<:Any})
+    if InfrastructureModels.ismultinetwork(data)
+        Memento.error(_LOGGER, "calc_thermal_limits! does not yet support multinetwork data")
     end
 
     @assert("per_unit" in keys(data) && data["per_unit"])
@@ -1134,10 +1171,46 @@ function correct_thermal_limits!(data::Dict{String,<:Any})
 end
 
 
-"checks that each branch has a reasonable current rating-a, if not computes one"
+"checks that each branch has non-negative current ratings and removes zero current ratings"
 function correct_current_limits!(data::Dict{String,<:Any})
     if InfrastructureModels.ismultinetwork(data)
         Memento.error(_LOGGER, "correct_current_limits! does not yet support multinetwork data")
+    end
+
+    modified = Set{Int}()
+
+    branches = [branch for branch in values(data["branch"])]
+    if haskey(data, "ne_branch")
+        append!(branches, values(data["ne_branch"]))
+    end
+
+    conductors = 1:get(data, "conductors", 1)
+
+    for branch in branches
+        for rate_key in ["c_rating_a", "c_rating_b", "c_rating_c"]
+            if haskey(branch, rate_key)
+                rate_value = branch[rate_key]
+                for c in conductors
+                    if rate_value[c] < 0.0
+                        Memento.error(_LOGGER, "negative $(rate_key) value on branch $(branch["index"]), this code only supports non-negative $(rate_key) values")
+                    end
+                end
+                if all(isapprox(rate_value[c], 0.0) for c in conductors)
+                    delete!(branch, rate_key)
+                    Memento.warn(_LOGGER, "removing zero $(rate_key) limit on branch $(branch["index"])")
+                    push!(modified, branch["index"])
+                end
+            end
+        end
+    end
+
+    return modified
+end
+
+"checks that each branch has a reasonable current rating-a, if not computes one"
+function calc_current_limits!(data::Dict{String,<:Any})
+    if InfrastructureModels.ismultinetwork(data)
+        Memento.error(_LOGGER, "calc_current_limits! does not yet support multinetwork data")
     end
 
     @assert("per_unit" in keys(data) && data["per_unit"])

--- a/src/core/variable.jl
+++ b/src/core/variable.jl
@@ -679,20 +679,24 @@ end
 
 "variable: `-ne_branch[l][\"rate_a\"] <= p_ne[l,i,j] <= ne_branch[l][\"rate_a\"]` for `(l,i,j)` in `ne_arcs`"
 function variable_active_branch_flow_ne(pm::AbstractPowerModel; nw::Int=pm.cnw, cnd::Int=pm.ccnd)
+    flow_lb, flow_ub = ref_calc_branch_flow_bounds(ref(pm, nw, :ne_branch), ref(pm, nw, :bus), cnd)
+
     var(pm, nw, cnd)[:p_ne] = JuMP.@variable(pm.model,
         [(l,i,j) in ref(pm, nw, :ne_arcs)], base_name="$(nw)_$(cnd)_p_ne",
-        lower_bound = -ref(pm, nw, :ne_branch, l, "rate_a", cnd),
-        upper_bound =  ref(pm, nw, :ne_branch, l, "rate_a", cnd),
+        lower_bound = flow_lb[l],
+        upper_bound = flow_ub[l],
         start = comp_start_value(ref(pm, nw, :ne_branch, l), "p_start", cnd)
     )
 end
 
 "variable: `-ne_branch[l][\"rate_a\"] <= q_ne[l,i,j] <= ne_branch[l][\"rate_a\"]` for `(l,i,j)` in `ne_arcs`"
 function variable_reactive_branch_flow_ne(pm::AbstractPowerModel; nw::Int=pm.cnw, cnd::Int=pm.ccnd)
+    flow_lb, flow_ub = ref_calc_branch_flow_bounds(ref(pm, nw, :ne_branch), ref(pm, nw, :bus), cnd)
+
     var(pm, nw, cnd)[:q_ne] = JuMP.@variable(pm.model,
         [(l,i,j) in ref(pm, nw, :ne_arcs)], base_name="$(nw)_$(cnd)_q_ne",
-        lower_bound = -ref(pm, nw, :ne_branch, l, "rate_a", cnd),
-        upper_bound =  ref(pm, nw, :ne_branch, l, "rate_a", cnd),
+        lower_bound = flow_lb[l],
+        upper_bound = flow_ub[l],
         start = comp_start_value(ref(pm, nw, :ne_branch, l), "q_start", cnd)
     )
 end

--- a/src/form/wr.jl
+++ b/src/form/wr.jl
@@ -360,7 +360,11 @@ function variable_current_magnitude_sqr(pm::AbstractPowerModel; nw::Int=pm.cnw, 
     buspairs = ref(pm, nw, :buspairs)
     ub = Dict()
     for (bp, buspair) in buspairs
-        ub[bp] = ((buspair["rate_a"][cnd]*buspair["tap"][cnd])/buspair["vm_fr_min"][cnd])^2
+        if haskey(buspair, "rate_a")
+            ub[bp] = ((buspair["rate_a"][cnd]*buspair["tap"][cnd])/buspair["vm_fr_min"][cnd])^2
+        else
+            ub[bp] = Inf
+        end
     end
     var(pm, nw, cnd)[:ccm] = JuMP.@variable(pm.model,
         [bp in ids(pm, nw, :buspairs)], base_name="$(nw)_$(cnd)_ccm",

--- a/src/io/common.jl
+++ b/src/io/common.jl
@@ -50,6 +50,7 @@ function correct_network_data!(data::Dict{String,<:Any})
     mod_branch[:xfer_fix] = correct_transformer_parameters!(data)
     mod_branch[:vad_bounds] = correct_voltage_angle_differences!(data)
     mod_branch[:mva_zero] = correct_thermal_limits!(data)
+    mod_branch[:ma_zero] = correct_current_limits!(data)
     mod_branch[:orientation] = correct_branch_directions!(data)
     check_branch_loops(data)
 

--- a/test/multiconductor.jl
+++ b/test/multiconductor.jl
@@ -408,8 +408,8 @@ end
         @test_warn(TESTLOG, "branch found with non-positive tap value of -1.0, setting a tap to 1.0", PowerModels.correct_transformer_parameters!(mp_data_3p))
 
         mp_data_3p["branch"]["1"]["rate_a"][2] = -1.0
-        @test_warn(TESTLOG, "this code only supports positive rate_a values, changing the value on branch 1, conductor 2 to 100.47", PowerModels.correct_thermal_limits!(mp_data_3p))
-        @test isapprox(mp_data_3p["branch"]["1"]["rate_a"][2], 1.0047227335; atol=1e-6)
+        @test_throws(TESTLOG, ErrorException, PowerModels.correct_thermal_limits!(mp_data_3p))
+        mp_data_3p["branch"]["1"]["rate_a"][2] = 1.0
 
         mp_data_3p["branch"]["4"] = deepcopy(mp_data_3p["branch"]["1"])
         mp_data_3p["branch"]["4"]["f_bus"] = mp_data_3p["branch"]["1"]["t_bus"]

--- a/test/opf-var.jl
+++ b/test/opf-var.jl
@@ -3,11 +3,10 @@ TESTLOG = Memento.getlogger(PowerModels)
 
 function build_current_data(base_data)
     c_data = PowerModels.parse_file(base_data)
-    PowerModels.correct_current_limits!(c_data)
+    PowerModels.calc_current_limits!(c_data)
     for (i,branch) in c_data["branch"]
         delete!(branch, "rate_a")
     end
-
     return c_data
 end
 
@@ -22,13 +21,12 @@ end
             @test result["termination_status"] == LOCALLY_SOLVED
             @test isapprox(result["objective"], 15669.8; atol = 1e0)
         end
-        # does not converge in SCS.jl v0.4.0
-        #@testset "5-bus current limit case" begin
-        #    result = PowerModels._run_cl_opf("../test/data/matpower/case5_clm.m", ACPPowerModel, ipopt_solver)
+        @testset "5-bus current limit case" begin
+           result = PowerModels._run_cl_opf("../test/data/matpower/case5_clm.m", ACPPowerModel, ipopt_solver)
 
-        #    @test result["termination_status"] == LOCALLY_SOLVED
-        #    @test isapprox(result["objective"], 17239.3; atol = 1e0)
-        #end
+           @test result["termination_status"] == LOCALLY_SOLVED
+           @test isapprox(result["objective"], 17015.5; atol = 1e0)
+        end
         @testset "14-bus no limits case" begin
             data = build_current_data("../test/data/matpower/case14.m")
             result = PowerModels._run_cl_opf(data, ACPPowerModel, ipopt_solver)
@@ -138,13 +136,15 @@ end
         #    @test result["termination_status"] == OPTIMAL
         #    @test isapprox(result["objective"], 15418.4; atol = 1e0)
         #end
-        @testset "14-bus case" begin
-            data = build_current_data("../test/data/matpower/case14.m")
-            result = PowerModels._run_cl_opf(data, SDPWRMPowerModel, scs_solver)
 
-            @test result["termination_status"] == OPTIMAL
-            @test isapprox(result["objective"], 8081.52; atol = 1e0)
-        end
+        # too slow of unit tests
+        # @testset "14-bus case" begin
+        #     data = build_current_data("../test/data/matpower/case14.m")
+        #     result = PowerModels._run_cl_opf(data, SDPWRMPowerModel, scs_solver)
+
+        #     @test result["termination_status"] == OPTIMAL
+        #     @test isapprox(result["objective"], 8081.52; atol = 1e0)
+        # end
     end
 
 end

--- a/test/opf.jl
+++ b/test/opf.jl
@@ -44,7 +44,9 @@
         @test isapprox(result["objective"], 8190.09; atol = 1e0)
     end
     @testset "5-bus with only current limit data" begin
-        result = run_ac_opf("../test/data/matpower/case5_clm.m", ipopt_solver)
+        data = PowerModels.parse_file("../test/data/matpower/case5_clm.m")
+        calc_thermal_limits!(data)
+        result = run_ac_opf(data, ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 16513.6; atol = 1e0)
@@ -387,7 +389,9 @@ end
         @test isapprox(result["objective"], 8082.54; atol = 1e0)
     end
     @testset "5-bus with only current limit data" begin
-        result = run_opf("../test/data/matpower/case5_clm.m", LPACCPowerModel, ipopt_solver)
+        data = PowerModels.parse_file("../test/data/matpower/case5_clm.m")
+        calc_thermal_limits!(data)
+        result = run_opf(data, LPACCPowerModel, ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 16559.3; atol = 1e0)
@@ -743,12 +747,13 @@ end
     #    @test result["termination_status"] == LOCALLY_SOLVED
     #    @test isapprox(result["objective"], 7291.69; atol = 1e0) # Mosek v8 value
     #end
-    @testset "14-bus case" begin
-        result = run_opf("../test/data/matpower/case14.m", SDPWRMPowerModel, scs_solver)
+    # too slow for unit tests
+    # @testset "14-bus case" begin
+    #     result = run_opf("../test/data/matpower/case14.m", SDPWRMPowerModel, scs_solver)
 
-        @test result["termination_status"] == OPTIMAL
-        @test isapprox(result["objective"], 8081.52; atol = 1e0)
-    end
+    #     @test result["termination_status"] == OPTIMAL
+    #     @test isapprox(result["objective"], 8081.52; atol = 1e0)
+    # end
     @testset "6-bus case" begin
         result = run_opf("../test/data/matpower/case6.m", SDPWRMPowerModel, scs_solver)
 
@@ -778,12 +783,13 @@ end
         @test result["termination_status"] == OPTIMAL
         @test isapprox(result["objective"], 1005.31; atol = 1e-1)
     end
-    @testset "14-bus case" begin
-        result = run_opf("../test/data/matpower/case14.m", SparseSDPWRMPowerModel, scs_solver)
+    # too slow for unit tests
+    # @testset "14-bus case" begin
+    #     result = run_opf("../test/data/matpower/case14.m", SparseSDPWRMPowerModel, scs_solver)
 
-        @test result["termination_status"] == OPTIMAL
-        @test isapprox(result["objective"], 8081.5; atol = 1e0)
-    end
+    #     @test result["termination_status"] == OPTIMAL
+    #     @test isapprox(result["objective"], 8081.5; atol = 1e0)
+    # end
 
     # multiple components are not currently supported by this form
     #=
@@ -796,7 +802,9 @@ end
     =#
 
     @testset "passing in decomposition" begin
-        data = PowerModels.parse_file("../test/data/matpower/case14.m")
+        # too slow for unit tests
+        #data = PowerModels.parse_file("../test/data/matpower/case14.m")
+        data = PowerModels.parse_file("../test/data/pti/case5_alc.raw")
         pm = InitializePowerModel(SparseSDPWRMPowerModel, data)
         PowerModels.ref_add_core!(pm)
 
@@ -804,7 +812,7 @@ end
         cliques = PowerModels._maximal_cliques(cadj)
         lookup_bus_index = Dict((reverse(p) for p = pairs(lookup_index)))
         groups = [[lookup_bus_index[gi] for gi in g] for g in cliques]
-        @test PowerModels._problem_size(groups) == 344
+        @test PowerModels._problem_size(groups) == 83
 
         pm.ext[:SDconstraintDecomposition] = PowerModels._SDconstraintDecomposition(groups, lookup_index, sigma)
 
@@ -812,7 +820,7 @@ end
         result = optimize_model!(pm, scs_solver)
 
         @test result["termination_status"] == OPTIMAL
-        @test isapprox(result["objective"], 8081.5; atol = 1e0)
+        @test isapprox(result["objective"], 1005.31; atol = 1e0)
     end
 
 end

--- a/test/output.jl
+++ b/test/output.jl
@@ -74,7 +74,9 @@ end
 
 @testset "test dual value output" begin
     settings = Dict("output" => Dict("duals" => true))
-    result = run_dc_opf("../test/data/matpower/case14.m", ipopt_solver, setting = settings)
+    data = PowerModels.parse_file("../test/data/matpower/case14.m")
+    calc_thermal_limits!(data)
+    result = run_dc_opf(data, ipopt_solver, setting = settings)
 
     PowerModels.make_mixed_units!(result["solution"])
     @testset "14 bus - kcl duals" begin

--- a/test/tnep.jl
+++ b/test/tnep.jl
@@ -9,7 +9,9 @@ end
 
 @testset "test ac tnep" begin
     @testset "3-bus case" begin
-        result = run_tnep("../test/data/matpower/case3_tnep.m", ACPPowerModel, juniper_solver)
+        data = PowerModels.parse_file("../test/data/matpower/case3_tnep.m")
+        calc_thermal_limits!(data)
+        result = run_tnep(data, ACPPowerModel, juniper_solver)
 
         check_tnep_status(result["solution"])
 
@@ -30,7 +32,9 @@ end
 
 @testset "test soc tnep" begin
     @testset "3-bus case" begin
-        result = run_tnep("../test/data/matpower/case3_tnep.m", SOCWRPowerModel, juniper_solver; setting = Dict("output" => Dict("branch_flows" => true)))
+        data = PowerModels.parse_file("../test/data/matpower/case3_tnep.m")
+        calc_thermal_limits!(data)
+        result = run_tnep(data, SOCWRPowerModel, juniper_solver; setting = Dict("output" => Dict("branch_flows" => true)))
 
         check_tnep_status(result["solution"])
 
@@ -51,7 +55,9 @@ end
 
 @testset "test qc tnep" begin
     @testset "3-bus case" begin
-        result = run_tnep("../test/data/matpower/case3_tnep.m", QCWRPowerModel, juniper_solver)
+        data = PowerModels.parse_file("../test/data/matpower/case3_tnep.m")
+        calc_thermal_limits!(data)
+        result = run_tnep(data, QCWRPowerModel, juniper_solver)
 
         check_tnep_status(result["solution"])
 
@@ -72,7 +78,9 @@ end
 
 @testset "test dc tnep" begin
     @testset "3-bus case" begin
-        result = run_tnep("../test/data/matpower/case3_tnep.m", DCPPowerModel, juniper_solver)
+        data = PowerModels.parse_file("../test/data/matpower/case3_tnep.m")
+        calc_thermal_limits!(data)
+        result = run_tnep(data, DCPPowerModel, juniper_solver)
 
         check_tnep_status(result["solution"])
 
@@ -94,7 +102,9 @@ end
     #=
     # turn off due to numerical stability across operating systems
     @testset "3-bus case" begin
-        result = run_tnep("../test/data/matpower/case3_tnep.m", DCPLLPowerModel, juniper_solver)
+        data = PowerModels.parse_file("../test/data/matpower/case3_tnep.m")
+        calc_thermal_limits!(data)
+        result = run_tnep(data, DCPLLPowerModel, juniper_solver)
 
         check_tnep_status(result["solution"])
 
@@ -116,7 +126,9 @@ end
 
 @testset "test tnep branch flow output" begin
     @testset "3-bus case" begin
-        result = run_tnep("../test/data/matpower/case3_tnep.m", SOCWRPowerModel, juniper_solver; setting = Dict("output" => Dict("branch_flows" => true)))
+        data = PowerModels.parse_file("../test/data/matpower/case3_tnep.m")
+        calc_thermal_limits!(data)
+        result = run_tnep(data, SOCWRPowerModel, juniper_solver; setting = Dict("output" => Dict("branch_flows" => true)))
 
         check_tnep_status(result["solution"])
 


### PR DESCRIPTION
This feature is open for discussion for the next 48 hours or so.  The goal is to provide support to cases where only a subset of the branches have thermal limits.  In the new semantics existing problem definitions don't need to change; constraint templates like `constraint_thermal_limit_from` first check if a suitable limit value exists in the data model, if not, they skip adding that constraint.

In the case of things like `constraint_thermal_limit_from_on_off`, to be mathematically well defined, every branch must have a finite limit.  These constraint templates throw an error if a limit is not found.  The helper functions `calc_thermal_limits!` and `calc_current_limits!` can be used to add resonable limit values on all branches (these replicate the previous semantics).

Some benifits,
- Performance improvements are possible in models with very few binding limits
- It is possible to make a model with a mixture of thermal and current limits as specified in the data model

CC @jd-lara, @frederikgeth, @claytonpbarrows, @pseudocubic, @sanderclaeys, @rb004f, @hakanergun, @pseudocubic 