### PR TITLE
Update QC Model Names

### DIFF
--- a/docs/src/experiment-results.md
+++ b/docs/src/experiment-results.md
@@ -7,7 +7,7 @@ This experiment consists of running the following PowerModels commands,
 ```
 result_ac  = run_opf(case,   ACPPowerModel, with_optimizer(Ipopt.Optimizer, tol=1e-6))
 result_soc = run_opf(case, SOCWRPowerModel, with_optimizer(Ipopt.Optimizer, tol=1e-6))
-result_qc  = run_opf(case,  QCWRPowerModel, with_optimizer(Ipopt.Optimizer, tol=1e-6))
+result_qc  = run_opf(case,  QCRMPowerModel, with_optimizer(Ipopt.Optimizer, tol=1e-6))
 ```
 for each `case` in the NESTA archive. If the value of `result["termination_status"]` is `LOCALLY_SOLVED` then the values of `result["objective"]` and `result["solve_time"]` are reported, otherwise an `err.` or `--` is displayed. A value of `n.d.` indicates that no data was available. The optimality gap is defined as,
 ```

--- a/docs/src/formulation-details.md
+++ b/docs/src/formulation-details.md
@@ -69,8 +69,8 @@ LPACCPowerModel
 ```@docs
 SOCWRPowerModel
 SOCWRConicPowerModel
-QCWRPowerModel
-QCWRTriPowerModel
+QCRMPowerModel
+QCLSPowerModel
 SOCBFPowerModel
 SOCBFConicPowerModel
 ```

--- a/docs/src/formulations.md
+++ b/docs/src/formulations.md
@@ -17,7 +17,7 @@ ACPPowerModel <: AbstractACPForm
 DCPPowerModel <: AbstractDCPForm
 
 SOCWRPowerModel <: AbstractWRForm
-QCWRPowerModel <: AbstractWRForm
+QCRMPowerModel <: AbstractWRForm
 
 SOCBFPowerModel <: AbstractSOCBFModel
 ```

--- a/src/core/types.jl
+++ b/src/core/types.jl
@@ -11,7 +11,7 @@
     # quadratic relaxations
     SOCWRPowerModel, SOCWRConicPowerModel,
     SOCBFPowerModel, SOCBFConicPowerModel,
-    QCWRPowerModel, QCWRTriPowerModel,
+    QCRMPowerModel, QCLSPowerModel,
 
     # sdp relaxations
     SDPWRMPowerModel, SparseSDPWRMPowerModel
@@ -253,8 +253,11 @@ mutable struct SOCWRConicPowerModel <: AbstractSOCWRConicModel @pm_fields end
 ""
 abstract type AbstractQCWRModel <: AbstractWRModel end
 
+abstract type AbstractQCRMPowerModel <: AbstractQCWRModel end
+
 """
-"Quadratic-Convex" relaxation of AC OPF
+The "Quadratic-Convex" relaxation of the AC power flow equations.
+Recursive McCormik relaxations are used for the trilinear terms (i.e. QCRM).
 ```
 @Article{Hijazi2017,
   author="Hijazi, Hassan and Coffrin, Carleton and Hentenryck, Pascal Van",
@@ -271,14 +274,26 @@ abstract type AbstractQCWRModel <: AbstractWRModel end
 }
 ```
 """
-mutable struct QCWRPowerModel <: AbstractQCWRModel @pm_fields end
+mutable struct QCRMPowerModel <: AbstractQCRMPowerModel @pm_fields end
 
 
 ""
-abstract type AbstractQCWRTriModel <: AbstractQCWRModel end
+abstract type AbstractQCLSModel <: AbstractQCWRModel end
 
 """
-"Quadratic-Convex" relaxation of AC OPF with convex hull of triple product
+A strengthened version of the "Quadratic-Convex" relaxation of the AC power flow equations.
+An extreme-point encoding of trilinar terms is used along with a constraint to link the
+lambda variables in multiple trilinar terms (i.e. QCLS).
+```
+@misc{1809.04565,
+  author="Kaarthik Sundar and Harsha Nagarajan and Sidhant Misra and Mowen Lu and Carleton Coffrin and Russell Bent",
+  title="Optimization-Based Bound Tightening using a Strengthened QC-Relaxation of the Optimal Power Flow Problem",
+  year="2018",
+  Eprint = "arXiv:1809.04565",
+}
+```
+
+The original model derivation is available in,
 ```
 @Article{Hijazi2017,
   author="Hijazi, Hassan and Coffrin, Carleton and Hentenryck, Pascal Van",
@@ -295,7 +310,7 @@ abstract type AbstractQCWRTriModel <: AbstractQCWRModel end
 }
 ```
 """
