### PR TITLE
Make dcline optional in the data model 

### DIFF
--- a/src/core/base.jl
+++ b/src/core/base.jl
@@ -300,6 +300,10 @@ end
 function _ref_add_core!(nw_refs::Dict)
     for (nw, ref) in nw_refs
 
+        if !haskey(ref, :dcline)
+            ref[:dcline] = Dict()
+        end
+
         ### filter out inactive components ###
         ref[:bus] = Dict(x for x in ref[:bus] if (x.second["bus_type"] != pm_component_status_inactive["bus"]))
         ref[:load] = Dict(x for x in ref[:load] if (x.second["status"] != pm_component_status_inactive["load"] && x.second["load_bus"] in keys(ref[:bus])))

--- a/src/core/solution.jl
+++ b/src/core/solution.jl
@@ -189,10 +189,12 @@ end
 
 ""
 function add_setpoint_dcline_flow!(sol, pm::AbstractPowerModel)
-    add_setpoint!(sol, pm, "dcline", "pf", :p_dc, status_name=pm_component_status["dcline"], var_key = (idx,item) -> (idx, item["f_bus"], item["t_bus"]))
-    add_setpoint!(sol, pm, "dcline", "qf", :q_dc, status_name=pm_component_status["dcline"], var_key = (idx,item) -> (idx, item["f_bus"], item["t_bus"]))
-    add_setpoint!(sol, pm, "dcline", "pt", :p_dc, status_name=pm_component_status["dcline"], var_key = (idx,item) -> (idx, item["t_bus"], item["f_bus"]))
-    add_setpoint!(sol, pm, "dcline", "qt", :q_dc, status_name=pm_component_status["dcline"], var_key = (idx,item) -> (idx, item["t_bus"], item["f_bus"]))
+    if haskey(pm.data, "dcline")
+        add_setpoint!(sol, pm, "dcline", "pf", :p_dc, status_name=pm_component_status["dcline"], var_key = (idx,item) -> (idx, item["f_bus"], item["t_bus"]))
+        add_setpoint!(sol, pm, "dcline", "qf", :q_dc, status_name=pm_component_status["dcline"], var_key = (idx,item) -> (idx, item["f_bus"], item["t_bus"]))
+        add_setpoint!(sol, pm, "dcline", "pt", :p_dc, status_name=pm_component_status["dcline"], var_key = (idx,item) -> (idx, item["t_bus"], item["f_bus"]))
+        add_setpoint!(sol, pm, "dcline", "qt", :q_dc, status_name=pm_component_status["dcline"], var_key = (idx,item) -> (idx, item["t_bus"], item["f_bus"]))
+    end
 end
 
 ""

--- a/src/io/psse.jl
+++ b/src/io/psse.jl
@@ -641,6 +641,10 @@ function _psse2pm_dcline!(pm_data::Dict, pti_data::Dict, import_all::Bool)
             push!(pm_data["dcline"], sub_data)
         end
     end
+
+    if length(pm_data["dcline"]) == 0
+        delete!(pm_data, "dcline")
+    end
 end
 
 

--- a/test/multinetwork.jl
+++ b/test/multinetwork.jl
@@ -326,9 +326,11 @@ TESTLOG = Memento.getlogger(PowerModels)
                 #@test isapprox(opf_result["solution"]["gen"][i]["qg"], pf_result["solution"]["gen"][i]["qg"]; atol = 1e-3)
             end
 
-            for (i,dcline) in nw_data["dcline"]
-                @test isapprox(opf_result["solution"]["nw"][n]["dcline"][i]["pf"], pf_result["solution"]["nw"][n]["dcline"][i]["pf"]; atol = 1e-3)
-                @test isapprox(opf_result["solution"]["nw"][n]["dcline"][i]["pt"], pf_result["solution"]["nw"][n]["dcline"][i]["pt"]; atol = 1e-3)
+            if haskey(nw_data, "dcline")
+                for (i,dcline) in nw_data["dcline"]
+                    @test isapprox(opf_result["solution"]["nw"][n]["dcline"][i]["pf"], pf_result["solution"]["nw"][n]["dcline"][i]["pf"]; atol = 1e-3)
+                    @test isapprox(opf_result["solution"]["nw"][n]["dcline"][i]["pt"], pf_result["solution"]["nw"][n]["dcline"][i]["pt"]; atol = 1e-3)
+                end
             end
         end
 

--- a/test/output.jl
+++ b/test/output.jl
@@ -147,9 +147,11 @@ end
             #@test isapprox(opf_result["solution"]["gen"][i]["qg"], pf_result["solution"]["gen"][i]["qg"]; atol = 1e-3)
         end
 
-        for (i,dcline) in data["dcline"]
-            @test isapprox(opf_result["solution"]["dcline"][i]["pf"], pf_result["solution"]["dcline"][i]["pf"]; atol = 1e-3)
-            @test isapprox(opf_result["solution"]["dcline"][i]["pt"], pf_result["solution"]["dcline"][i]["pt"]; atol = 1e-3)
+        if haskey(data, "dcline")
+            for (i,dcline) in data["dcline"]
+                @test isapprox(opf_result["solution"]["dcline"][i]["pf"], pf_result["solution"]["dcline"][i]["pf"]; atol = 1e-3)
+                @test isapprox(opf_result["solution"]["dcline"][i]["pt"], pf_result["solution"]["dcline"][i]["pt"]; atol = 1e-3)
+            end
         end
     end
 

--- a/test/psse.jl
+++ b/test/psse.jl
@@ -11,12 +11,14 @@ function set_costs!(data::Dict)
         gen["model"] = 2
     end
 
-    for (n, dcline) in data["dcline"]
-        dcline["cost"] = [0., 0., 0.]
-        dcline["ncost"] = 3
-        dcline["startup"] = 0.
-        dcline["shutdown"] = 0.
-        dcline["model"] = 2
+    if haskey(data, "dcline")
+        for (n, dcline) in data["dcline"]
+            dcline["cost"] = [0., 0., 0.]
+            dcline["ncost"] = 3
+            dcline["startup"] = 0.
+            dcline["shutdown"] = 0.
+            dcline["model"] = 2
+        end
     end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -72,5 +72,4 @@ include("common.jl")
     include("warmstart.jl")
 
     include("docs.jl")
-
 end


### PR DESCRIPTION
This PR is fairly speculative.  Based on discussions in PowerModelsDistribution, I explored the possibility of making `"dcline"` an optional field in the PowerModels data model (https://github.com/lanl-ansi/PowerModels.jl/issues/585).

Overall, I am not sure the added complexity of having `haskey(data, "dcline")...` all over PowerModels is worth the benefits to PowerModelsDistribution, which is only the ability to omit `"dcline" =>[]` from the data model, as far as I understand.  So my feeling at the moment is that we should endure the slight weirdness of an empty dcline block in PowerModelsDistribution in favor of code simplicity in PowerModels and interoperability between the two packages, however this is open for discussion.

Thoughts, @pseudocubic, @frederikgeth, @sanderclaeys, @hakanergun?