### PR TITLE
improve solution reporting for IVR

### DIFF
--- a/src/core/variable.jl
+++ b/src/core/variable.jl
@@ -599,7 +599,7 @@ function variable_branch_series_current_real(pm::AbstractPowerModel; nw::Int=pm.
     bus = ref(pm, nw, :bus)
 
     csr = var(pm, nw)[:csr] = JuMP.@variable(pm.model,
-        [(l,i,j) in ref(pm, nw, :arcs_from)], base_name="$(nw)_csr",
+        [l in ids(pm, nw, :branch)], base_name="$(nw)_csr",
         start = comp_start_value(branch[l], "csr_start", 0.0)
     )
 
@@ -625,20 +625,15 @@ function variable_branch_series_current_real(pm::AbstractPowerModel; nw::Int=pm.
             end
         end
 
-        for (l,i,j) in ref(pm, nw, :arcs_from)
+        for l in ids(pm, nw, :branch)
             if !isinf(ub[l])
-                JuMP.set_lower_bound(csr[(l,i,j)], -ub[l])
-                JuMP.set_upper_bound(csr[(l,i,j)], ub[l])
+                JuMP.set_lower_bound(csr[l], -ub[l])
+                JuMP.set_upper_bound(csr[l],  ub[l])
             end
         end
     end
 
-    if report
-        for (l,i,j) in ref(pm, nw, :arcs_from)
-            @assert !haskey(sol(pm, nw, :branch, l), :csr)
-            sol(pm, nw, :branch, l)[:csr] = csr[(l,i,j)]
-        end
-    end
+    report && sol_component_value(pm, nw, :branch, :csr_fr, ids(pm, nw, :branch), csr)
 end
 
 "variable: `csi[l,i,j] ` for `(l,i,j)` in `arcs_from`"
@@ -646,7 +641,7 @@ function variable_branch_series_current_imaginary(pm::AbstractPowerModel; nw::In
     branch = ref(pm, nw, :branch)
     bus = ref(pm, nw, :bus)
     csi = var(pm, nw)[:csi] = JuMP.@variable(pm.model,
-        [(l,i,j) in ref(pm, nw, :arcs_from)], base_name="$(nw)_csi",
+        [l in ids(pm, nw, :branch)], base_name="$(nw)_csi",
         start = comp_start_value(branch[l], "csi_start", 0.0)
     )
 
@@ -672,20 +667,14 @@ function variable_branch_series_current_imaginary(pm::AbstractPowerModel; nw::In
             end
         end
 
-        for (l,i,j) in ref(pm, nw, :arcs_from)
+        for l in ids(pm, nw, :branch)
             if !isinf(ub[l])
-                JuMP.set_lower_bound(csi[(l,i,j)], -ub[l])
-                JuMP.set_upper_bound(csi[(l,i,j)], ub[l])
+                JuMP.set_lower_bound(csi[l], -ub[l])
+                JuMP.set_upper_bound(csi[l], ub[l])
             end
         end
     end
-
-    if report
-        for (l,i,j) in ref(pm, nw, :arcs_from)
-            @assert !haskey(sol(pm, nw, :branch, l), :csi)
-            sol(pm, nw, :branch, l)[:csi] = csi[(l,i,j)]
-        end
-    end
+    report && sol_component_value(pm, nw, :branch, :csi_fr, ids(pm, nw, :branch), csi)
 end
 
 
@@ -1180,14 +1169,14 @@ end
 function variable_demand_factor(pm::AbstractPowerModel; nw::Int=pm.cnw, relax::Bool=false, report::Bool=true)
     if relax == true
         z_demand = var(pm, nw)[:z_demand] = JuMP.@variable(pm.model,
-            [i in ids(pm, nw, :load)], base_name="$(nw)_z_demand", 
-            upper_bound = 1, 
+            [i in ids(pm, nw, :load)], base_name="$(nw)_z_demand",
+            upper_bound = 1,
             lower_bound = 0,
             start = comp_start_value(ref(pm, nw, :load, i), "z_demand_start", 1.0)
         )
     else
         z_demand = var(pm, nw)[:z_demand] = JuMP.@variable(pm.model,
-            [i in ids(pm, nw, :load)], base_name="$(nw)_z_demand", 
+            [i in ids(pm, nw, :load)], base_name="$(nw)_z_demand",
             binary = true,
             start = comp_start_value(ref(pm, nw, :load, i), "z_demand_start", 1.0)
         )
@@ -1207,14 +1196,14 @@ end
 function variable_shunt_factor(pm::AbstractPowerModel; nw::Int=pm.cnw, relax::Bool=false, report::Bool=true)
     if relax == true
         z_shunt = var(pm, nw)[:z_shunt] = JuMP.@variable(pm.model,
-            [i in ids(pm, nw, :shunt)], base_name="$(nw)_z_shunt", 
-            upper_bound = 1, 
+            [i in ids(pm, nw, :shunt)], base_name="$(nw)_z_shunt",
+            upper_bound = 1,
             lower_bound = 0,
             start = comp_start_value(ref(pm, nw, :shunt, i), "z_shunt_start", 1.0)
         )
     else
         z_shunt = var(pm, nw)[:z_shunt] = JuMP.@variable(pm.model,
-            [i in ids(pm, nw, :shunt)], base_name="$(nw)_z_shunt", 
+            [i in ids(pm, nw, :shunt)], base_name="$(nw)_z_shunt",
             binary = true,
             start = comp_start_value(ref(pm, nw, :shunt, i), "z_shunt_start", 1.0)
         )

--- a/src/form/iv.jl
+++ b/src/form/iv.jl
@@ -111,8 +111,8 @@ function constraint_current_from(pm::AbstractIVRModel, n::Int, f_bus, f_idx, g_s
     vr_fr = var(pm, n, :vr, f_bus)
     vi_fr = var(pm, n, :vi, f_bus)
 
-    csr_fr =  var(pm, n, :csr, f_idx)
-    csi_fr =  var(pm, n, :csi, f_idx)
+    csr_fr =  var(pm, n, :csr, f_idx[1])
+    csi_fr =  var(pm, n, :csi, f_idx[1])
 
     cr_fr =  var(pm, n, :cr, f_idx)
     ci_fr =  var(pm, n, :ci, f_idx)
@@ -128,8 +128,8 @@ function constraint_current_to(pm::AbstractIVRModel, n::Int, t_bus, f_idx, t_idx
     vr_to = var(pm, n, :vr, t_bus)
     vi_to = var(pm, n, :vi, t_bus)
 
-    csr_to =  -var(pm, n, :csr, f_idx)
-    csi_to =  -var(pm, n, :csi, f_idx)
+    csr_to =  -var(pm, n, :csr, f_idx[1])
+    csi_to =  -var(pm, n, :csi, f_idx[1])
 
     cr_to =  var(pm, n, :cr, t_idx)
     ci_to =  var(pm, n, :ci, t_idx)
@@ -149,8 +149,8 @@ function constraint_voltage_drop(pm::AbstractIVRModel, n::Int, i, f_bus, t_bus, 
     vr_to = var(pm, n, :vr, t_bus)
     vi_to = var(pm, n, :vi, t_bus)
 
-    csr_fr =  var(pm, n, :csr, f_idx)
-    csi_fr =  var(pm, n, :csi, f_idx)
+    csr_fr =  var(pm, n, :csr, f_idx[1])
+    csi_fr =  var(pm, n, :csi, f_idx[1])
 
     JuMP.@constraint(pm.model, vr_to == (vr_fr*tr + vi_fr*ti)/tm^2 - r*csr_fr + x*csi_fr)
     JuMP.@constraint(pm.model, vi_to == (vi_fr*tr - vr_fr*ti)/tm^2 - r*csi_fr - x*csr_fr)


### PR DESCRIPTION
This changes the indexing of the series current variable for the IVR form, i.e. from `csr[(l,i,j)] for (l,i,j) in ref(pm, :arcs_from)` to `csr[l] for l in ids(pm, :branch)`.  Note that the series current is still defined in the i->j direction. This change makes it cleaner to report the variable to the solution builder.

This furthermore keeps the implementation consistent with IVR in PMD. 