### PR TITLE
Bug Fix: check if stored energy variable exists

### DIFF
--- a/src/core/constraint_template.jl
+++ b/src/core/constraint_template.jl
@@ -849,7 +849,12 @@ function constraint_storage_state(pm::AbstractPowerModel, i::Int, nw_1::Int, nw_
         time_elapsed = 1.0
     end
 
-    constraint_storage_state(pm, nw_1, nw_2, i, storage["charge_efficiency"], storage["discharge_efficiency"], time_elapsed)
+    if haskey(ref(pm, nw_1, :storage), i)
+        constraint_storage_state(pm, nw_1, nw_2, i, storage["charge_efficiency"], storage["discharge_efficiency"], time_elapsed)
+    else 
+        # if the storage device has status=0 in nw_1, then the stored energy variable will not exist. Initialize storage from data model instead.
+        constraint_storage_state_initial(pm, nw_2, i, storage["energy"], storage["charge_efficiency"], storage["discharge_efficiency"], time_elapsed)
+    end
 end
 
 ""

--- a/test/multinetwork.jl
+++ b/test/multinetwork.jl
@@ -331,6 +331,9 @@ TESTLOG = Memento.getlogger(PowerModels)
             for (n,network) in mn_data["nw"]
                 delete!(network, "time_elapsed")
             end
+
+            mn_data["nw"]["1"]["storage"]["1"]["status"] = 0  # verify that storage activation does not cause error
+
             Memento.setlevel!(TESTLOG, "warn")
             @test_warn(TESTLOG, "network data should specify time_elapsed, using 1.0 as a default", PowerModels.run_mn_opf_strg(mn_data, PowerModels.ACPPowerModel, juniper_solver))
             Memento.setlevel!(TESTLOG, "error")


### PR DESCRIPTION
In constraint_storage_state(pm,i,nw_1,nw_2) check
if ref(pm, nw_1, :storage, i) exists.  If the storage device had
status 0 in nw_1, this variable will not exist.  Instead, initialize
the stored energy from the network data.

Fixes #653 

@ccoffrin 