### PR TITLE
PSSE transformer Zeq scaling, winding and nominal voltage import all fix

### DIFF
--- a/src/io/psse.jl
+++ b/src/io/psse.jl
@@ -360,9 +360,23 @@ function _psse2pm_transformer!(pm_data::Dict, pti_data::Dict, import_all::Bool)
                     br_x *= (transformer["NOMV1"]^2 / _get_bus_value(transformer["I"], "base_kv", pm_data)^2) * (pm_data["baseMVA"] / transformer["SBASE1-2"])
                 end
 
-				# Tap Zeq scaling
-                sub_data["br_r"] = br_r * (transformer["WINDV2"]/transformer["NOMV2"])^2
-                sub_data["br_x"] = br_x * (transformer["WINDV2"]/transformer["NOMV2"])^2
+				# Zeq scaling for tap2 (see eq (4.21b) in PROGRAM APPLICATION GUIDE 1 in PSSE installation folder)
+                # Unit Transformations
+                if transformer["CW"] == 1  # "for off-nominal turns ratio in pu of winding bus base voltage"
+					br_r *= (transformer["WINDV2"])^2
+					br_x *= (transformer["WINDV2"])^2
+				else  # NOT "for off-nominal turns ratio in pu of winding bus base voltage"
+					if transformer["CW"] == 2  # "for winding voltage in kV"
+						br_r *= (transformer["WINDV2"]/_get_bus_value(transformer["J"], "base_kv", pm_data))^2
+						br_x *= (transformer["WINDV2"]/_get_bus_value(transformer["J"], "base_kv", pm_data))^2
+					else  # "for off-nominal turns ratio in pu of nominal winding voltage, NOMV1, NOMV2 and NOMV3."
+						br_r *= (transformer["WINDV2"]*(transformer["NOMV2"]/_get_bus_value(transformer["J"], "base_kv", pm_data)))^2
+						br_x *= (transformer["WINDV2"]*(transformer["NOMV2"]/_get_bus_value(transformer["J"], "base_kv", pm_data)))^2
+					end
+				end
+
+                sub_data["br_r"] = br_r
+                sub_data["br_x"] = br_x
 
                 sub_data["g_fr"] = pop!(transformer, "MAG1")
                 sub_data["b_fr"] = pop!(transformer, "MAG2")
@@ -383,7 +397,7 @@ function _psse2pm_transformer!(pm_data::Dict, pti_data::Dict, import_all::Bool)
                     delete!(sub_data, "rate_c")
                 end
 
-                sub_data["tap"] = transformer["WINDV1"] / transformer["WINDV2"]
+                sub_data["tap"] = pop!(transformer, "WINDV1") / pop!(transformer, "WINDV2")
                 sub_data["shift"] = pop!(transformer, "ANG1")
 
                 # Unit Transformations
@@ -409,7 +423,7 @@ function _psse2pm_transformer!(pm_data::Dict, pti_data::Dict, import_all::Bool)
 
                 _import_remaining!(sub_data, transformer, import_all; exclude=["I", "J", "K", "CZ", "CW", "R1-2", "R2-3", "R3-1",
                                                                               "X1-2", "X2-3", "X3-1", "SBASE1-2", "SBASE2-3",
-                                                                              "SBASE3-1", "MAG1", "MAG2", "STAT"])
+                                                                              "SBASE3-1", "MAG1", "MAG2", "STAT", "NOMV1", "NOMV2"])
 
                 push!(pm_data["branch"], sub_data)
             else  # Three-winding Transformers
@@ -445,15 +459,34 @@ function _psse2pm_transformer!(pm_data::Dict, pti_data::Dict, import_all::Bool)
                     br_x23 *= (transformer["NOMV2"]^2 / _get_bus_value(bus_id2, "base_kv", pm_data)^2) * (pm_data["baseMVA"] / transformer["SBASE2-3"])
                     br_x31 *= (transformer["NOMV3"]^2 / _get_bus_value(bus_id3, "base_kv", pm_data)^2) * (pm_data["baseMVA"] / transformer["SBASE3-1"])
                 end
-
-				# Tap Zeq scaling
-				br_r12 *= (transformer["WINDV2"]/transformer["NOMV2"])^2
-				br_r23 *= (transformer["WINDV3"]/transformer["NOMV3"])^2
-				br_r31 *= (transformer["WINDV1"]/transformer["NOMV1"])^2
-				br_b12 *= (transformer["WINDV2"]/transformer["NOMV2"])^2
-				br_b23 *= (transformer["WINDV3"]/transformer["NOMV3"])^2
-				br_b31 *= (transformer["WINDV1"]/transformer["NOMV1"])^2				
 				
