### PR TITLE
Add linear branch flow model and branch flow storage problem type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@ PowerModels.jl Change Log
 =========================
 
 ### Staged
-- nothing
+- Add support for building storage models with branch flow formulations (#676)
+- A linear branch flow formulation was added (#676)
 
 ### v0.15.2
 - Add support for on/off storage in SOCWRPowerModel

--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ The primary developer is Carleton Coffrin(@ccoffrin) with support from the follo
 - Miles Lubin (@mlubin) MIT, Julia/JuMP advise
 - Yeesian Ng (@yeesian) MIT, Documenter.jl setup
 - Kaarthik Sundar (@kaarthiksundar) LANL, OBBT utility
+- Per Aaslid (@peraaslid) SINTEF ER, Branch flow storage model and linear branch flow formulation
 
 
 ## Citing PowerModels

--- a/src/core/types.jl
+++ b/src/core/types.jl
@@ -29,7 +29,7 @@ abstract type AbstractConicModel <: AbstractPowerModel end
 abstract type AbstractBFModel <: AbstractPowerModel end
 
 
-"for variants of branch flow models that target QP or NLP solvers"
+"for variants of branch flow models that target LP solvers"
 abstract type AbstractBFLPModel <: AbstractBFModel end
 
 "for variants of branch flow models that target QP or NLP solvers"

--- a/src/core/types.jl
+++ b/src/core/types.jl
@@ -28,6 +28,10 @@ abstract type AbstractConicModel <: AbstractPowerModel end
 "for branch flow models"
 abstract type AbstractBFModel <: AbstractPowerModel end
 
+
+"for variants of branch flow models that target QP or NLP solvers"
+abstract type AbstractBFLPModel <: AbstractBFModel end
+
 "for variants of branch flow models that target QP or NLP solvers"
 abstract type AbstractBFQPModel <: AbstractBFModel end
 
@@ -389,6 +393,8 @@ Extended as discussed in:
 """
 mutable struct SOCBFPowerModel <: AbstractSOCBFModel @pm_fields end
 
+
+mutable struct LPBFPowerModel <: AbstractBFLPModel @pm_fields end
 
 ""
 abstract type AbstractSOCBFConicModel <: AbstractBFConicModel end

--- a/src/core/types.jl
+++ b/src/core/types.jl
@@ -398,7 +398,8 @@ Linear approximation of branch flow model.
 
 The implementation builds on the second-order cone relaxation of the branch
 flow model, but neglects the active and reactive loss terms associated with
-the squared current magnitued.
+the squared current magnitude so the power flow equations become linear.
+Note that flow bounds are still second order cones.
 ```
 @article{Baran1989OptimalSystems,
     title = {{Optimal capacitor placement on radial distribution systems}},

--- a/src/core/types.jl
+++ b/src/core/types.jl
@@ -30,7 +30,7 @@ abstract type AbstractBFModel <: AbstractPowerModel end
 
 
 "for variants of branch flow models that target LP solvers"
-abstract type AbstractBFLPModel <: AbstractBFModel end
+abstract type AbstractBFAModel <: AbstractBFModel end
 
 "for variants of branch flow models that target QP or NLP solvers"
 abstract type AbstractBFQPModel <: AbstractBFModel end
@@ -414,7 +414,7 @@ Note that flow bounds are still second order cones.
 }
 ```
 """
-mutable struct LPBFPowerModel <: AbstractBFLPModel @pm_fields end
+mutable struct BFAPowerModel <: AbstractBFAModel @pm_fields end
 
 ""
 abstract type AbstractSOCBFConicModel <: AbstractBFConicModel end

--- a/src/core/types.jl
+++ b/src/core/types.jl
@@ -393,7 +393,26 @@ Extended as discussed in:
 """
 mutable struct SOCBFPowerModel <: AbstractSOCBFModel @pm_fields end
 
+"""
+Linear approximation of branch flow model.
 
+The implementation builds on the second-order cone relaxation of the branch
+flow model, but neglects the active and reactive loss terms associated with
+the squared current magnitued.
+```
+@article{Baran1989OptimalSystems,
+    title = {{Optimal capacitor placement on radial distribution systems}},
+    year = {1989},
+    journal = {IEEE Transactions on Power Delivery},
+    author = {Baran, Mesut E. and Wu, Felix F.},
+    number = {1},
+    pages = {725--734},
+    volume = {4},
+    doi = {10.1109/61.19265},
+    issn = {19374208}
+}
+```
+"""
 mutable struct LPBFPowerModel <: AbstractBFLPModel @pm_fields end
 
 ""

--- a/src/form/bf.jl
+++ b/src/form/bf.jl
@@ -151,28 +151,6 @@ function constraint_voltage_angle_difference(pm::AbstractBFModel, n::Int, f_idx,
         )
 end
 
-# ""
-# function constraint_storage_loss(pm::AbstractBFModel, n::Int, i, bus, r, x, p_loss, q_loss; conductors=[1])
-#     ccm = var(pm, n, :ccm, i)
-#     ps = var(pm, n, :ps, i)
-#     qs = var(pm, n, :qs, i)
-#     sc = var(pm, n, :sc, i)
-#     sd = var(pm, n, :sd, i)
-#
-#
-#     JuMP.@constraint(pm.model,
-#         sum(ps[c] for c in conductors) + (sd - sc)
-#         ==
-#         p_loss + sum(r[c]*ccm[c] for c in conductors)
-#     )
-#
-#     JuMP.@constraint(pm.model,
-#         sum(qs[c] for c in conductors)
-#         ==
-#         q_loss + sum(x[c]*ccm[c] for c in conductors)
-#     )
-# end
-
 """
 Defines linear branch flow model power flow equations
 """

--- a/src/form/bf.jl
+++ b/src/form/bf.jl
@@ -154,7 +154,7 @@ end
 """
 Defines linear branch flow model power flow equations
 """
-function constraint_flow_losses(pm::AbstractBFLPModel, n::Int, i, f_bus, t_bus, f_idx, t_idx, r, x, g_sh_fr, g_sh_to, b_sh_fr, b_sh_to, tm)
+function constraint_flow_losses(pm::AbstractBFAModel, n::Int, i, f_bus, t_bus, f_idx, t_idx, r, x, g_sh_fr, g_sh_to, b_sh_fr, b_sh_to, tm)
     p_fr = var(pm, n, :p, f_idx)
     q_fr = var(pm, n, :q, f_idx)
     p_to = var(pm, n, :p, t_idx)
@@ -170,7 +170,7 @@ end
 """
 Defines voltage drop over a branch, linking from and to side voltage magnitude
 """
-function constraint_voltage_magnitude_difference(pm::AbstractBFLPModel, n::Int, i, f_bus, t_bus, f_idx, t_idx, r, x, g_sh_fr, b_sh_fr, tm)
+function constraint_voltage_magnitude_difference(pm::AbstractBFAModel, n::Int, i, f_bus, t_bus, f_idx, t_idx, r, x, g_sh_fr, b_sh_fr, tm)
     p_fr = var(pm, n, :p, f_idx)
     q_fr = var(pm, n, :q, f_idx)
     w_fr = var(pm, n, :w, f_bus)
@@ -181,18 +181,18 @@ end
 
 
 ""
-function constraint_model_current(pm::AbstractBFLPModel, n::Int)
+function constraint_model_current(pm::AbstractBFAModel, n::Int)
 
 end
 
 ""
-function variable_current_magnitude_sqr(pm::AbstractBFLPModel; nw::Int=pm.cnw, bounded::Bool=true, report::Bool=true)
+function variable_current_magnitude_sqr(pm::AbstractBFAModel; nw::Int=pm.cnw, bounded::Bool=true, report::Bool=true)
 
 end
 
 
 "Neglects the active and reactive loss terms associated with the squared current magnitude."
-function constraint_storage_loss(pm::AbstractBFLPModel, n::Int, i, bus, r, x, p_loss, q_loss; conductors=[1])
+function constraint_storage_loss(pm::AbstractBFAModel, n::Int, i, bus, r, x, p_loss, q_loss; conductors=[1])
     ps = var(pm, n, :ps, i)
     qs = var(pm, n, :qs, i)
     sc = var(pm, n, :sc, i)

--- a/src/form/bf.jl
+++ b/src/form/bf.jl
@@ -151,6 +151,28 @@ function constraint_voltage_angle_difference(pm::AbstractBFModel, n::Int, f_idx,
         )
 end
 
+""
+function constraint_storage_loss(pm::AbstractBFModel, n::Int, i, bus, r, x, p_loss, q_loss; conductors=[1])
+    ccm = var(pm, n, :ccm, i)
+    ps = var(pm, n, :ps, i)
+    qs = var(pm, n, :qs, i)
+    sc = var(pm, n, :sc, i)
+    sd = var(pm, n, :sd, i)
+
+
+    JuMP.@constraint(pm.model,
+        sum(ps[c] for c in conductors) + (sd - sc)
+        ==
+        p_loss + sum(r[c]*ccm[c] for c in conductors)
+    )
+
+    JuMP.@constraint(pm.model,
+        sum(qs[c] for c in conductors)
+        ==
+        q_loss + sum(x[c]*ccm[c] for c in conductors)
+    )
+end
+
 """
 Defines linear branch flow model power flow equations
 """

--- a/src/form/bf.jl
+++ b/src/form/bf.jl
@@ -151,27 +151,27 @@ function constraint_voltage_angle_difference(pm::AbstractBFModel, n::Int, f_idx,
         )
 end
 
-""
-function constraint_storage_loss(pm::AbstractBFModel, n::Int, i, bus, r, x, p_loss, q_loss; conductors=[1])
-    ccm = var(pm, n, :ccm, i)
-    ps = var(pm, n, :ps, i)
-    qs = var(pm, n, :qs, i)
-    sc = var(pm, n, :sc, i)
-    sd = var(pm, n, :sd, i)
-
-
-    JuMP.@constraint(pm.model,
-        sum(ps[c] for c in conductors) + (sd - sc)
-        ==
-        p_loss + sum(r[c]*ccm[c] for c in conductors)
-    )
-
-    JuMP.@constraint(pm.model,
-        sum(qs[c] for c in conductors)
-        ==
-        q_loss + sum(x[c]*ccm[c] for c in conductors)
-    )
-end
+# ""
+# function constraint_storage_loss(pm::AbstractBFModel, n::Int, i, bus, r, x, p_loss, q_loss; conductors=[1])
+#     ccm = var(pm, n, :ccm, i)
+#     ps = var(pm, n, :ps, i)
+#     qs = var(pm, n, :qs, i)
+#     sc = var(pm, n, :sc, i)
+#     sd = var(pm, n, :sd, i)
+#
+#
+#     JuMP.@constraint(pm.model,
+#         sum(ps[c] for c in conductors) + (sd - sc)
+#         ==
+#         p_loss + sum(r[c]*ccm[c] for c in conductors)
+#     )
+#
+#     JuMP.@constraint(pm.model,
+#         sum(qs[c] for c in conductors)
+#         ==
+#         q_loss + sum(x[c]*ccm[c] for c in conductors)
+#     )
+# end
 
 """
 Defines linear branch flow model power flow equations
@@ -213,7 +213,7 @@ function variable_current_magnitude_sqr(pm::AbstractBFLPModel; nw::Int=pm.cnw, b
 end
 
 
-""
+"Neglects the active and reactive loss terms associated with the squared current magnitude."
 function constraint_storage_loss(pm::AbstractBFLPModel, n::Int, i, bus, r, x, p_loss, q_loss; conductors=[1])
     ps = var(pm, n, :ps, i)
     qs = var(pm, n, :qs, i)

--- a/src/form/bf.jl
+++ b/src/form/bf.jl
@@ -150,3 +150,45 @@ function constraint_voltage_angle_difference(pm::AbstractBFModel, n::Int, f_idx,
                  >= ((ti + tzi*g_fr - tzr*b_fr)*(w_fr/tm^2) - tzi*p_fr - tzr*q_fr)
         )
 end
+
+"""
+Defines branch flow model power flow equations
+"""
+function constraint_flow_losses(pm::AbstractBFLPModel, n::Int, i, f_bus, t_bus, f_idx, t_idx, r, x, g_sh_fr, g_sh_to, b_sh_fr, b_sh_to, tm)
+    p_fr = var(pm, n, :p, f_idx)
+    q_fr = var(pm, n, :q, f_idx)
+    p_to = var(pm, n, :p, t_idx)
+    q_to = var(pm, n, :q, t_idx)
+    w_fr = var(pm, n, :w, f_bus)
+    w_to = var(pm, n, :w, t_bus)
+
+    JuMP.@constraint(pm.model, p_fr + p_to == g_sh_fr*(w_fr/tm^2) + g_sh_to*w_to)
+    JuMP.@constraint(pm.model, q_fr + q_to == b_sh_fr*(w_fr/tm^2) + b_sh_to*w_to)
+end
+
+
+"""
+Defines voltage drop over a branch, linking from and to side voltage magnitude
+"""
+function constraint_voltage_magnitude_difference(pm::AbstractBFLPModel, n::Int, i, f_bus, t_bus, f_idx, t_idx, r, x, g_sh_fr, b_sh_fr, tm)
+    p_fr = var(pm, n, :p, f_idx)
+    q_fr = var(pm, n, :q, f_idx)
+    w_fr = var(pm, n, :w, f_bus)
+    w_to = var(pm, n, :w, t_bus)
+
+    JuMP.@constraint(pm.model, (w_fr/tm^2) - w_to ==  2*(r*p_fr + x*q_fr))
+end
+
+
+"""
+Defines relationship between branch (series) power flow, branch (series) current and node voltage magnitude
+"""
+function constraint_model_current(pm::AbstractBFLPModel, n::Int)
+
+
+end
+
+""
+function variable_current_magnitude_sqr(pm::AbstractBFLPModel; nw::Int=pm.cnw, bounded::Bool=true, report::Bool=true)
+
+end

--- a/src/form/bf.jl
+++ b/src/form/bf.jl
@@ -152,7 +152,7 @@ function constraint_voltage_angle_difference(pm::AbstractBFModel, n::Int, f_idx,
 end
 
 """
-Defines branch flow model power flow equations
+Defines linear branch flow model power flow equations
 """
 function constraint_flow_losses(pm::AbstractBFLPModel, n::Int, i, f_bus, t_bus, f_idx, t_idx, r, x, g_sh_fr, g_sh_to, b_sh_fr, b_sh_to, tm)
     p_fr = var(pm, n, :p, f_idx)
@@ -180,15 +180,34 @@ function constraint_voltage_magnitude_difference(pm::AbstractBFLPModel, n::Int, 
 end
 
 
-"""
-Defines relationship between branch (series) power flow, branch (series) current and node voltage magnitude
-"""
+""
 function constraint_model_current(pm::AbstractBFLPModel, n::Int)
-
 
 end
 
 ""
 function variable_current_magnitude_sqr(pm::AbstractBFLPModel; nw::Int=pm.cnw, bounded::Bool=true, report::Bool=true)
 
+end
+
+
+""
+function constraint_storage_loss(pm::AbstractBFLPModel, n::Int, i, bus, r, x, p_loss, q_loss; conductors=[1])
+    ps = var(pm, n, :ps, i)
+    qs = var(pm, n, :qs, i)
+    sc = var(pm, n, :sc, i)
+    sd = var(pm, n, :sd, i)
+
+
+    JuMP.@constraint(pm.model,
+        sum(ps[c] for c in conductors) + (sd - sc)
+        ==
+        p_loss
+    )
+
+    JuMP.@constraint(pm.model,
+        sum(qs[c] for c in conductors)
+        ==
+        q_loss
+    )
 end

--- a/src/form/shared.jl
+++ b/src/form/shared.jl
@@ -15,14 +15,14 @@
 function variable_shunt_factor(pm::AbstractWConvexModels; nw::Int=pm.cnw, relax::Bool=false, report::Bool=true)
     if !relax
         z_shunt = var(pm, nw)[:z_shunt] = JuMP.@variable(pm.model,
-            [i in ids(pm, nw, :shunt)], base_name="$(nw)_z_shunt", 
+            [i in ids(pm, nw, :shunt)], base_name="$(nw)_z_shunt",
             binary = true,
             start = comp_start_value(ref(pm, nw, :shunt, i), "z_shunt_start", 1.0)
         )
     else
         z_shunt = var(pm, nw)[:z_shunt] = JuMP.@variable(pm.model,
-            [i in ids(pm, nw, :shunt)], base_name="$(nw)_z_shunt", 
-            upper_bound = 1, 
+            [i in ids(pm, nw, :shunt)], base_name="$(nw)_z_shunt",
+            upper_bound = 1,
             lower_bound = 0,
             start = comp_start_value(ref(pm, nw, :shunt, i), "z_shunt_start", 1.0)
         )
@@ -343,3 +343,28 @@ function constraint_current_limit(pm::AbstractWModels, n::Int, f_idx, c_rating_a
     JuMP.@constraint(pm.model, p_to^2 + q_to^2 <= w_to*c_rating_a^2)
 end
 
+""
+function constraint_storage_loss(pm::AbstractWModels, n::Int, i, bus, r, x, p_loss, q_loss; conductors=[1])
+    w = var(pm, n, :w, bus)
+    ccms = var(pm, n, :ccms, i)
+    ps = var(pm, n, :ps, i)
+    qs = var(pm, n, :qs, i)
+    sc = var(pm, n, :sc, i)
+    sd = var(pm, n, :sd, i)
+
+    for c in conductors
+        JuMP.@constraint(pm.model, ps[c]^2 + qs[c]^2 <= w[c]*ccms[c])
+    end
+
+    JuMP.@constraint(pm.model,
+        sum(ps[c] for c in conductors) + (sd - sc)
+        ==
+        p_loss + sum(r[c]*ccms[c] for c in conductors)
+    )
+
+    JuMP.@constraint(pm.model,
+        sum(qs[c] for c in conductors)
+        ==
+        q_loss + sum(x[c]*ccms[c] for c in conductors)
+    )
+end

--- a/src/form/wr.jl
+++ b/src/form/wr.jl
@@ -336,34 +336,6 @@ function variable_voltage_product_ne(pm::AbstractWRModel; nw::Int=pm.cnw, report
 end
 
 
-"do nothing by default but some formulations require this"
-function variable_current_storage(pm::AbstractWModels; nw::Int=pm.cnw, bounded::Bool=true, report::Bool=true)
-    ccms = var(pm, nw)[:ccms] = JuMP.@variable(pm.model,
-        [i in ids(pm, nw, :storage)], base_name="$(nw)_ccms",
-        start = comp_start_value(ref(pm, nw, :storage, i), "ccms_start")
-    )
-
-    if bounded
-        bus = ref(pm, nw, :bus)
-        for (i, storage) in ref(pm, nw, :storage)
-            ub = Inf
-            if haskey(storage, "thermal_rating")
-                sb = bus[storage["storage_bus"]]
-                ub = (storage["thermal_rating"]/sb["vmin"])^2
-            end
-
-            JuMP.set_lower_bound(ccms[i], 0.0)
-            if !isinf(ub)
-                JuMP.set_upper_bound(ccms[i], ub)
-            end
-        end
-    end
-
-    report && sol_component_value(pm, nw, :storage, :ccms, ids(pm, nw, :storage), ccms)
-end
-
-
-
 ###### QC Relaxations ######
 
 

--- a/src/form/wr.jl
+++ b/src/form/wr.jl
@@ -337,7 +337,7 @@ end
 
 
 "do nothing by default but some formulations require this"
-function variable_current_storage(pm::AbstractWRModel; nw::Int=pm.cnw, bounded::Bool=true, report::Bool=true)
+function variable_current_storage(pm::AbstractWModels; nw::Int=pm.cnw, bounded::Bool=true, report::Bool=true)
     ccms = var(pm, nw)[:ccms] = JuMP.@variable(pm.model,
         [i in ids(pm, nw, :storage)], base_name="$(nw)_ccms",
         start = comp_start_value(ref(pm, nw, :storage, i), "ccms_start")

--- a/src/form/wr.jl
+++ b/src/form/wr.jl
@@ -362,32 +362,6 @@ function variable_current_storage(pm::AbstractWRModel; nw::Int=pm.cnw, bounded::
     report && sol_component_value(pm, nw, :storage, :ccms, ids(pm, nw, :storage), ccms)
 end
 
-""
-function constraint_storage_loss(pm::AbstractWRModel, n::Int, i, bus, r, x, p_loss, q_loss; conductors=[1])
-    w = var(pm, n, :w, bus)
-    ccms = var(pm, n, :ccms, i)
-    ps = var(pm, n, :ps, i)
-    qs = var(pm, n, :qs, i)
-    sc = var(pm, n, :sc, i)
-    sd = var(pm, n, :sd, i)
-
-    for c in conductors
-        JuMP.@constraint(pm.model, ps[c]^2 + qs[c]^2 <= w[c]*ccms[c])
-    end
-
-    JuMP.@constraint(pm.model, 
-        sum(ps[c] for c in conductors) + (sd - sc)
-        ==
-        p_loss + sum(r[c]*ccms[c] for c in conductors)
-    )
-
-    JuMP.@constraint(pm.model, 
-        sum(qs[c] for c in conductors)
-        ==
-        q_loss + sum(x[c]*ccms[c] for c in conductors)
-    )
-end
-
 
 
 ###### QC Relaxations ######

--- a/src/prob/opf_bf.jl
+++ b/src/prob/opf_bf.jl
@@ -4,6 +4,11 @@ function run_opf_bf(file, model_type::Type{T}, optimizer; kwargs...) where T <: 
 end
 
 ""
+function run_mn_opf_bf_strg(file, model_type::Type, optimizer; kwargs...)
+    return run_model(file, model_type, optimizer, build_mn_opf_bf_strg; multinetwork=true, kwargs...)
+end
+
+""
 function build_opf_bf(pm::AbstractPowerModel)
     variable_voltage(pm)
     variable_generation(pm)
@@ -36,4 +41,61 @@ function build_opf_bf(pm::AbstractPowerModel)
     for i in ids(pm, :dcline)
         constraint_dcline(pm, i)
     end
+end
+
+""
+function build_mn_opf_bf_strg(pm::AbstractPowerModel)
+    for (n, network) in nws(pm)
+        variable_voltage(pm, nw=n)
+        variable_generation(pm, nw=n)
+        variable_storage_mi(pm, nw=n)
+        variable_branch_flow(pm, nw=n)
+        variable_dcline_flow(pm, nw=n)
+
+        constraint_model_current(pm, nw=n)
+
+        for i in ids(pm, :ref_buses, nw=n)
+            constraint_theta_ref(pm, i, nw=n)
+        end
+
+        for i in ids(pm, :bus, nw=n)
+            constraint_power_balance(pm, i, nw=n)
+        end
+
+        for i in ids(pm, :storage, nw=n)
+            constraint_storage_complementarity_mi(pm, i, nw=n)
+            constraint_storage_loss(pm, i, nw=n)
+            constraint_storage_thermal_limit(pm, i, nw=n)
+        end
+
+        for i in ids(pm, :branch, nw=n)
+            constraint_flow_losses(pm, i, nw=n)
+            constraint_voltage_magnitude_difference(pm, i, nw=n)
+
+            constraint_voltage_angle_difference(pm, i, nw=n)
+
+            constraint_thermal_limit_from(pm, i, nw=n)
+            constraint_thermal_limit_to(pm, i, nw=n)
+        end
+
+        for i in ids(pm, :dcline, nw=n)
+            constraint_dcline(pm, i, nw=n)
+        end
+    end
+
+    network_ids = sort(collect(nw_ids(pm)))
+
+    n_1 = network_ids[1]
+    for i in ids(pm, :storage, nw=n_1)
+        constraint_storage_state(pm, i, nw=n_1)
+    end
+
+    for n_2 in network_ids[2:end]
+        for i in ids(pm, :storage, nw=n_2)
+            constraint_storage_state(pm, i, n_1, n_2)
+        end
+        n_1 = n_2
+    end
+
+    objective_min_fuel_and_flow_cost(pm)
 end

--- a/src/prob/opf_bf.jl
+++ b/src/prob/opf_bf.jl
@@ -43,7 +43,7 @@ function build_opf_bf(pm::AbstractPowerModel)
     end
 end
 
-""
+"Build multinetwork branch flow storage OPF"
 function build_mn_opf_bf_strg(pm::AbstractPowerModel)
     for (n, network) in nws(pm)
         variable_voltage(pm, nw=n)

--- a/src/prob/opf_bf.jl
+++ b/src/prob/opf_bf.jl
@@ -50,6 +50,7 @@ function build_mn_opf_bf_strg(pm::AbstractPowerModel)
         variable_generation(pm, nw=n)
         variable_storage_mi(pm, nw=n)
         variable_branch_flow(pm, nw=n)
+        variable_branch_current(pm, nw=n)
         variable_dcline_flow(pm, nw=n)
 
         constraint_model_current(pm, nw=n)

--- a/test/multinetwork.jl
+++ b/test/multinetwork.jl
@@ -311,6 +311,33 @@ TESTLOG = Memento.getlogger(PowerModels)
             @test isapprox(result["solution"]["nw"]["4"]["storage"]["2"]["qs"],  0.0000000; atol = 1e-3)
         end
 
+        @testset "test soc bf opf" begin
+            result = PowerModels.run_mn_opf_bf_strg(mn_data, PowerModels.SOCBFPowerModel, juniper_solver)
+
+            @test result["termination_status"] == LOCALLY_SOLVED
+            @test isapprox(result["objective"], 72407.45; atol = 1e0)
+
+            @test isapprox(result["solution"]["nw"]["1"]["storage"]["1"]["ps"],  0.3460208; atol = 1e-3)
+            @test isapprox(result["solution"]["nw"]["1"]["storage"]["1"]["qs"],  0.0000000; atol = 1e-3)
+            @test isapprox(result["solution"]["nw"]["1"]["storage"]["2"]["ps"],  0.7364543; atol = 1e-3)
+            @test isapprox(result["solution"]["nw"]["1"]["storage"]["2"]["qs"],  0.0000000; atol = 1e-3)
+
+            @test isapprox(result["solution"]["nw"]["2"]["storage"]["1"]["ps"],  0.3460209; atol = 1e-3)
+            @test isapprox(result["solution"]["nw"]["2"]["storage"]["1"]["qs"],  0.0000000; atol = 1e-3)
+            @test isapprox(result["solution"]["nw"]["2"]["storage"]["2"]["ps"],  0.7364541; atol = 1e-3)
+            @test isapprox(result["solution"]["nw"]["2"]["storage"]["2"]["qs"],  0.0000000; atol = 1e-3)
+
+            @test isapprox(result["solution"]["nw"]["3"]["storage"]["1"]["ps"],  0.3460209; atol = 1e-3)
+            @test isapprox(result["solution"]["nw"]["3"]["storage"]["1"]["qs"],  0.0000000; atol = 1e-3)
+            @test isapprox(result["solution"]["nw"]["3"]["storage"]["2"]["ps"],  0.7364537; atol = 1e-3)
+            @test isapprox(result["solution"]["nw"]["3"]["storage"]["2"]["qs"],  0.0000000; atol = 1e-3)
+
+            @test isapprox(result["solution"]["nw"]["4"]["storage"]["1"]["ps"],  0.1660210; atol = 1e-3)
+            @test isapprox(result["solution"]["nw"]["4"]["storage"]["1"]["qs"],  0.0000000; atol = 1e-3)
+            @test isapprox(result["solution"]["nw"]["4"]["storage"]["2"]["ps"],  0.7364528; atol = 1e-3)
+            @test isapprox(result["solution"]["nw"]["4"]["storage"]["2"]["qs"],  0.0000000; atol = 1e-3)
+        end
+
         @testset "test linear bf opf" begin
             result = PowerModels.run_mn_opf_bf_strg(mn_data, PowerModels.LPBFPowerModel, juniper_solver)
 

--- a/test/multinetwork.jl
+++ b/test/multinetwork.jl
@@ -364,6 +364,7 @@ TESTLOG = Memento.getlogger(PowerModels)
             @test isapprox(result["solution"]["nw"]["4"]["storage"]["2"]["ps"],  0.0000000; atol = 1e-3)
             @test isapprox(result["solution"]["nw"]["4"]["storage"]["2"]["qs"],  0.0000000; atol = 1e-3)
 
+            # This formulation is lossless. Sum of loads and storage should equal sum of generation.
             for (n, net) in mn_data["nw"]
                 @test isapprox(sum(l["pd"] for l in values(net["load"])),
                     sum(g["pg"] for g in values(result["solution"]["nw"][n]["gen"])) -

--- a/test/multinetwork.jl
+++ b/test/multinetwork.jl
@@ -352,7 +352,7 @@ TESTLOG = Memento.getlogger(PowerModels)
         end
 
         @testset "test linear bf opf" begin
-            result = PowerModels.run_mn_opf_bf_strg(mn_data, PowerModels.LPBFPowerModel, juniper_solver)
+            result = PowerModels.run_mn_opf_bf_strg(mn_data, PowerModels.BFAPowerModel, juniper_solver)
 
             @test result["termination_status"] == LOCALLY_SOLVED
             @test isapprox(result["objective"], 57980.0; atol = 1e0)

--- a/test/multinetwork.jl
+++ b/test/multinetwork.jl
@@ -197,6 +197,23 @@ TESTLOG = Memento.getlogger(PowerModels)
                 atol = 1e-3
             )
         end
+
+        @testset "test linear bf opf" begin
+            result = PowerModels.run_mn_opf(mn_data, LPBFPowerModel, ipopt_solver)
+
+            @test result["termination_status"] == LOCALLY_SOLVED
+            @test isapprox(result["objective"], 29620.0; atol = 1e0)
+            @test isapprox(
+                result["solution"]["nw"]["1"]["gen"]["2"]["pg"],
+                result["solution"]["nw"]["2"]["gen"]["2"]["pg"];
+                atol = 1e-3
+            )
+            @test isapprox(
+                result["solution"]["nw"]["1"]["gen"]["4"]["pg"],
+                result["solution"]["nw"]["2"]["gen"]["4"]["pg"];
+                atol = 1e-3
+            )
+        end
     end
 
     @testset "2 period 5-bus dual variable case" begin
@@ -286,6 +303,33 @@ TESTLOG = Memento.getlogger(PowerModels)
 
         @testset "test soc opf" begin
             result = PowerModels.run_mn_opf_strg(mn_data, PowerModels.SOCWRPowerModel, juniper_solver)
+
+            @test result["termination_status"] == LOCALLY_SOLVED
+            @test isapprox(result["objective"], 58853.5; atol = 1e0)
+
+            @test isapprox(result["solution"]["nw"]["1"]["storage"]["1"]["ps"], -0.0597052; atol = 1e-3)
+            @test isapprox(result["solution"]["nw"]["1"]["storage"]["1"]["qs"],  0.0000000; atol = 1e-3)
+            @test isapprox(result["solution"]["nw"]["1"]["storage"]["2"]["ps"], -0.0596959; atol = 1e-3)
+            @test isapprox(result["solution"]["nw"]["1"]["storage"]["2"]["qs"],  0.0000000; atol = 1e-3)
+
+            @test isapprox(result["solution"]["nw"]["2"]["storage"]["1"]["ps"], -0.0597053; atol = 1e-3)
+            @test isapprox(result["solution"]["nw"]["2"]["storage"]["1"]["qs"],  0.0000000; atol = 1e-3)
+            @test isapprox(result["solution"]["nw"]["2"]["storage"]["2"]["ps"], -0.0596960; atol = 1e-3)
+            @test isapprox(result["solution"]["nw"]["2"]["storage"]["2"]["qs"],  0.0000000; atol = 1e-3)
+
+            @test isapprox(result["solution"]["nw"]["3"]["storage"]["1"]["ps"], -0.0597056; atol = 1e-3)
+            @test isapprox(result["solution"]["nw"]["3"]["storage"]["1"]["qs"],  0.0000000; atol = 1e-3)
+            @test isapprox(result["solution"]["nw"]["3"]["storage"]["2"]["ps"], -0.0596961; atol = 1e-3)
+            @test isapprox(result["solution"]["nw"]["3"]["storage"]["2"]["qs"],  0.0000000; atol = 1e-3)
+
+            @test isapprox(result["solution"]["nw"]["4"]["storage"]["1"]["ps"],  0.0000000; atol = 1e-3)
+            @test isapprox(result["solution"]["nw"]["4"]["storage"]["1"]["qs"],  0.0000000; atol = 1e-3)
+            @test isapprox(result["solution"]["nw"]["4"]["storage"]["2"]["ps"], -0.0596964; atol = 1e-3)
+            @test isapprox(result["solution"]["nw"]["4"]["storage"]["2"]["qs"],  0.0000000; atol = 1e-3)
+        end
+
+        @testset "test linear bf opf" begin
+            result = PowerModels.run_mn_opf_strg(mn_data, PowerModels.LPBFPowerModel, juniper_solver)
 
             @test result["termination_status"] == LOCALLY_SOLVED
             @test isapprox(result["objective"], 58853.5; atol = 1e0)

--- a/test/multinetwork.jl
+++ b/test/multinetwork.jl
@@ -315,26 +315,26 @@ TESTLOG = Memento.getlogger(PowerModels)
             result = PowerModels.run_mn_opf_bf_strg(mn_data, PowerModels.SOCBFPowerModel, juniper_solver)
 
             @test result["termination_status"] == LOCALLY_SOLVED
-            @test isapprox(result["objective"], 72407.45; atol = 1e0)
+            @test isapprox(result["objective"], 58826.36; atol = 1e0)
 
-            @test isapprox(result["solution"]["nw"]["1"]["storage"]["1"]["ps"],  0.3460208; atol = 1e-3)
+            @test isapprox(result["solution"]["nw"]["1"]["storage"]["1"]["ps"], -0.0597052; atol = 1e-3)
             @test isapprox(result["solution"]["nw"]["1"]["storage"]["1"]["qs"],  0.0000000; atol = 1e-3)
-            @test isapprox(result["solution"]["nw"]["1"]["storage"]["2"]["ps"],  0.7364543; atol = 1e-3)
+            @test isapprox(result["solution"]["nw"]["1"]["storage"]["2"]["ps"], -0.0596960; atol = 1e-3)
             @test isapprox(result["solution"]["nw"]["1"]["storage"]["2"]["qs"],  0.0000000; atol = 1e-3)
 
-            @test isapprox(result["solution"]["nw"]["2"]["storage"]["1"]["ps"],  0.3460209; atol = 1e-3)
+            @test isapprox(result["solution"]["nw"]["2"]["storage"]["1"]["ps"], -0.0597053; atol = 1e-3)
             @test isapprox(result["solution"]["nw"]["2"]["storage"]["1"]["qs"],  0.0000000; atol = 1e-3)
-            @test isapprox(result["solution"]["nw"]["2"]["storage"]["2"]["ps"],  0.7364541; atol = 1e-3)
+            @test isapprox(result["solution"]["nw"]["2"]["storage"]["2"]["ps"], -0.0597053; atol = 1e-3)
             @test isapprox(result["solution"]["nw"]["2"]["storage"]["2"]["qs"],  0.0000000; atol = 1e-3)
 
-            @test isapprox(result["solution"]["nw"]["3"]["storage"]["1"]["ps"],  0.3460209; atol = 1e-3)
+            @test isapprox(result["solution"]["nw"]["3"]["storage"]["1"]["ps"], -0.0597056; atol = 1e-3)
             @test isapprox(result["solution"]["nw"]["3"]["storage"]["1"]["qs"],  0.0000000; atol = 1e-3)
-            @test isapprox(result["solution"]["nw"]["3"]["storage"]["2"]["ps"],  0.7364537; atol = 1e-3)
+            @test isapprox(result["solution"]["nw"]["3"]["storage"]["2"]["ps"], -0.0596962; atol = 1e-3)
             @test isapprox(result["solution"]["nw"]["3"]["storage"]["2"]["qs"],  0.0000000; atol = 1e-3)
 
-            @test isapprox(result["solution"]["nw"]["4"]["storage"]["1"]["ps"],  0.1660210; atol = 1e-3)
+            @test isapprox(result["solution"]["nw"]["4"]["storage"]["1"]["ps"],  0.0000000; atol = 1e-3)
             @test isapprox(result["solution"]["nw"]["4"]["storage"]["1"]["qs"],  0.0000000; atol = 1e-3)
-            @test isapprox(result["solution"]["nw"]["4"]["storage"]["2"]["ps"],  0.7364528; atol = 1e-3)
+            @test isapprox(result["solution"]["nw"]["4"]["storage"]["2"]["ps"], -0.0596964; atol = 1e-3)
             @test isapprox(result["solution"]["nw"]["4"]["storage"]["2"]["qs"],  0.0000000; atol = 1e-3)
         end
 

--- a/test/multinetwork.jl
+++ b/test/multinetwork.jl
@@ -197,23 +197,6 @@ TESTLOG = Memento.getlogger(PowerModels)
                 atol = 1e-3
             )
         end
-
-        @testset "test linear bf opf" begin
-            result = PowerModels.run_mn_opf(mn_data, LPBFPowerModel, ipopt_solver)
-
-            @test result["termination_status"] == LOCALLY_SOLVED
-            @test isapprox(result["objective"], 29620.0; atol = 1e0)
-            @test isapprox(
-                result["solution"]["nw"]["1"]["gen"]["2"]["pg"],
-                result["solution"]["nw"]["2"]["gen"]["2"]["pg"];
-                atol = 1e-3
-            )
-            @test isapprox(
-                result["solution"]["nw"]["1"]["gen"]["4"]["pg"],
-                result["solution"]["nw"]["2"]["gen"]["4"]["pg"];
-                atol = 1e-3
-            )
-        end
     end
 
     @testset "2 period 5-bus dual variable case" begin
@@ -329,29 +312,29 @@ TESTLOG = Memento.getlogger(PowerModels)
         end
 
         @testset "test linear bf opf" begin
-            result = PowerModels.run_mn_opf_strg(mn_data, PowerModels.LPBFPowerModel, juniper_solver)
+            result = PowerModels.run_mn_opf_bf_strg(mn_data, PowerModels.LPBFPowerModel, juniper_solver)
 
             @test result["termination_status"] == LOCALLY_SOLVED
-            @test isapprox(result["objective"], 58853.5; atol = 1e0)
+            @test isapprox(result["objective"], 57980.0; atol = 1e0)
 
-            @test isapprox(result["solution"]["nw"]["1"]["storage"]["1"]["ps"], -0.0597052; atol = 1e-3)
+            @test isapprox(result["solution"]["nw"]["1"]["storage"]["1"]["ps"],  0.0000000; atol = 1e-3)
             @test isapprox(result["solution"]["nw"]["1"]["storage"]["1"]["qs"],  0.0000000; atol = 1e-3)
-            @test isapprox(result["solution"]["nw"]["1"]["storage"]["2"]["ps"], -0.0596959; atol = 1e-3)
+            @test isapprox(result["solution"]["nw"]["1"]["storage"]["2"]["ps"], -0.0834412; atol = 1e-3)
             @test isapprox(result["solution"]["nw"]["1"]["storage"]["2"]["qs"],  0.0000000; atol = 1e-3)
 
-            @test isapprox(result["solution"]["nw"]["2"]["storage"]["1"]["ps"], -0.0597053; atol = 1e-3)
+            @test isapprox(result["solution"]["nw"]["2"]["storage"]["1"]["ps"],  0.0000000; atol = 1e-3)
             @test isapprox(result["solution"]["nw"]["2"]["storage"]["1"]["qs"],  0.0000000; atol = 1e-3)
-            @test isapprox(result["solution"]["nw"]["2"]["storage"]["2"]["ps"], -0.0596960; atol = 1e-3)
+            @test isapprox(result["solution"]["nw"]["2"]["storage"]["2"]["ps"],  0.0000000; atol = 1e-3)
             @test isapprox(result["solution"]["nw"]["2"]["storage"]["2"]["qs"],  0.0000000; atol = 1e-3)
 
-            @test isapprox(result["solution"]["nw"]["3"]["storage"]["1"]["ps"], -0.0597056; atol = 1e-3)
+            @test isapprox(result["solution"]["nw"]["3"]["storage"]["1"]["ps"],  0.0000000; atol = 1e-3)
             @test isapprox(result["solution"]["nw"]["3"]["storage"]["1"]["qs"],  0.0000000; atol = 1e-3)
-            @test isapprox(result["solution"]["nw"]["3"]["storage"]["2"]["ps"], -0.0596961; atol = 1e-3)
+            @test isapprox(result["solution"]["nw"]["3"]["storage"]["2"]["ps"], -0.1565587; atol = 1e-3)
             @test isapprox(result["solution"]["nw"]["3"]["storage"]["2"]["qs"],  0.0000000; atol = 1e-3)
 
-            @test isapprox(result["solution"]["nw"]["4"]["storage"]["1"]["ps"],  0.0000000; atol = 1e-3)
+            @test isapprox(result["solution"]["nw"]["4"]["storage"]["1"]["ps"], -0.1800000; atol = 1e-3)
             @test isapprox(result["solution"]["nw"]["4"]["storage"]["1"]["qs"],  0.0000000; atol = 1e-3)
-            @test isapprox(result["solution"]["nw"]["4"]["storage"]["2"]["ps"], -0.0596964; atol = 1e-3)
+            @test isapprox(result["solution"]["nw"]["4"]["storage"]["2"]["ps"],  0.0000000; atol = 1e-3)
             @test isapprox(result["solution"]["nw"]["4"]["storage"]["2"]["qs"],  0.0000000; atol = 1e-3)
         end
 

--- a/test/multinetwork.jl
+++ b/test/multinetwork.jl
@@ -336,6 +336,13 @@ TESTLOG = Memento.getlogger(PowerModels)
             @test isapprox(result["solution"]["nw"]["4"]["storage"]["1"]["qs"],  0.0000000; atol = 1e-3)
             @test isapprox(result["solution"]["nw"]["4"]["storage"]["2"]["ps"],  0.0000000; atol = 1e-3)
             @test isapprox(result["solution"]["nw"]["4"]["storage"]["2"]["qs"],  0.0000000; atol = 1e-3)
+
+            for (n, net) in mn_data["nw"]
+                @test isapprox(sum(l["pd"] for l in values(net["load"])),
+                    sum(g["pg"] for g in values(result["solution"]["nw"][n]["gen"])) -
+                    sum(s["ps"] for s in values(result["solution"]["nw"][n]["storage"]));
+                    atol = 1e-3)
+            end
         end
 
         @testset "test dc polar opf" begin

--- a/test/opf.jl
+++ b/test/opf.jl
@@ -746,10 +746,14 @@ end
         @test isapprox(result["objective"], 5658.22; atol = 1e0)
     end
     @testset "5-bus transformer swap case" begin
-        result = run_opf_bf("../test/data/matpower/case5.m", LPBFPowerModel, ipopt_solver)
+        data = PowerModels.parse_file("../test/data/matpower/case5.m")
+        result = run_opf_bf(data, LPBFPowerModel, ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 14810; atol = 1e0)
+        @test isapprox(sum(l["pd"] for l in values(data["load"])),
+            sum(g["pg"] for g in values(result["solution"]["gen"]));
+            atol = 1e-3)
     end
     @testset "5-bus asymmetric case" begin
         result = run_opf_bf("../test/data/matpower/case5_asym.m", LPBFPowerModel, ipopt_solver)

--- a/test/opf.jl
+++ b/test/opf.jl
@@ -738,6 +738,66 @@ end
     end
 end
 
+@testset "test linear distflow opf_bf" begin
+    @testset "3-bus case" begin
+        result = run_opf_bf("../test/data/matpower/case3.m", LPBFPowerModel, ipopt_solver)
+
+        @test result["termination_status"] == LOCALLY_SOLVED
+        @test isapprox(result["objective"], 5658.22; atol = 1e0)
+    end
+    @testset "5-bus transformer swap case" begin
+        result = run_opf_bf("../test/data/matpower/case5.m", LPBFPowerModel, ipopt_solver)
+
+        @test result["termination_status"] == LOCALLY_SOLVED
+        @test isapprox(result["objective"], 14810; atol = 1e0)
+    end
+    @testset "5-bus asymmetric case" begin
+        result = run_opf_bf("../test/data/matpower/case5_asym.m", LPBFPowerModel, ipopt_solver)
+
+        @test result["termination_status"] == LOCALLY_SOLVED
+        @test isapprox(result["objective"], 14810; atol = 1e0)
+    end
+    @testset "5-bus gap case" begin
+        result = run_opf_bf("../test/data/matpower/case5_gap.m", LPBFPowerModel, ipopt_solver)
+
+        @test result["termination_status"] == LOCALLY_SOLVED
+        @test isapprox(result["objective"], -27410.0; atol = 1e0)
+    end
+    @testset "5-bus with asymmetric line charge" begin
+        result = run_opf_bf("../test/data/pti/case5_alc.raw", LPBFPowerModel, ipopt_solver)
+
+        @test result["termination_status"] == LOCALLY_SOLVED
+        @test isapprox(result["objective"], 1002.46; atol = 1e0)
+    end
+    @testset "5-bus with pwl costs" begin
+        result = run_opf_bf("../test/data/matpower/case5_pwlc.m", LPBFPowerModel, ipopt_solver)
+
+        @test result["termination_status"] == LOCALLY_SOLVED
+        @test isapprox(result["objective"], 42565.8; atol = 1e0)
+    end
+    @testset "6-bus case" begin
+        result = run_opf_bf("../test/data/matpower/case6.m", LPBFPowerModel, ipopt_solver)
+
+        @test result["termination_status"] == LOCALLY_SOLVED
+        @test isapprox(result["objective"], 11277.9; atol = 1e0)
+    end
+    # @testset "24-bus rts case" begin
+    #     result = run_opf_bf("../test/data/matpower/case24.m", LPBFPowerModel, ipopt_solver)
+    #
+    #     @test result["termination_status"] == LOCALLY_SOLVED
+    #     @test isapprox(result["objective"], 70690.7; atol = 1e0)
+    # end
+    @testset "3-bus case w/ r,x=0 on branch" begin
+        mp_data = PowerModels.parse_file("../test/data/matpower/case3.m")
+        mp_data["branch"]["1"]["br_r"] = mp_data["branch"]["1"]["br_x"] = 0.0
+        result = run_opf_bf(mp_data, LPBFPowerModel, ipopt_solver)
+        @test result["termination_status"] == LOCALLY_SOLVED
+    end
+    @testset "14-bus variable bounds" begin
+        pm = instantiate_model("../test/data/matpower/case14.m", LPBFPowerModel, PowerModels.build_opf_bf)
+        @test check_variable_bounds(pm.model)
+    end
+end
 
 @testset "test qc opf" begin
     @testset "3-bus case" begin

--- a/test/opf.jl
+++ b/test/opf.jl
@@ -740,14 +740,14 @@ end
 
 @testset "test linear distflow opf_bf" begin
     @testset "3-bus case" begin
-        result = run_opf_bf("../test/data/matpower/case3.m", LPBFPowerModel, ipopt_solver)
+        result = run_opf_bf("../test/data/matpower/case3.m", BFAPowerModel, ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 5658.22; atol = 1e0)
     end
     @testset "5-bus transformer swap case" begin
         data = PowerModels.parse_file("../test/data/matpower/case5.m")
-        result = run_opf_bf(data, LPBFPowerModel, ipopt_solver)
+        result = run_opf_bf(data, BFAPowerModel, ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 14810; atol = 1e0)
@@ -756,37 +756,37 @@ end
             atol = 1e-3)
     end
     @testset "5-bus asymmetric case" begin
-        result = run_opf_bf("../test/data/matpower/case5_asym.m", LPBFPowerModel, ipopt_solver)
+        result = run_opf_bf("../test/data/matpower/case5_asym.m", BFAPowerModel, ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 14810; atol = 1e0)
     end
     @testset "5-bus gap case" begin
-        result = run_opf_bf("../test/data/matpower/case5_gap.m", LPBFPowerModel, ipopt_solver)
+        result = run_opf_bf("../test/data/matpower/case5_gap.m", BFAPowerModel, ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], -27410.0; atol = 1e0)
     end
     @testset "5-bus with asymmetric line charge" begin
-        result = run_opf_bf("../test/data/pti/case5_alc.raw", LPBFPowerModel, ipopt_solver)
+        result = run_opf_bf("../test/data/pti/case5_alc.raw", BFAPowerModel, ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 1002.46; atol = 1e0)
     end
     @testset "5-bus with pwl costs" begin
-        result = run_opf_bf("../test/data/matpower/case5_pwlc.m", LPBFPowerModel, ipopt_solver)
+        result = run_opf_bf("../test/data/matpower/case5_pwlc.m", BFAPowerModel, ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 42565.8; atol = 1e0)
     end
     @testset "6-bus case" begin
-        result = run_opf_bf("../test/data/matpower/case6.m", LPBFPowerModel, ipopt_solver)
+        result = run_opf_bf("../test/data/matpower/case6.m", BFAPowerModel, ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 11277.9; atol = 1e0)
     end
     # @testset "24-bus rts case" begin
-    #     result = run_opf_bf("../test/data/matpower/case24.m", LPBFPowerModel, ipopt_solver)
+    #     result = run_opf_bf("../test/data/matpower/case24.m", BFAPowerModel, ipopt_solver)
     #
     #     @test result["termination_status"] == LOCALLY_SOLVED
     #     @test isapprox(result["objective"], 70690.7; atol = 1e0)
@@ -794,11 +794,11 @@ end
     @testset "3-bus case w/ r,x=0 on branch" begin
         mp_data = PowerModels.parse_file("../test/data/matpower/case3.m")
         mp_data["branch"]["1"]["br_r"] = mp_data["branch"]["1"]["br_x"] = 0.0
-        result = run_opf_bf(mp_data, LPBFPowerModel, ipopt_solver)
+        result = run_opf_bf(mp_data, BFAPowerModel, ipopt_solver)
         @test result["termination_status"] == LOCALLY_SOLVED
     end
     @testset "14-bus variable bounds" begin
-        pm = instantiate_model("../test/data/matpower/case14.m", LPBFPowerModel, PowerModels.build_opf_bf)
+        pm = instantiate_model("../test/data/matpower/case14.m", BFAPowerModel, PowerModels.build_opf_bf)
         @test check_variable_bounds(pm.model)
     end
 end

--- a/test/pf.jl
+++ b/test/pf.jl
@@ -311,6 +311,54 @@ end
 end
 
 
+@testset "test linear distflow pf_bf" begin
+    @testset "3-bus case" begin
+        result = run_pf_bf("../test/data/matpower/case3.m", LPBFPowerModel, ipopt_solver, solution_processors=[sol_data_model!])
+
+        @test result["termination_status"] == LOCALLY_SOLVED
+        @test isapprox(result["objective"], 0; atol = 1e-2)
+
+        @test result["solution"]["gen"]["1"]["pg"] >= 1.480
+
+        @test isapprox(result["solution"]["gen"]["2"]["pg"], 1.600063; atol = 1e-3)
+        @test isapprox(result["solution"]["gen"]["3"]["pg"], 0.0; atol = 1e-3)
+
+        @test isapprox(result["solution"]["bus"]["1"]["vm"], 1.09999; atol = 1e-3)
+        @test isapprox(result["solution"]["bus"]["2"]["vm"], 0.92616; atol = 1e-3)
+        @test isapprox(result["solution"]["bus"]["3"]["vm"], 0.89999; atol = 1e-3)
+
+        @test isapprox(result["solution"]["dcline"]["1"]["pf"],  0.10; atol = 1e-4)
+        @test isapprox(result["solution"]["dcline"]["1"]["pt"], -0.10; atol = 1e-4)
+    end
+    @testset "5-bus asymmetric case" begin
+        result = run_pf_bf("../test/data/matpower/case5_asym.m", LPBFPowerModel, ipopt_solver)
+
+        @test result["termination_status"] == LOCALLY_SOLVED
+        @test isapprox(result["objective"], 0; atol = 1e-2)
+    end
+    @testset "5-bus case with hvdc line" begin
+        result = run_pf_bf("../test/data/matpower/case5_dc.m", LPBFPowerModel, ipopt_solver)
+
+        @test result["termination_status"] == LOCALLY_SOLVED
+        @test isapprox(result["objective"], 0; atol = 1e-2)
+    end
+    @testset "6-bus case" begin
+        result = run_pf_bf("../test/data/matpower/case6.m", LPBFPowerModel, ipopt_solver, solution_processors=[sol_data_model!])
+
+        @test result["termination_status"] == LOCALLY_SOLVED
+        @test isapprox(result["objective"], 0; atol = 1e-2)
+        @test isapprox(result["solution"]["bus"]["1"]["vm"], 1.09999; atol = 1e-3)
+        @test isapprox(result["solution"]["bus"]["4"]["vm"], 1.09999; atol = 1e-3)
+    end
+    @testset "24-bus rts case" begin
+        result = run_pf_bf("../test/data/matpower/case24.m", LPBFPowerModel, ipopt_solver)
+
+        @test result["termination_status"] == LOCALLY_SOLVED
+        @test isapprox(result["objective"], 0; atol = 1e-2)
+    end
+end
+
+
 @testset "test sdp pf" begin
     # note: may have issues on linux (04/02/18)
     @testset "3-bus case" begin

--- a/test/pf.jl
+++ b/test/pf.jl
@@ -313,7 +313,7 @@ end
 
 @testset "test linear distflow pf_bf" begin
     @testset "3-bus case" begin
-        result = run_pf_bf("../test/data/matpower/case3.m", LPBFPowerModel, ipopt_solver, solution_processors=[sol_data_model!])
+        result = run_pf_bf("../test/data/matpower/case3.m", BFAPowerModel, ipopt_solver, solution_processors=[sol_data_model!])
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 0; atol = 1e-2)
@@ -331,19 +331,19 @@ end
         @test isapprox(result["solution"]["dcline"]["1"]["pt"], -0.10; atol = 1e-4)
     end
     @testset "5-bus asymmetric case" begin
-        result = run_pf_bf("../test/data/matpower/case5_asym.m", LPBFPowerModel, ipopt_solver)
+        result = run_pf_bf("../test/data/matpower/case5_asym.m", BFAPowerModel, ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 0; atol = 1e-2)
     end
     @testset "5-bus case with hvdc line" begin
-        result = run_pf_bf("../test/data/matpower/case5_dc.m", LPBFPowerModel, ipopt_solver)
+        result = run_pf_bf("../test/data/matpower/case5_dc.m", BFAPowerModel, ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 0; atol = 1e-2)
     end
     @testset "6-bus case" begin
-        result = run_pf_bf("../test/data/matpower/case6.m", LPBFPowerModel, ipopt_solver, solution_processors=[sol_data_model!])
+        result = run_pf_bf("../test/data/matpower/case6.m", BFAPowerModel, ipopt_solver, solution_processors=[sol_data_model!])
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 0; atol = 1e-2)
@@ -352,7 +352,7 @@ end
     end
     @testset "24-bus rts case" begin
         data = parse_file("../test/data/matpower/case24.m")
-        result = run_pf_bf(data, LPBFPowerModel, ipopt_solver)
+        result = run_pf_bf(data, BFAPowerModel, ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 0; atol = 1e-2)

--- a/test/pf.jl
+++ b/test/pf.jl
@@ -351,10 +351,14 @@ end
         @test isapprox(result["solution"]["bus"]["4"]["vm"], 1.09999; atol = 1e-3)
     end
     @testset "24-bus rts case" begin
-        result = run_pf_bf("../test/data/matpower/case24.m", LPBFPowerModel, ipopt_solver)
+        data = parse_file("../test/data/matpower/case24.m")
+        result = run_pf_bf(data, LPBFPowerModel, ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 0; atol = 1e-2)
+        @test isapprox(sum(l["pd"] for l in values(data["load"])),
+            sum(g["pg"] for g in values(result["solution"]["gen"]));
+            atol = 1e-3)
     end
 end
 


### PR DESCRIPTION
This PR adds the linearized branch flow model formulation for OPF and PF including tests. A storage problem for branch flow has also been added (`build_mn_opf_bf_strg`) and tested for both the new linearized branch flow and existing branch flow. `build_mn_opf_bf_strg` is the branch flow equivalent of bus injection model problem `build_mn_opf_strg`