### PR TITLE
add info needed for variable space conversion to result, using setting

### DIFF
--- a/src/core/data.jl
+++ b/src/core/data.jl
@@ -2514,3 +2514,39 @@ function _make_multiconductor!(data::Dict{String,<:Any}, conductors::Real)
         end
     end
 end
+
+
+""
+function _get_topology(data)
+    topo = Dict()
+
+    for unitname in ["load", "gen", "storage", "shunt"]
+        topo[unitname] = Dict()
+        for (i, unit) in data[unitname]
+            topo[unitname][i] = Dict()
+            topo[unitname][i][unitname*"_bus"] = unit[unitname*"_bus"]
+        end
+    end
+
+    for branchname in ["branch", "dcline", "switch"]
+        topo[branchname] = Dict()
+        for (i, branch) in data[branchname]
+            topo[branchname][i] = Dict()
+            topo[branchname][i]["f_bus"] = branch["f_bus"]
+            topo[branchname][i]["t_bus"] = branch["t_bus"]
+        end
+    end
+    return topo
+end
+
+
+function _get_angle_reference(data)
+    refbus = Dict("bus"=> Dict())
+    for (i, bus) in data["bus"]
+        if bus["bus_type"] == 3
+            refbus["bus"][i] = Dict()
+            refbus["bus"][i]["va"] = bus["va"]
+        end
+    end
+    return refbus
+end

--- a/src/core/solution.jl
+++ b/src/core/solution.jl
@@ -21,8 +21,13 @@ function build_solution(pm::AbstractPowerModel, solve_time; solution_builder=sol
             data_nws[n] = Dict(
                 "name" => get(nw_data, "name", "anonymous"),
                 "bus_count" => length(nw_data["bus"]),
-                "branch_count" => length(nw_data["branch"])
+                "branch_count" => length(nw_data["branch"]),
             )
+            if haskey(pm.setting, "output") && haskey(pm.setting["output"], "topo") && pm.setting["output"]["topo"]
+                topo = _get_topology(nw_data)
+                refbus =  _get_angle_reference(nw_data)
+                merge!(data_nws[n], topo, refbus)
+            end
         end
     else
         sol["baseMVA"] = pm.data["baseMVA"]
@@ -32,6 +37,11 @@ function build_solution(pm::AbstractPowerModel, solve_time; solution_builder=sol
         solution_builder(pm, sol)
         data["bus_count"] = length(pm.data["bus"])
         data["branch_count"] = length(pm.data["branch"])
+        if haskey(pm.setting, "output") && haskey(pm.setting["output"], "topo") && pm.setting["output"]["topo"]
+            refbus = _get_angle_reference(pm.data)
+            topo = _get_topology(pm.data)
+            merge!(data, topo, refbus)
+        end
     end
 
     solution = Dict{String,Any}(


### PR DESCRIPTION
This is a possible first step in the direction of https://github.com/lanl-ansi/PowerModels.jl/issues/627. 

This PR adds a setting to have a self-contained result dict to enable conversion between variable spaces, using just the result dict. If enabled, it adds topology of all components, and angles of reference buses to result["data"].

- Do you think this is in scope?
- What would be a good name for the setting?
- It is off by default, is this preferred?

I'll add unit tests following feedback.