+				# Zeq scaling for tap2 (see eq (4.21b) in PROGRAM APPLICATION GUIDE 1 in PSSE installation folder)
+                # Unit Transformations
+                if transformer["CW"] == 1  # "for off-nominal turns ratio in pu of winding bus base voltage"
+					br_r12 *= (transformer["WINDV2"])^2
+					br_x12 *= (transformer["WINDV2"])^2
+					br_r23 *= (transformer["WINDV3"])^2
+					br_x23 *= (transformer["WINDV3"])^2
+					br_r31 *= (transformer["WINDV1"])^2
+					br_x31 *= (transformer["WINDV1"])^2
+				else  # NOT "for off-nominal turns ratio in pu of winding bus base voltage"
+					if transformer["CW"] == 2  # "for winding voltage in kV"
+						br_r12 *= (transformer["WINDV2"]/_get_bus_value(transformer["J"], "base_kv", pm_data))^2
+						br_x12 *= (transformer["WINDV2"]/_get_bus_value(transformer["J"], "base_kv", pm_data))^2
+						br_r23 *= (transformer["WINDV3"]/_get_bus_value(transformer["K"], "base_kv", pm_data))^2
+						br_x23 *= (transformer["WINDV3"]/_get_bus_value(transformer["K"], "base_kv", pm_data))^2
+						br_r31 *= (transformer["WINDV1"]/_get_bus_value(transformer["I"], "base_kv", pm_data))^2
+						br_x31 *= (transformer["WINDV1"]/_get_bus_value(transformer["I"], "base_kv", pm_data))^2
+					else  # "for off-nominal turns ratio in pu of nominal winding voltage, NOMV1, NOMV2 and NOMV3."
+						br_r12 *= (transformer["WINDV2"]*(transformer["NOMV2"]/_get_bus_value(transformer["J"], "base_kv", pm_data)))^2
+						br_x12 *= (transformer["WINDV2"]*(transformer["NOMV2"]/_get_bus_value(transformer["J"], "base_kv", pm_data)))^2
+						br_r23 *= (transformer["WINDV3"]*(transformer["NOMV3"]/_get_bus_value(transformer["K"], "base_kv", pm_data)))^2
+						br_x23 *= (transformer["WINDV3"]*(transformer["NOMV3"]/_get_bus_value(transformer["K"], "base_kv", pm_data)))^2
+						br_r31 *= (transformer["WINDV1"]*(transformer["NOMV1"]/_get_bus_value(transformer["I"], "base_kv", pm_data)))^2
+						br_x31 *= (transformer["WINDV1"]*(transformer["NOMV1"]/_get_bus_value(transformer["I"], "base_kv", pm_data)))^2
+					end
+				end
+
                 # See "Power System Stability and Control", ISBN: 0-07-035958-X, Eq. 6.72
                 Zr_p = 1/2 * (br_r12 - br_r23 + br_r31)
                 Zr_s = 1/2 * (br_r23 - br_r31 + br_r12)
@@ -491,7 +524,7 @@ function _psse2pm_transformer!(pm_data::Dict, pti_data::Dict, import_all::Bool)
                         delete!(sub_data, "rate_c")
                     end
 
-                    sub_data["tap"] = transformer["WINDV$m"]
+                    sub_data["tap"] = pop!(transformer, "WINDV$m")
                     sub_data["shift"] = pop!(transformer, "ANG$m")
 
                     # Unit Transformations
@@ -524,7 +557,8 @@ function _psse2pm_transformer!(pm_data::Dict, pti_data::Dict, import_all::Bool)
                     _import_remaining!(sub_data, transformer, import_all; 
                         exclude=["I", "J", "K", "CZ", "CW", "R1-2", "R2-3", "R3-1",
                               "X1-2", "X2-3", "X3-1", "SBASE1-2", "SBASE2-3", "CKT",
-                              "SBASE3-1", "MAG1", "MAG2", "STAT","RATA1",
+                              "SBASE3-1", "MAG1", "MAG2", "STAT","NOMV1", "NOMV2",
+                              "NOMV3", "WINDV1", "WINDV2", "WINDV3", "RATA1",
                               "RATA2", "RATA3", "RATB1", "RATB2", "RATB3", "RATC1",
                               "RATC2", "RATC3", "ANG1", "ANG2", "ANG3"]
                         )