-mutable struct QCWRTriPowerModel <: AbstractQCWRTriModel @pm_fields end
+mutable struct QCLSPowerModel <: AbstractQCLSModel @pm_fields end
 
 
 

--- a/src/form/wr.jl
+++ b/src/form/wr.jl
@@ -709,12 +709,12 @@ end
 
 
 ""
-function variable_voltage_magnitude_product(pm::AbstractQCWRTriModel; nw::Int=pm.cnw, cnd::Int=pm.ccnd)
+function variable_voltage_magnitude_product(pm::AbstractQCLSModel; nw::Int=pm.cnw, cnd::Int=pm.ccnd)
     # do nothing - no lifted variables required for voltage variable product
 end
 
 "creates lambda variables for convex combination model"
-function variable_voltage_magnitude_product_multipliers(pm::AbstractQCWRTriModel; nw::Int=pm.cnw, cnd::Int=pm.ccnd)
+function variable_voltage_magnitude_product_multipliers(pm::AbstractQCLSModel; nw::Int=pm.cnw, cnd::Int=pm.ccnd)
     var(pm, nw, cnd)[:lambda_wr] = JuMP.@variable(pm.model,
         [bp in ids(pm, nw, :buspairs), i=1:8], base_name="$(nw)_$(cnd)_lambda",
         lower_bound = 0, upper_bound = 1, start = 0.0)
@@ -725,7 +725,7 @@ function variable_voltage_magnitude_product_multipliers(pm::AbstractQCWRTriModel
 end
 
 ""
-function variable_voltage(pm::AbstractQCWRTriModel; kwargs...)
+function variable_voltage(pm::AbstractQCLSModel; kwargs...)
     variable_voltage_angle(pm; kwargs...)
     variable_voltage_magnitude(pm; kwargs...)
 
@@ -742,7 +742,7 @@ end
 
 
 ""
-function constraint_model_voltage(pm::AbstractQCWRTriModel, n::Int, c::Int)
+function constraint_model_voltage(pm::AbstractQCLSModel, n::Int, c::Int)
     _check_missing_keys(var(pm, n, c), [:vm,:va,:td,:si,:cs,:w,:wr,:wi,:lambda_wr,:lambda_wi], typeof(pm))
 
     v = var(pm, n, c, :vm)

--- a/src/util/obbt.jl
+++ b/src/util/obbt.jl
@@ -68,7 +68,7 @@ function run_obbt_opf!(file::String, optimizer; kwargs...)
 end
 
 function run_obbt_opf!(data::Dict{String,<:Any}, optimizer;
-    model_type::Type = QCWRTriPowerModel,
+    model_type::Type = QCLSPowerModel,
     max_iter::Int = 100,
     time_limit::Float64 = 3600.0,
     upper_bound::Float64 = Inf,

--- a/test/matpower.jl
+++ b/test/matpower.jl
@@ -89,7 +89,7 @@ end
         @test isapprox(result["objective"], 7642.6; atol = 1e0)
     end
     @testset "QC Model" begin
-        result = run_opf("../test/data/matpower/case14.m", QCWRPowerModel, ipopt_solver)
+        result = run_opf("../test/data/matpower/case14.m", QCRMPowerModel, ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 8075.1; atol = 1e0)

--- a/test/opf.jl
+++ b/test/opf.jl
@@ -632,37 +632,37 @@ end
 
 @testset "test qc opf" begin
     @testset "3-bus case" begin
-        result = run_opf("../test/data/matpower/case3.m", QCWRPowerModel, ipopt_solver)
+        result = run_opf("../test/data/matpower/case3.m", QCRMPowerModel, ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 5780; atol = 1e0)
     end
     @testset "5-bus asymmetric case" begin
-        result = run_opf("../test/data/matpower/case5_asym.m", QCWRPowerModel, ipopt_solver)
+        result = run_opf("../test/data/matpower/case5_asym.m", QCRMPowerModel, ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 15921; atol = 1e0)
     end
     @testset "5-bus gap case" begin
-        result = run_opf("../test/data/matpower/case5_gap.m", QCWRPowerModel, ipopt_solver)
+        result = run_opf("../test/data/matpower/case5_gap.m", QCRMPowerModel, ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], -27659.8; atol = 1e0)
     end
     @testset "5-bus with asymmetric line charge" begin
-        result = run_opf("../test/data/pti/case5_alc.raw", QCWRPowerModel, ipopt_solver)
+        result = run_opf("../test/data/pti/case5_alc.raw", QCRMPowerModel, ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 1005.27; atol = 1e0)
     end
     @testset "5-bus with pwl costs" begin
-        result = run_opf("../test/data/matpower/case5_pwlc.m", QCWRPowerModel, ipopt_solver)
+        result = run_opf("../test/data/matpower/case5_pwlc.m", QCRMPowerModel, ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 42895; atol = 1e0)
     end
     @testset "6-bus case" begin
-        result = run_opf("../test/data/matpower/case6.m", QCWRPowerModel, ipopt_solver)
+        result = run_opf("../test/data/matpower/case6.m", QCRMPowerModel, ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 11484.2; atol = 1e0)
@@ -670,7 +670,7 @@ end
         @test isapprox(result["solution"]["bus"]["4"]["va"], 0.0; atol = 1e-4)
     end
     @testset "24-bus rts case" begin
-        result = run_opf("../test/data/matpower/case24.m", QCWRPowerModel, ipopt_solver)
+        result = run_opf("../test/data/matpower/case24.m", QCRMPowerModel, ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 76599.9; atol = 1e0)
@@ -679,25 +679,25 @@ end
 
 @testset "test qc opf with trilinear convexhull relaxation" begin
     @testset "3-bus case" begin
-        result = run_opf("../test/data/matpower/case3.m", QCWRTriPowerModel, ipopt_solver)
+        result = run_opf("../test/data/matpower/case3.m", QCLSPowerModel, ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 5817.91; atol = 1e0)
     end
     @testset "5-bus asymmetric case" begin
-        result = run_opf("../test/data/matpower/case5_asym.m", QCWRTriPowerModel, ipopt_solver)
+        result = run_opf("../test/data/matpower/case5_asym.m", QCLSPowerModel, ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 15929.2; atol = 1e0)
     end
     @testset "5-bus gap case" begin
-        result = run_opf("../test/data/matpower/case5_gap.m", QCWRTriPowerModel, ipopt_solver)
+        result = run_opf("../test/data/matpower/case5_gap.m", QCLSPowerModel, ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], -27659.8; atol = 1e0)
     end
     @testset "6-bus case" begin
-        result = run_opf("../test/data/matpower/case6.m", QCWRTriPowerModel, ipopt_solver)
+        result = run_opf("../test/data/matpower/case6.m", QCLSPowerModel, ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 11512.9; atol = 1e0)
@@ -705,7 +705,7 @@ end
         @test isapprox(result["solution"]["bus"]["4"]["va"], 0.0; atol = 1e-4)
     end
     @testset "24-bus rts case" begin
-        result = run_opf("../test/data/matpower/case24.m", QCWRTriPowerModel, ipopt_solver)
+        result = run_opf("../test/data/matpower/case24.m", QCLSPowerModel, ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 76785.4; atol = 1e0)

--- a/test/ots.jl
+++ b/test/ots.jl
@@ -147,7 +147,7 @@ end
 
 @testset "test qc ots" begin
     @testset "3-bus case" begin
-        result = run_ots("../test/data/matpower/case3.m", QCWRPowerModel, juniper_solver)
+        result = run_ots("../test/data/matpower/case3.m", QCRMPowerModel, juniper_solver)
 
         check_br_status(result["solution"])
 
@@ -155,7 +155,7 @@ end
         @test isapprox(result["objective"], 5746.7; atol = 1e0)
     end
     @testset "5-bus case" begin
-        result = run_ots("../test/data/matpower/case5.m", QCWRPowerModel, juniper_solver)
+        result = run_ots("../test/data/matpower/case5.m", QCRMPowerModel, juniper_solver)
 
         check_br_status(result["solution"])
 
@@ -163,7 +163,7 @@ end
         @test isapprox(result["objective"], 15051.4; atol = 5e1)
     end
     @testset "5-bus asymmetric case" begin
-        result = run_ots("../test/data/matpower/case5_asym.m", QCWRPowerModel, juniper_solver)
+        result = run_ots("../test/data/matpower/case5_asym.m", QCRMPowerModel, juniper_solver)
 
         check_br_status(result["solution"])
 