--- a/src/io/psse.jl
+++ b/src/io/psse.jl
@@ -459,7 +459,7 @@ function _psse2pm_transformer!(pm_data::Dict, pti_data::Dict, import_all::Bool)
                     br_x23 *= (transformer["NOMV2"]^2 / _get_bus_value(bus_id2, "base_kv", pm_data)^2) * (pm_data["baseMVA"] / transformer["SBASE2-3"])
                     br_x31 *= (transformer["NOMV3"]^2 / _get_bus_value(bus_id3, "base_kv", pm_data)^2) * (pm_data["baseMVA"] / transformer["SBASE3-1"])
                 end
-				
+
                 # See "Power System Stability and Control", ISBN: 0-07-035958-X, Eq. 6.72
                 Zr_p = 1/2 * (br_r12 - br_r23 + br_r31)
                 Zr_s = 1/2 * (br_r23 - br_r31 + br_r12)

--- a/src/io/psse.jl
+++ b/src/io/psse.jl
@@ -460,33 +460,6 @@ function _psse2pm_transformer!(pm_data::Dict, pti_data::Dict, import_all::Bool)
                     br_x31 *= (transformer["NOMV3"]^2 / _get_bus_value(bus_id3, "base_kv", pm_data)^2) * (pm_data["baseMVA"] / transformer["SBASE3-1"])
                 end
 				
-				# Zeq scaling for tap2 (see eq (4.21b) in PROGRAM APPLICATION GUIDE 1 in PSSE installation folder)
-                # Unit Transformations
-                if transformer["CW"] == 1  # "for off-nominal turns ratio in pu of winding bus base voltage"
-					br_r12 *= (transformer["WINDV2"])^2
-					br_x12 *= (transformer["WINDV2"])^2
-					br_r23 *= (transformer["WINDV3"])^2
-					br_x23 *= (transformer["WINDV3"])^2
-					br_r31 *= (transformer["WINDV1"])^2
-					br_x31 *= (transformer["WINDV1"])^2
-				else  # NOT "for off-nominal turns ratio in pu of winding bus base voltage"
-					if transformer["CW"] == 2  # "for winding voltage in kV"
-						br_r12 *= (transformer["WINDV2"]/_get_bus_value(transformer["J"], "base_kv", pm_data))^2
-						br_x12 *= (transformer["WINDV2"]/_get_bus_value(transformer["J"], "base_kv", pm_data))^2
-						br_r23 *= (transformer["WINDV3"]/_get_bus_value(transformer["K"], "base_kv", pm_data))^2
-						br_x23 *= (transformer["WINDV3"]/_get_bus_value(transformer["K"], "base_kv", pm_data))^2
-						br_r31 *= (transformer["WINDV1"]/_get_bus_value(transformer["I"], "base_kv", pm_data))^2
-						br_x31 *= (transformer["WINDV1"]/_get_bus_value(transformer["I"], "base_kv", pm_data))^2
-					else  # "for off-nominal turns ratio in pu of nominal winding voltage, NOMV1, NOMV2 and NOMV3."
-						br_r12 *= (transformer["WINDV2"]*(transformer["NOMV2"]/_get_bus_value(transformer["J"], "base_kv", pm_data)))^2
-						br_x12 *= (transformer["WINDV2"]*(transformer["NOMV2"]/_get_bus_value(transformer["J"], "base_kv", pm_data)))^2
-						br_r23 *= (transformer["WINDV3"]*(transformer["NOMV3"]/_get_bus_value(transformer["K"], "base_kv", pm_data)))^2
-						br_x23 *= (transformer["WINDV3"]*(transformer["NOMV3"]/_get_bus_value(transformer["K"], "base_kv", pm_data)))^2
-						br_r31 *= (transformer["WINDV1"]*(transformer["NOMV1"]/_get_bus_value(transformer["I"], "base_kv", pm_data)))^2
-						br_x31 *= (transformer["WINDV1"]*(transformer["NOMV1"]/_get_bus_value(transformer["I"], "base_kv", pm_data)))^2
-					end
-				end
-
                 # See "Power System Stability and Control", ISBN: 0-07-035958-X, Eq. 6.72
                 Zr_p = 1/2 * (br_r12 - br_r23 + br_r31)
                 Zr_s = 1/2 * (br_r23 - br_r31 + br_r12)


### PR DESCRIPTION
Proposition to solve: PSSE import - transformer impedance scaling and winding voltage #629

I haven't done side by side tests for three winding transformers as my network didn't have any.
However, for two winding transformers I can confirm it was necessary to scale Z with |t2|^2 to get the same results as PSSE. This is described in PSSE manual cited in the issue thread.

Winding voltage and nominal voltage are required for manual implementation of tap changers and should be loaded when import all is specified.