@@ -171,13 +171,13 @@ end
         @test isapprox(result["objective"], 14999.7; atol = 1e0)
     end
     @testset "5-bus with asymmetric line charge" begin
-        result = run_ots("../test/data/pti/case5_alc.raw", QCWRPowerModel, juniper_solver)
+        result = run_ots("../test/data/pti/case5_alc.raw", QCRMPowerModel, juniper_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 1003.97; atol = 5e0)
     end
     @testset "6-bus case" begin
-        result = run_ots("../test/data/matpower/case6.m", QCWRPowerModel, juniper_solver)
+        result = run_ots("../test/data/matpower/case6.m", QCRMPowerModel, juniper_solver)
 
         check_br_status(result["solution"])
 

--- a/test/tnep.jl
+++ b/test/tnep.jl
@@ -57,7 +57,7 @@ end
     @testset "3-bus case" begin
         data = PowerModels.parse_file("../test/data/matpower/case3_tnep.m")
         calc_thermal_limits!(data)
-        result = run_tnep(data, QCWRPowerModel, juniper_solver)
+        result = run_tnep(data, QCRMPowerModel, juniper_solver)
 
         check_tnep_status(result["solution"])
 
@@ -66,7 +66,7 @@ end
     end
 
     @testset "5-bus rts case" begin
-        result = run_tnep("../test/data/matpower/case5_tnep.m", QCWRPowerModel, juniper_solver)
+        result = run_tnep("../test/data/matpower/case5_tnep.m", QCRMPowerModel, juniper_solver)
 
         check_tnep_status(result["solution"])
 

--- a/test/util.jl
+++ b/test/util.jl
@@ -4,13 +4,13 @@
         result_ac = run_ac_opf("../test/data/matpower/case3.m", ipopt_solver);
         upper_bound = result_ac["objective"]
 
-        data, stats = run_obbt_opf!("../test/data/matpower/case3.m", ipopt_solver, model_type=QCWRTriPowerModel);
+        data, stats = run_obbt_opf!("../test/data/matpower/case3.m", ipopt_solver, model_type=QCLSPowerModel);
         @test isapprox(stats["final_relaxation_objective"], 5901.96; atol=1e0)
         @test isnan(stats["final_rel_gap_from_ub"])
         @test stats["iteration_count"] == 5
 
         data, stats = run_obbt_opf!("../test/data/matpower/case3.m", ipopt_solver, 
-            model_type = QCWRTriPowerModel,
+            model_type = QCLSPowerModel,
             upper_bound = upper_bound, 
             upper_bound_constraint = true, 
             rel_gap_tol = 1e-3);
@@ -26,13 +26,13 @@ end
         result_ac = run_ac_opf("../test/data/matpower/case3.m", ipopt_solver);
         upper_bound = result_ac["objective"]
 
-        data, stats = run_obbt_opf!("../test/data/matpower/case3.m", ipopt_solver, model_type=QCWRPowerModel);
+        data, stats = run_obbt_opf!("../test/data/matpower/case3.m", ipopt_solver, model_type=QCRMPowerModel);
         @test isapprox(stats["final_relaxation_objective"], 5900.04; atol=1e0)
         @test isnan(stats["final_rel_gap_from_ub"])
         @test stats["iteration_count"] == 5
 
         data, stats = run_obbt_opf!("../test/data/matpower/case3.m", ipopt_solver, 
-            model_type = QCWRPowerModel,
+            model_type = QCRMPowerModel,
             upper_bound = upper_bound, 
             upper_bound_constraint = true, 
             rel_gap_tol = 1e-3);
@@ -51,7 +51,7 @@ end
         upper_bound = result_ac["objective"]
 
         data, stats = run_obbt_opf!(data, ipopt_solver,
-            model_type=QCWRPowerModel,
+            model_type=QCRMPowerModel,
             upper_bound = upper_bound,
             upper_bound_constraint = true);
         @test isapprox(stats["final_relaxation_objective"], 982.216; atol=1e0)


### PR DESCRIPTION
Along with the type system update, I'm proposing to do the following rename in PowerModels v0.13,
- QCWRPowerModel -> QCRMPowerModel (i.e. recursive McCormick)
- QCWRTriPowerModel -> QCLSPowerModel (i.e. lambda-strong)

CC @kaarthiksundar, @harshangrjn