### PR TITLE
Rename run_* to solve_*

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ docs/site/
 docs/.documenter
 .project
 .tags
+.vscode

--- a/src/PowerModels.jl
+++ b/src/PowerModels.jl
@@ -88,4 +88,20 @@ include("util/flow_limit_cuts.jl")
 # this must come last to support automated export
 include("core/export.jl")
 
+# deprecate section
+@deprecate run_nfa_opb(file, optimizer; kwargs...) solve_nfa_opb(file, optimizer; kwargs...)
+@deprecate run_opb(file, model_type::Type, optimizer; kwargs...) solve_opb(file, model_type::Type, optimizer; kwargs...)
+@deprecate run_opf_bf(file, model_type::Type{T}, optimizer; kwargs...) where T <: AbstractBFModel solve_opf_bf(file, model_type::Type{T}, optimizer; kwargs...) where T <: AbstractBFModel
+@deprecate run_mn_opf_bf(file, model_type::Type, optimizer; kwargs...) solve_mn_opf_bf(file, model_type::Type, optimizer; kwargs...) 
+@deprecate run_opf_iv(file, model_constructor, optimizer; kwargs...) solve_opf_iv(file, model_constructor, optimizer; kwargs...)
+@deprecate run_ac_opf(file, optimizer; kwargs...) solve_ac_opf(file, optimizer; kwargs...)
+@deprecate run_dc_opf(file, optimizer; kwargs...) solve_dc_opf(file, optimizer; kwargs...)
+@deprecate run_opf(file, model_type::Type, optimizer; kwargs...) solve_opf(file, model_type::Type, optimizer; kwargs...)
+@deprecate run_mn_opf(file, model_type::Type, optimizer; kwargs...) solve_mn_opf(file, model_type::Type, optimizer; kwargs...)
+@deprecate run_mn_opf_strg(file, model_type::Type, optimizer; kwargs...) solve_mn_opf_strg(file, model_type::Type, optimizer; kwargs...)
+@deprecate run_opf_ptdf(file, model_type::Type, optimizer; full_inverse=false, kwargs...) solve_opf_ptdf(file, model_type::Type, optimizer; full_inverse=false, kwargs...)
+@deprecate run_pf_bf(file, model_type::Type, optimizer; kwargs...) solve_pf_bf(file, model_type::Type, optimizer; kwargs...)
+@deprecate run_pf_iv(file, model_constructor, optimizer; kwargs...) solve_pf_iv(file, model_constructor, optimizer; kwargs...)
+@deprecate run_tnep(file, model_type::Type, optimizer; kwargs...) solve_tnep(file, model_type::Type, optimizer; kwargs...)
+
 end

--- a/src/core/base.jl
+++ b/src/core/base.jl
@@ -22,13 +22,13 @@ conductor_ids(pm::AbstractPowerModel; nw::Int=pm.cnw) = pm.ref[:nw][nw][:conduct
 
 
 ""
-function run_model(file::String, model_type::Type, optimizer, build_method; kwargs...)
+function solve_model(file::String, model_type::Type, optimizer, build_method; kwargs...)
     data = PowerModels.parse_file(file)
-    return run_model(data, model_type, optimizer, build_method; kwargs...)
+    return solve_model(data, model_type, optimizer, build_method; kwargs...)
 end
 
 ""
-function run_model(data::Dict{String,<:Any}, model_type::Type, optimizer, build_method; ref_extensions=[], solution_processors=[], multinetwork=false, multiconductor=false, kwargs...)
+function solve_model(data::Dict{String,<:Any}, model_type::Type, optimizer, build_method; ref_extensions=[], solution_processors=[], multinetwork=false, multiconductor=false, kwargs...)
     if multinetwork != _IM.ismultinetwork(data)
         model_requirement = multinetwork ? "multi-network" : "single-network"
         data_type = _IM.ismultinetwork(data) ? "multi-network" : "single-network"

--- a/src/prob/opb.jl
+++ b/src/prob/opb.jl
@@ -1,11 +1,11 @@
 ""
-function run_nfa_opb(file, optimizer; kwargs...)
-    return run_opb(file, NFAPowerModel, optimizer; kwargs...)
+function solve_nfa_opb(file, optimizer; kwargs...)
+    return solve_opb(file, NFAPowerModel, optimizer; kwargs...)
 end
 
 "the optimal power balance problem"
-function run_opb(file, model_type::Type, optimizer; kwargs...)
-    return run_model(file, model_type, optimizer, build_opb; ref_extensions=[ref_add_connected_components!], kwargs...)
+function solve_opb(file, model_type::Type, optimizer; kwargs...)
+    return solve_model(file, model_type, optimizer, build_opb; ref_extensions=[ref_add_connected_components!], kwargs...)
 end
 
 ""

--- a/src/prob/opf.jl
+++ b/src/prob/opf.jl
@@ -1,16 +1,16 @@
 ""
-function run_ac_opf(file, optimizer; kwargs...)
-    return run_opf(file, ACPPowerModel, optimizer; kwargs...)
+function solve_ac_opf(file, optimizer; kwargs...)
+    return solve_opf(file, ACPPowerModel, optimizer; kwargs...)
 end
 
 ""
-function run_dc_opf(file, optimizer; kwargs...)
-    return run_opf(file, DCPPowerModel, optimizer; kwargs...)
+function solve_dc_opf(file, optimizer; kwargs...)
+    return solve_opf(file, DCPPowerModel, optimizer; kwargs...)
 end
 
 ""
-function run_opf(file, model_type::Type, optimizer; kwargs...)
-    return run_model(file, model_type, optimizer, build_opf; kwargs...)
+function solve_opf(file, model_type::Type, optimizer; kwargs...)
+    return solve_model(file, model_type, optimizer, build_opf; kwargs...)
 end
 
 ""
@@ -50,8 +50,8 @@ end
 
 
 "a toy example of how to model with multi-networks"
-function run_mn_opf(file, model_type::Type, optimizer; kwargs...)
-    return run_model(file, model_type, optimizer, build_mn_opf; multinetwork=true, kwargs...)
+function solve_mn_opf(file, model_type::Type, optimizer; kwargs...)
+    return solve_model(file, model_type, optimizer, build_mn_opf; multinetwork=true, kwargs...)
 end
 
 ""
@@ -92,8 +92,8 @@ end
 
 
 "a toy example of how to model with multi-networks and storage"
-function run_mn_opf_strg(file, model_type::Type, optimizer; kwargs...)
-    return run_model(file, model_type, optimizer, build_mn_opf_strg; multinetwork=true, kwargs...)
+function solve_mn_opf_strg(file, model_type::Type, optimizer; kwargs...)
+    return solve_model(file, model_type, optimizer, build_mn_opf_strg; multinetwork=true, kwargs...)
 end
 
 ""
@@ -162,11 +162,11 @@ Solves an opf using ptdfs with no explicit voltage or line flow variables.
 This formulation is most often used when a small subset of the line flow
 constraints are active in the data model.
 """
-function run_opf_ptdf(file, model_type::Type, optimizer; full_inverse=false, kwargs...)
+function solve_opf_ptdf(file, model_type::Type, optimizer; full_inverse=false, kwargs...)
     if !full_inverse
-        return run_model(file, model_type, optimizer, build_opf_ptdf; ref_extensions=[ref_add_connected_components!,ref_add_sm!], kwargs...)
+        return solve_model(file, model_type, optimizer, build_opf_ptdf; ref_extensions=[ref_add_connected_components!,ref_add_sm!], kwargs...)
     else
-        return run_model(file, model_type, optimizer, build_opf_ptdf; ref_extensions=[ref_add_connected_components!,ref_add_sm_inv!], kwargs...)
+        return solve_model(file, model_type, optimizer, build_opf_ptdf; ref_extensions=[ref_add_connected_components!,ref_add_sm_inv!], kwargs...)
     end
 end
 

--- a/src/prob/opf_bf.jl
+++ b/src/prob/opf_bf.jl
@@ -1,11 +1,11 @@
 ""
-function run_opf_bf(file, model_type::Type{T}, optimizer; kwargs...) where T <: AbstractBFModel
-    return run_model(file, model_type, optimizer, build_opf_bf; kwargs...)
+function solve_opf_bf(file, model_type::Type{T}, optimizer; kwargs...) where T <: AbstractBFModel
+    return solve_model(file, model_type, optimizer, build_opf_bf; kwargs...)
 end
 
 ""
-function run_mn_opf_bf_strg(file, model_type::Type, optimizer; kwargs...)
-    return run_model(file, model_type, optimizer, build_mn_opf_bf_strg; multinetwork=true, kwargs...)
+function solve_mn_opf_bf_strg(file, model_type::Type, optimizer; kwargs...)
+    return solve_model(file, model_type, optimizer, build_mn_opf_bf_strg; multinetwork=true, kwargs...)
 end
 
 ""

--- a/src/prob/opf_iv.jl
+++ b/src/prob/opf_iv.jl
@@ -1,6 +1,6 @@
 ""
-function run_opf_iv(file, model_constructor, optimizer; kwargs...)
-    return run_model(file, model_constructor, optimizer, build_opf_iv; kwargs...)
+function solve_opf_iv(file, model_constructor, optimizer; kwargs...)
+    return solve_model(file, model_constructor, optimizer, build_opf_iv; kwargs...)
 end
 
 ""

--- a/src/prob/ots.jl
+++ b/src/prob/ots.jl
@@ -5,8 +5,8 @@
 #
 
 ""
-function run_ots(file, model_type::Type, optimizer; kwargs...)
-    return run_model(file, model_type, optimizer, build_ots; ref_extensions=[ref_add_on_off_va_bounds!], kwargs...)
+function solve_ots(file, model_type::Type, optimizer; kwargs...)
+    return solve_model(file, model_type, optimizer, build_ots; ref_extensions=[ref_add_on_off_va_bounds!], kwargs...)
 end
 
 ""

--- a/src/prob/pf.jl
+++ b/src/prob/pf.jl
@@ -1,16 +1,16 @@
 "solves the AC Power Flow in polar coordinates using a JuMP model"
-function run_ac_pf(file, optimizer; kwargs...)
-    return run_pf(file, ACPPowerModel, optimizer; kwargs...)
+function solve_ac_pf(file, optimizer; kwargs...)
+    return solve_pf(file, ACPPowerModel, optimizer; kwargs...)
 end
 
 "solves the linear DC Power Flow using a JuMP model"
-function run_dc_pf(file, optimizer; kwargs...)
-    return run_pf(file, DCPPowerModel, optimizer; kwargs...)
+function solve_dc_pf(file, optimizer; kwargs...)
+    return solve_pf(file, DCPPowerModel, optimizer; kwargs...)
 end
 
 "solves a formulation-agnostic Power Flow using a JuMP model"
-function run_pf(file, model_type::Type, optimizer; kwargs...)
-    return run_model(file, model_type, optimizer, build_pf; kwargs...)
+function solve_pf(file, model_type::Type, optimizer; kwargs...)
+    return solve_model(file, model_type, optimizer, build_pf; kwargs...)
 end
 
 "specification of the formulation agnostic Power Flow model"

--- a/src/prob/pf_bf.jl
+++ b/src/prob/pf_bf.jl
@@ -1,6 +1,6 @@
 ""
-function run_pf_bf(file, model_type::Type, optimizer; kwargs...)
-    return run_model(file, model_type, optimizer, build_pf_bf; kwargs...)
+function solve_pf_bf(file, model_type::Type, optimizer; kwargs...)
+    return solve_model(file, model_type, optimizer, build_pf_bf; kwargs...)
 end
 
 ""

--- a/src/prob/pf_iv.jl
+++ b/src/prob/pf_iv.jl
@@ -1,6 +1,6 @@
 ""
-function run_pf_iv(file, model_constructor, optimizer; kwargs...)
-    return run_model(file, model_constructor, optimizer, build_pf_iv; kwargs...)
+function solve_pf_iv(file, model_constructor, optimizer; kwargs...)
+    return solve_model(file, model_constructor, optimizer, build_pf_iv; kwargs...)
 end
 
 ""

--- a/src/prob/test.jl
+++ b/src/prob/test.jl
@@ -7,8 +7,8 @@
 
 
 "opf using current limits instead of thermal limits, tests constraint_current_limit"
-function _run_opf_cl(file, model_type::Type, optimizer; kwargs...)
-    return run_model(file, model_type, optimizer, _build_opf_cl; kwargs...)
+function _solve_opf_cl(file, model_type::Type, optimizer; kwargs...)
+    return solve_model(file, model_type, optimizer, _build_opf_cl; kwargs...)
 end
 
 ""
@@ -46,8 +46,8 @@ end
 
 
 "opf with fixed switches"
-function _run_opf_sw(file, model_constructor, optimizer; kwargs...)
-    return run_model(file, model_constructor, optimizer, _build_opf_sw; kwargs...)
+function _solve_opf_sw(file, model_constructor, optimizer; kwargs...)
+    return solve_model(file, model_constructor, optimizer, _build_opf_sw; kwargs...)
 end
 
 ""
@@ -92,8 +92,8 @@ end
 
 
 "opf with controlable switches"
-function _run_oswpf(file, model_constructor, optimizer; kwargs...)
-    return run_model(file, model_constructor, optimizer, _build_oswpf; ref_extensions=[ref_add_on_off_va_bounds!], kwargs...)
+function _solve_oswpf(file, model_constructor, optimizer; kwargs...)
+    return solve_model(file, model_constructor, optimizer, _build_oswpf; ref_extensions=[ref_add_on_off_va_bounds!], kwargs...)
 end
 
 ""
@@ -141,8 +141,8 @@ end
 
 
 "opf with controlable switches, node breaker"
-function _run_oswpf_nb(file, model_constructor, optimizer; kwargs...)
-    return run_model(file, model_constructor, optimizer, _build_oswpf_nb; ref_extensions=[ref_add_on_off_va_bounds!], kwargs...)
+function _solve_oswpf_nb(file, model_constructor, optimizer; kwargs...)
+    return solve_model(file, model_constructor, optimizer, _build_oswpf_nb; ref_extensions=[ref_add_on_off_va_bounds!], kwargs...)
 end
 
 ""
@@ -221,8 +221,8 @@ end
 
 
 # a simple maximum loadability problem
-function _run_mld(file, model_constructor, solver; kwargs...)
-    return run_model(file, model_constructor, solver, _build_mld; kwargs...)
+function _solve_mld(file, model_constructor, solver; kwargs...)
+    return solve_model(file, model_constructor, solver, _build_mld; kwargs...)
 end
 
 function _build_mld(pm::AbstractPowerModel)
@@ -263,8 +263,8 @@ end
 
 
 "opf with unit commitment, tests constraint_current_limit"
-function _run_ucopf(file, model_type::Type, solver; kwargs...)
-    return run_model(file, model_type, solver, _build_ucopf; kwargs...)
+function _solve_ucopf(file, model_type::Type, solver; kwargs...)
+    return solve_model(file, model_type, solver, _build_ucopf; kwargs...)
 end
 
 ""
@@ -324,8 +324,8 @@ end
 
 
 ""
-function _run_mn_opb(file, model_type::Type, optimizer; kwargs...)
-    return run_model(file, model_type, optimizer, _build_mn_opb; ref_extensions=[ref_add_connected_components!], multinetwork=true, kwargs...)
+function _solve_mn_opb(file, model_type::Type, optimizer; kwargs...)
+    return solve_model(file, model_type, optimizer, _build_mn_opb; ref_extensions=[ref_add_connected_components!], multinetwork=true, kwargs...)
 end
 
 ""
@@ -343,8 +343,8 @@ end
 
 
 ""
-function _run_mn_pf(file, model_type::Type, optimizer; kwargs...)
-    return run_model(file, model_type, optimizer, _build_mn_pf; multinetwork=true, kwargs...)
+function _solve_mn_pf(file, model_type::Type, optimizer; kwargs...)
+    return solve_model(file, model_type, optimizer, _build_mn_pf; multinetwork=true, kwargs...)
 end
 
 ""
@@ -399,8 +399,8 @@ end
 
 
 "opf with storage"
-function _run_opf_strg(file, model_type::Type, optimizer; kwargs...)
-    return run_model(file, model_type, optimizer, _build_opf_strg; kwargs...)
+function _solve_opf_strg(file, model_type::Type, optimizer; kwargs...)
+    return solve_model(file, model_type, optimizer, _build_opf_strg; kwargs...)
 end
 
 ""
@@ -447,8 +447,8 @@ end
 
 
 "opf with mi storage variables"
-function _run_opf_strg_mi(file, model_type::Type, optimizer; kwargs...)
-    return run_model(file, model_type, optimizer, _build_opf_strg_mi; kwargs...)
+function _solve_opf_strg_mi(file, model_type::Type, optimizer; kwargs...)
+    return solve_model(file, model_type, optimizer, _build_opf_strg_mi; kwargs...)
 end
 
 ""
@@ -495,8 +495,8 @@ end
 
 
 "opf with tap magnitude and angle as optimization variables"
-function _run_opf_oltc_pst(file, model_type::Type, optimizer; kwargs...)
-    return run_model(file, model_type, optimizer, _build_opf_oltc_pst; kwargs...)
+function _solve_opf_oltc_pst(file, model_type::Type, optimizer; kwargs...)
+    return solve_model(file, model_type, optimizer, _build_opf_oltc_pst; kwargs...)
 end
 
 ""

--- a/src/prob/tnep.jl
+++ b/src/prob/tnep.jl
@@ -3,8 +3,8 @@
 #
 
 ""
-function run_tnep(file, model_type::Type, optimizer; kwargs...)
-    return run_model(file, model_type, optimizer, build_tnep; ref_extensions=[ref_add_on_off_va_bounds!,ref_add_ne_branch!], kwargs...)
+function solve_tnep(file, model_type::Type, optimizer; kwargs...)
+    return solve_model(file, model_type, optimizer, build_tnep; ref_extensions=[ref_add_on_off_va_bounds!,ref_add_ne_branch!], kwargs...)
 end
 
 "the general form of the tnep optimization model"

--- a/src/util/flow_limit_cuts.jl
+++ b/src/util/flow_limit_cuts.jl
@@ -9,12 +9,12 @@ constraint violations
 * `max_iter`: maximum number of flow iterations to perform.
 * `time_limit`: maximum amount of time (sec) for the algorithm.
 """
-function run_opf_flow_cuts(file::String, model_type::Type, optimizer; kwargs...)
+function solve_opf_flow_cuts(file::String, model_type::Type, optimizer; kwargs...)
     data = PowerModels.parse_file(file)
-    return run_opf_flow_cuts!(data, model_type, optimizer; kwargs...)
+    return solve_opf_flow_cuts!(data, model_type, optimizer; kwargs...)
 end
 
-function run_opf_flow_cuts!(data::Dict{String,<:Any}, model_type::Type, optimizer; solution_processors=[], max_iter::Int=100, time_limit::Float64=3600.0)
+function solve_opf_flow_cuts!(data::Dict{String,<:Any}, model_type::Type, optimizer; solution_processors=[], max_iter::Int=100, time_limit::Float64=3600.0)
     Memento.info(_LOGGER, "maximum cut iterations set to value of $max_iter")
 
     for (i,branch) in data["branch"]
@@ -26,7 +26,7 @@ function run_opf_flow_cuts!(data::Dict{String,<:Any}, model_type::Type, optimize
 
     start_time = time()
 
-    #result = run_opf(data, model_type, optimizer)
+    #result = solve_opf(data, model_type, optimizer)
     pm = instantiate_model(data, model_type, build_opf)
     result = optimize_model!(pm, optimizer=optimizer, solution_processors=solution_processors)
 
@@ -68,7 +68,7 @@ function run_opf_flow_cuts!(data::Dict{String,<:Any}, model_type::Type, optimize
 
         if violated
             iteration += 1
-            #result = run_opf(data, model_type, optimizer)
+            #result = solve_opf(data, model_type, optimizer)
             result = optimize_model!(pm, solution_processors=solution_processors)
 
             #print_summary(result["solution"])
@@ -96,12 +96,12 @@ supporting the PTDF problem specification at this time.
 * `time_limit`: maximum amount of time (sec) for the algorithm.
 * `full_inverse`: compute the complete admittance matrix inverse, instead of a branch by branch computation.
 """
-function run_opf_ptdf_flow_cuts(file::String, optimizer; kwargs...)
+function solve_opf_ptdf_flow_cuts(file::String, optimizer; kwargs...)
     data = PowerModels.parse_file(file)
-    return run_opf_ptdf_flow_cuts!(data, optimizer; kwargs...)
+    return solve_opf_ptdf_flow_cuts!(data, optimizer; kwargs...)
 end
 
-function run_opf_ptdf_flow_cuts!(data::Dict{String,<:Any}, optimizer; max_iter::Int=100, time_limit::Float64=3600.0, full_inverse=false)
+function solve_opf_ptdf_flow_cuts!(data::Dict{String,<:Any}, optimizer; max_iter::Int=100, time_limit::Float64=3600.0, full_inverse=false)
     Memento.info(_LOGGER, "maximum cut iterations set to value of $max_iter")
 
     for (i,branch) in data["branch"]
@@ -122,7 +122,7 @@ function run_opf_ptdf_flow_cuts!(data::Dict{String,<:Any}, optimizer; max_iter::
     start_time = time()
 
 
-    #result = run_ptdf_opf(data, DCPPowerModel, optimizer, full_inverse=full_inverse)
+    #result = solve_ptdf_opf(data, DCPPowerModel, optimizer, full_inverse=full_inverse)
     pm = instantiate_model(data, DCPPowerModel, build_opf_ptdf; ref_extensions=ref_extensions)
     result = optimize_model!(pm, optimizer=optimizer)
     update_data!(data, result["solution"])
@@ -170,7 +170,7 @@ function run_opf_ptdf_flow_cuts!(data::Dict{String,<:Any}, optimizer; max_iter::
         if violated
             iteration += 1
 
-            #result = run_ptdf_opf(data, DCPPowerModel, optimizer, full_inverse=full_inverse)
+            #result = solve_ptdf_opf(data, DCPPowerModel, optimizer, full_inverse=full_inverse)
             result = optimize_model!(pm)
 
             update_data!(data, result["solution"])

--- a/src/util/obbt.jl
+++ b/src/util/obbt.jl
@@ -13,7 +13,7 @@ Convex Relaxations with Bound Tightening for Power Network Optimization".
 The function can be invoked as follows:
 
 ```
-data, stats = run_obbt_opf!("matpower/case3.m", JuMP.with_optimizer(Ipopt.Optimizer, kwargs...)
+data, stats = solve_obbt_opf!("matpower/case3.m", JuMP.with_optimizer(Ipopt.Optimizer, kwargs...)
 ```
 
 `data` contains the parsed network data with tightened bounds. `stats` contains
@@ -62,12 +62,12 @@ Dict{String,Any} with 19 entries:
     `improvement_tol`.
 * `precision`: number of decimal digits to round the tightened bounds to.
 """
-function run_obbt_opf!(file::String, optimizer; kwargs...)
+function solve_obbt_opf!(file::String, optimizer; kwargs...)
     data = PowerModels.parse_file(file)
-    return run_obbt_opf!(data, optimizer; kwargs...)
+    return solve_obbt_opf!(data, optimizer; kwargs...)
 end
 
-function run_obbt_opf!(data::Dict{String,<:Any}, optimizer;
+function solve_obbt_opf!(data::Dict{String,<:Any}, optimizer;
     model_type::Type = QCLSPowerModel,
     max_iter::Int = 100,
     time_limit::Float64 = 3600.0,
@@ -327,7 +327,7 @@ function run_obbt_opf!(data::Dict{String,<:Any}, optimizer;
         td = var(model_bt, :td)
 
         # run the qc relaxation for the updated bounds
-        result_relaxation = run_opf(data, model_type::Type, optimizer)
+        result_relaxation = solve_opf(data, model_type::Type, optimizer)
 
         if result_relaxation["termination_status"] in status_pass
             current_rel_gap = (upper_bound - result_relaxation["objective"])/upper_bound

--- a/test/data.jl
+++ b/test/data.jl
@@ -30,7 +30,7 @@ TESTLOG = Memento.getlogger(PowerModels)
     end
 
     @testset "5-bus solution summary from dict" begin
-        result = run_ac_opf("../test/data/matpower/case5.m", ipopt_solver)
+        result = solve_ac_opf("../test/data/matpower/case5.m", ipopt_solver)
         output = sprint(PowerModels.summary, result["solution"])
 
         line_count = count(c -> c == '\n', output)
@@ -119,7 +119,7 @@ end
 
 
     @testset "3-bus case solution" begin
-        result = run_ac_opf("../test/data/matpower/case3.m", ipopt_solver)
+        result = solve_ac_opf("../test/data/matpower/case3.m", ipopt_solver)
         result_base = deepcopy(result)
 
         PowerModels.make_mixed_units!(result["solution"])
@@ -128,7 +128,7 @@ end
         @test InfrastructureModels.compare_dict(result, result_base)
     end
     @testset "5-bus case solution" begin
-        result = run_ac_opf("../test/data/matpower/case5_asym.m", ipopt_solver)
+        result = solve_ac_opf("../test/data/matpower/case5_asym.m", ipopt_solver)
         result_base = deepcopy(result)
 
         PowerModels.make_mixed_units!(result["solution"])
@@ -137,7 +137,7 @@ end
         @test InfrastructureModels.compare_dict(result, result_base)
     end
     @testset "24-bus case solution" begin
-        result = run_ac_opf("../test/data/matpower/case24.m", ipopt_solver)
+        result = solve_ac_opf("../test/data/matpower/case24.m", ipopt_solver)
         result_base = deepcopy(result)
 
         PowerModels.make_mixed_units!(result["solution"])
@@ -148,7 +148,7 @@ end
 
 
     @testset "5-bus case solution with duals" begin
-        result = run_dc_opf("../test/data/matpower/case5.m", ipopt_solver, setting = Dict("output" => Dict("branch_flows" => true, "duals" => true)))
+        result = solve_dc_opf("../test/data/matpower/case5.m", ipopt_solver, setting = Dict("output" => Dict("branch_flows" => true, "duals" => true)))
         result_base = deepcopy(result)
 
         PowerModels.make_mixed_units!(result["solution"])
@@ -428,7 +428,7 @@ end
     @testset "output values" begin
         data = PowerModels.parse_file("../test/data/matpower/case7_tplgy.m")
         PowerModels.simplify_network!(data)
-        result = run_opf(data, ACPPowerModel, ipopt_solver)
+        result = solve_opf(data, ACPPowerModel, ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 1778; atol = 1e0)
@@ -579,7 +579,7 @@ end
         data = PowerModels.parse_file("../test/data/matpower/case5.m")
         data["branch"]["4"]["br_status"] = 0
         data["buspairs"] = PowerModels.calc_buspair_parameters(data["bus"], data["branch"], 1:1, false)
-        result = run_opf(data, ACPPowerModel, ipopt_solver)
+        result = solve_opf(data, ACPPowerModel, ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 16642; atol = 1e0)
@@ -593,7 +593,7 @@ end
      @testset "5-bus ac polar flow" begin
         data = PowerModels.parse_file("../test/data/matpower/case5.m")
         data["branch"]["4"]["br_status"] = 0
-        result = run_opf(data, ACPPowerModel, ipopt_solver)
+        result = solve_opf(data, ACPPowerModel, ipopt_solver)
         PowerModels.update_data!(data, result["solution"])
 
         ac_flows = PowerModels.calc_branch_flow_ac(data)
@@ -611,7 +611,7 @@ end
     @testset "5-bus ac rect flow" begin
         data = PowerModels.parse_file("../test/data/matpower/case5.m")
         data["branch"]["4"]["br_status"] = 0
-        result = run_opf(data, ACRPowerModel, ipopt_solver, solution_processors=[sol_data_model!])
+        result = solve_opf(data, ACRPowerModel, ipopt_solver, solution_processors=[sol_data_model!])
         PowerModels.update_data!(data, result["solution"])
 
         ac_flows = PowerModels.calc_branch_flow_ac(data)
@@ -629,7 +629,7 @@ end
     @testset "5-bus dc flow" begin
         data = PowerModels.parse_file("../test/data/matpower/case5.m")
         data["branch"]["4"]["br_status"] = 0
-        result = run_opf(data, DCPPowerModel, ipopt_solver)
+        result = solve_opf(data, DCPPowerModel, ipopt_solver)
         PowerModels.update_data!(data, result["solution"])
 
         dc_flows = PowerModels.calc_branch_flow_dc(data)
@@ -651,7 +651,7 @@ end
 
      @testset "5-bus polynomial gen cost" begin
         data = PowerModels.parse_file("../test/data/matpower/case5.m")
-        result = run_opf(data, ACPPowerModel, ipopt_solver)
+        result = solve_opf(data, ACPPowerModel, ipopt_solver)
         PowerModels.update_data!(data, result["solution"])
 
         gen_cost = PowerModels.calc_gen_cost(data)
@@ -666,7 +666,7 @@ end
             @test isa(gen["ncost"], Int)
         end
 
-        result = run_opf(data, ACPPowerModel, ipopt_solver)
+        result = solve_opf(data, ACPPowerModel, ipopt_solver)
         PowerModels.update_data!(data, result["solution"])
 
         gen_cost = PowerModels.calc_gen_cost(data)
@@ -676,7 +676,7 @@ end
 
      @testset "5-bus polynomial gen and dcline cost" begin
         data = PowerModels.parse_file("../test/data/matpower/case5_dc.m")
-        result = run_opf(data, ACPPowerModel, ipopt_solver)
+        result = solve_opf(data, ACPPowerModel, ipopt_solver)
         PowerModels.update_data!(data, result["solution"])
 
         gen_cost = PowerModels.calc_gen_cost(data)
@@ -689,7 +689,7 @@ end
         data["gen"]["1"]["gen_status"] = 0
         data["dcline"]["1"]["br_status"] = 0
 
-        result = run_opf(data, ACPPowerModel, ipopt_solver)
+        result = solve_opf(data, ACPPowerModel, ipopt_solver)
         PowerModels.update_data!(data, result["solution"])
 
         gen_cost = PowerModels.calc_gen_cost(data)
@@ -705,7 +705,7 @@ end
      @testset "5-bus ac polar balance" begin
         data = PowerModels.parse_file("../test/data/matpower/case5_dc.m")
         data["branch"]["4"]["br_status"] = 0
-        result = run_opf(data, ACPPowerModel, ipopt_solver)
+        result = solve_opf(data, ACPPowerModel, ipopt_solver)
         PowerModels.update_data!(data, result["solution"])
 
         balance = PowerModels.calc_power_balance(data)
@@ -719,7 +719,7 @@ end
      @testset "5-bus dc balance" begin
         data = PowerModels.parse_file("../test/data/matpower/case5_dc.m")
         data["branch"]["4"]["br_status"] = 0
-        result = run_opf(data, DCPPowerModel, ipopt_solver)
+        result = solve_opf(data, DCPPowerModel, ipopt_solver)
         PowerModels.update_data!(data, result["solution"])
 
         balance = PowerModels.calc_power_balance(data)
@@ -734,7 +734,7 @@ end
      @testset "5-bus ac polar balance with storage" begin
         data = PowerModels.parse_file("../test/data/matpower/case5_strg.m")
         data["branch"]["4"]["br_status"] = 0
-        result = PowerModels._run_opf_strg(data, ACPPowerModel, ipopt_solver)
+        result = PowerModels._solve_opf_strg(data, ACPPowerModel, ipopt_solver)
         PowerModels.update_data!(data, result["solution"])
 
         balance = PowerModels.calc_power_balance(data)
@@ -748,7 +748,7 @@ end
      @testset "5-bus dc balance with storage" begin
         data = PowerModels.parse_file("../test/data/matpower/case5_strg.m")
         data["branch"]["4"]["br_status"] = 0
-        result = PowerModels._run_opf_strg(data, DCPPowerModel, ipopt_solver)
+        result = PowerModels._solve_opf_strg(data, DCPPowerModel, ipopt_solver)
         PowerModels.update_data!(data, result["solution"])
 
         balance = PowerModels.calc_power_balance(data)
@@ -763,7 +763,7 @@ end
      @testset "5-bus balance from flow ac" begin
         data = PowerModels.parse_file("../test/data/matpower/case5_dc.m")
         data["branch"]["4"]["br_status"] = 0
-        result = run_opf(data, ACPPowerModel, ipopt_solver)
+        result = solve_opf(data, ACPPowerModel, ipopt_solver)
         PowerModels.update_data!(data, result["solution"])
 
         flows = PowerModels.calc_branch_flow_ac(data)
@@ -780,7 +780,7 @@ end
      @testset "5-bus balance from flow dc" begin
         data = PowerModels.parse_file("../test/data/matpower/case5_dc.m")
         data["branch"]["4"]["br_status"] = 0
-        result = run_opf(data, DCPPowerModel, ipopt_solver)
+        result = solve_opf(data, DCPPowerModel, ipopt_solver)
         PowerModels.update_data!(data, result["solution"])
 
         flows = PowerModels.calc_branch_flow_dc(data)

--- a/test/docs.jl
+++ b/test/docs.jl
@@ -10,7 +10,7 @@
     @testset "README.md - Modifying Network Data" begin
         network_data = PowerModels.parse_file("../test/data/matpower/case3.m")
 
-        result = run_opf(network_data, ACPPowerModel, JuMP.with_optimizer(Ipopt.Optimizer, print_level=0))
+        result = solve_opf(network_data, ACPPowerModel, JuMP.with_optimizer(Ipopt.Optimizer, print_level=0))
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 5906.88; atol = 1e0)
@@ -18,7 +18,7 @@
         network_data["load"]["3"]["pd"] = 0.0
         network_data["load"]["3"]["qd"] = 0.0
 
-        result = run_opf(network_data, ACPPowerModel, JuMP.with_optimizer(Ipopt.Optimizer, print_level=0))
+        result = solve_opf(network_data, ACPPowerModel, JuMP.with_optimizer(Ipopt.Optimizer, print_level=0))
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 2937.16; atol = 1e0)

--- a/test/matpower.jl
+++ b/test/matpower.jl
@@ -1,6 +1,6 @@
 @testset "test matpower parser" begin
     @testset "30-bus case file" begin
-        result = run_opf("../test/data/matpower/case30.m", ACPPowerModel, ipopt_solver)
+        result = solve_opf("../test/data/matpower/case30.m", ACPPowerModel, ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 204.96; atol = 1e-1)
@@ -10,7 +10,7 @@
         data = PowerModels.parse_file("../test/data/matpower/case30.m")
         @test isa(JSON.json(data), String)
 
-        result = run_opf(data, ACPPowerModel, ipopt_solver)
+        result = solve_opf(data, ACPPowerModel, ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 204.96; atol = 1e-1)
@@ -20,7 +20,7 @@
         data = PowerModels.parse_matpower("../test/data/matpower/case30.m")
         @test isa(JSON.json(data), String)
 
-        result = run_opf(data, ACPPowerModel, ipopt_solver)
+        result = solve_opf(data, ACPPowerModel, ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 204.96; atol = 1e-1)
@@ -31,7 +31,7 @@
             data = PowerModels.parse_matpower(f)
             @test isa(JSON.json(data), String)
 
-            result = run_opf(data, ACPPowerModel, ipopt_solver)
+            result = solve_opf(data, ACPPowerModel, ipopt_solver)
 
             @test result["termination_status"] == LOCALLY_SOLVED
             @test isapprox(result["objective"], 204.96; atol = 1e-1)
@@ -57,7 +57,7 @@
     end
 
     @testset "2-bus case file with spaces" begin
-        result = run_pf("../test/data/matpower/case2.m", ACPPowerModel, ipopt_solver)
+        result = solve_pf("../test/data/matpower/case2.m", ACPPowerModel, ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 0.0; atol = 1e-1)
@@ -76,20 +76,20 @@ end
 
 @testset "test matpower data coercion" begin
     @testset "ACP Model" begin
-        result = run_opf("../test/data/matpower/case14.m", ACPPowerModel, ipopt_solver)
+        result = solve_opf("../test/data/matpower/case14.m", ACPPowerModel, ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 8081.5; atol = 1e0)
         #@test result["status"] = bus_name
     end
     @testset "DC Model" begin
-        result = run_opf("../test/data/matpower/case14.m", DCPPowerModel, ipopt_solver)
+        result = solve_opf("../test/data/matpower/case14.m", DCPPowerModel, ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 7642.6; atol = 1e0)
     end
     @testset "QC Model" begin
-        result = run_opf("../test/data/matpower/case14.m", QCRMPowerModel, ipopt_solver)
+        result = solve_opf("../test/data/matpower/case14.m", QCRMPowerModel, ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 8075.1; atol = 1e0)

--- a/test/model.jl
+++ b/test/model.jl
@@ -3,7 +3,7 @@
     @testset "run with user provided JuMP model" begin
         m = JuMP.Model()
         x = JuMP.@variable(m, my_var >= 0, start=0.0)
-        result = run_ac_opf("../test/data/matpower/case5.m", ipopt_solver, jump_model=m)
+        result = solve_ac_opf("../test/data/matpower/case5.m", ipopt_solver, jump_model=m)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 18269; atol = 1e0)
@@ -27,7 +27,7 @@ end
 
 @testset "exports for usablity" begin
     @testset "with_optimizer and NLP status" begin
-        result = run_opf("../test/data/matpower/case5.m", ACPPowerModel, with_optimizer(Ipopt.Optimizer, print_level=0))
+        result = solve_opf("../test/data/matpower/case5.m", ACPPowerModel, with_optimizer(Ipopt.Optimizer, print_level=0))
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test result["primal_status"] == FEASIBLE_POINT
@@ -36,7 +36,7 @@ end
     end
 
     @testset "with_optimizer and LP status" begin
-        result = run_opf("../test/data/matpower/case5.m", DCPPowerModel, with_optimizer(Cbc.Optimizer, logLevel=0))
+        result = solve_opf("../test/data/matpower/case5.m", DCPPowerModel, with_optimizer(Cbc.Optimizer, logLevel=0))
 
         @test result["termination_status"] == OPTIMAL
         @test result["primal_status"] == FEASIBLE_POINT

--- a/test/modify.jl
+++ b/test/modify.jl
@@ -4,26 +4,26 @@
     @testset "30-bus case file incremental" begin
         data = PowerModels.parse_file("../test/data/matpower/case30.m")
 
-        result = run_opf(data, ACPPowerModel, ipopt_solver)
+        result = solve_opf(data, ACPPowerModel, ipopt_solver)
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 204.96; atol = 1e-1)
 
         data["branch"]["6"]["br_status"] = 0
 
-        result = run_opf(data, ACPPowerModel, ipopt_solver)
+        result = solve_opf(data, ACPPowerModel, ipopt_solver)
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 195.25; atol = 1e-1)
 
         data["gen"]["6"]["gen_status"] = 0
 
-        result = run_opf(data, ACPPowerModel, ipopt_solver)
+        result = solve_opf(data, ACPPowerModel, ipopt_solver)
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 195.896; atol = 1e-1)
 
         data["load"]["4"]["pd"] = 0
         data["load"]["4"]["qd"] = 0
 
-        result = run_opf(data, ACPPowerModel, ipopt_solver)
+        result = solve_opf(data, ACPPowerModel, ipopt_solver)
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 104.428; atol = 1e-1)
     end
@@ -53,7 +53,7 @@
 
         PowerModels.update_data!(data, data_delta)
 
-        result = run_opf(data, ACPPowerModel, ipopt_solver)
+        result = solve_opf(data, ACPPowerModel, ipopt_solver)
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 104.428; atol = 1e-1)
     end

--- a/test/multinetwork.jl
+++ b/test/multinetwork.jl
@@ -109,19 +109,19 @@ TESTLOG = Memento.getlogger(PowerModels)
     end
 
 
-    @testset "test run_opf with multinetwork data" begin
+    @testset "test solve_opf with multinetwork data" begin
         mn_data = build_mn_data("../test/data/matpower/case5.m")
-        @test_throws(TESTLOG, ErrorException, PowerModels.run_opf(mn_data, ACPPowerModel, ipopt_solver))
+        @test_throws(TESTLOG, ErrorException, PowerModels.solve_opf(mn_data, ACPPowerModel, ipopt_solver))
     end
 
-    @testset "test run_mn_opf with single-network data" begin
-        @test_throws(TESTLOG, ErrorException, PowerModels.run_mn_opf("../test/data/matpower/case5.m", ACPPowerModel, ipopt_solver))
+    @testset "test solve_mn_opf with single-network data" begin
+        @test_throws(TESTLOG, ErrorException, PowerModels.solve_mn_opf("../test/data/matpower/case5.m", ACPPowerModel, ipopt_solver))
     end
 
     @testset "test multi-network solution" begin
         # test case where generator status is 1 but the gen_bus status is 0
         mn_data = build_mn_data("../test/data/matpower/case5.m")
-        result = PowerModels.run_mn_opf(mn_data, ACPPowerModel, ipopt_solver)
+        result = PowerModels.solve_mn_opf(mn_data, ACPPowerModel, ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 36538.2; atol = 1e0)
@@ -135,7 +135,7 @@ TESTLOG = Memento.getlogger(PowerModels)
 
 
         @testset "test dc polar opb" begin
-            result = PowerModels._run_mn_opb(mn_data, DCPPowerModel, ipopt_solver)
+            result = PowerModels._solve_mn_opb(mn_data, DCPPowerModel, ipopt_solver)
 
             @test result["termination_status"] == LOCALLY_SOLVED
             @test isapprox(result["objective"], 29620.0; atol = 1e0)
@@ -153,7 +153,7 @@ TESTLOG = Memento.getlogger(PowerModels)
 
 
         @testset "test ac polar opf" begin
-            result = PowerModels.run_mn_opf(mn_data, ACPPowerModel, ipopt_solver)
+            result = PowerModels.solve_mn_opf(mn_data, ACPPowerModel, ipopt_solver)
 
             @test result["termination_status"] == LOCALLY_SOLVED
             @test isapprox(result["objective"], 35103.8; atol = 1e0)
@@ -170,7 +170,7 @@ TESTLOG = Memento.getlogger(PowerModels)
         end
 
         @testset "test dc polar opf" begin
-            result = PowerModels.run_mn_opf(mn_data, DCPPowerModel, ipopt_solver)
+            result = PowerModels.solve_mn_opf(mn_data, DCPPowerModel, ipopt_solver)
 
             @test result["termination_status"] == LOCALLY_SOLVED
             @test isapprox(result["objective"], 34959.8; atol = 1e0)
@@ -187,7 +187,7 @@ TESTLOG = Memento.getlogger(PowerModels)
         end
 
         @testset "test soc opf" begin
-            result = PowerModels.run_mn_opf(mn_data, SOCWRPowerModel, ipopt_solver)
+            result = PowerModels.solve_mn_opf(mn_data, SOCWRPowerModel, ipopt_solver)
 
             @test result["termination_status"] == LOCALLY_SOLVED
             @test isapprox(result["objective"], 29999.4; atol = 1e0)
@@ -204,7 +204,7 @@ TESTLOG = Memento.getlogger(PowerModels)
         end
 
         @testset "test nfa opf" begin
-            result = PowerModels.run_mn_opf(mn_data, NFAPowerModel, ipopt_solver)
+            result = PowerModels.solve_mn_opf(mn_data, NFAPowerModel, ipopt_solver)
 
             @test result["termination_status"] == LOCALLY_SOLVED
             @test isapprox(result["objective"], 29620.0; atol = 1e0)
@@ -225,7 +225,7 @@ TESTLOG = Memento.getlogger(PowerModels)
         mn_data = build_mn_data("../test/data/matpower/case5.m")
 
         @testset "test dc polar opf" begin
-            result = PowerModels.run_mn_opf(mn_data, DCPPowerModel, ipopt_solver, setting = Dict("output" => Dict("duals" => true)))
+            result = PowerModels.solve_mn_opf(mn_data, DCPPowerModel, ipopt_solver, setting = Dict("output" => Dict("duals" => true)))
 
             @test result["termination_status"] == LOCALLY_SOLVED
             @test isapprox(result["objective"], 35226.4; atol = 1e0)
@@ -252,21 +252,21 @@ TESTLOG = Memento.getlogger(PowerModels)
         mn_data = build_mn_data("../test/data/matpower/case14.m", "../test/data/matpower/case24.m")
 
         @testset "test ac polar opf" begin
-            result = PowerModels.run_mn_opf(mn_data, ACPPowerModel, ipopt_solver)
+            result = PowerModels.solve_mn_opf(mn_data, ACPPowerModel, ipopt_solver)
 
             @test result["termination_status"] == LOCALLY_SOLVED
             @test isapprox(result["objective"], 87886.5; atol = 1e0)
         end
 
         @testset "test ac rectangular opf" begin
-            result = PowerModels.run_mn_opf(mn_data, ACRPowerModel, ipopt_solver)
+            result = PowerModels.solve_mn_opf(mn_data, ACRPowerModel, ipopt_solver)
 
             @test result["termination_status"] == LOCALLY_SOLVED
             @test isapprox(result["objective"], 87886.5; atol = 1e0)
         end
 
         @testset "test soc opf" begin
-            result = PowerModels.run_mn_opf(mn_data, SOCWRPowerModel, ipopt_solver)
+            result = PowerModels.solve_mn_opf(mn_data, SOCWRPowerModel, ipopt_solver)
 
             @test result["termination_status"] == LOCALLY_SOLVED
             @test isapprox(result["objective"], 78765.8; atol = 1e0)
@@ -278,7 +278,7 @@ TESTLOG = Memento.getlogger(PowerModels)
         mn_data = build_mn_data("../test/data/matpower/case5_strg.m", replicates=4)
 
         @testset "test ac polar opf" begin
-            result = PowerModels.run_mn_opf_strg(mn_data, PowerModels.ACPPowerModel, juniper_solver)
+            result = PowerModels.solve_mn_opf_strg(mn_data, PowerModels.ACPPowerModel, juniper_solver)
 
             @test result["termination_status"] == LOCALLY_SOLVED
             @test isapprox(result["objective"], 70435.5; atol = 1e0)
@@ -307,7 +307,7 @@ TESTLOG = Memento.getlogger(PowerModels)
         end
 
         @testset "test soc opf" begin
-            result = PowerModels.run_mn_opf_strg(mn_data, PowerModels.SOCWRPowerModel, juniper_solver)
+            result = PowerModels.solve_mn_opf_strg(mn_data, PowerModels.SOCWRPowerModel, juniper_solver)
 
             @test result["termination_status"] == LOCALLY_SOLVED
             @test isapprox(result["objective"], 58853.5; atol = 1e0)
@@ -334,7 +334,7 @@ TESTLOG = Memento.getlogger(PowerModels)
         end
 
         @testset "test soc bf opf" begin
-            result = PowerModels.run_mn_opf_bf_strg(mn_data, PowerModels.SOCBFPowerModel, juniper_solver)
+            result = PowerModels.solve_mn_opf_bf_strg(mn_data, PowerModels.SOCBFPowerModel, juniper_solver)
 
             @test result["termination_status"] == LOCALLY_SOLVED
             @test isapprox(result["objective"], 58826.36; atol = 1e0)
@@ -361,7 +361,7 @@ TESTLOG = Memento.getlogger(PowerModels)
         end
 
         @testset "test linear bf opf" begin
-            result = PowerModels.run_mn_opf_bf_strg(mn_data, PowerModels.BFAPowerModel, juniper_solver)
+            result = PowerModels.solve_mn_opf_bf_strg(mn_data, PowerModels.BFAPowerModel, juniper_solver)
 
             @test result["termination_status"] == LOCALLY_SOLVED
             @test isapprox(result["objective"], 57980.0; atol = 1e0)
@@ -402,7 +402,7 @@ TESTLOG = Memento.getlogger(PowerModels)
                 end
             end
 
-            result = PowerModels.run_mn_opf_strg(mn_data, PowerModels.DCPPowerModel, juniper_solver)
+            result = PowerModels.solve_mn_opf_strg(mn_data, PowerModels.DCPPowerModel, juniper_solver)
 
             @test result["termination_status"] == LOCALLY_SOLVED
             @test isapprox(result["objective"], 69703.10; atol = 1e0)
@@ -419,7 +419,7 @@ TESTLOG = Memento.getlogger(PowerModels)
             mn_data["nw"]["1"]["storage"]["1"]["status"] = 0  # verify that storage activation does not cause error
 
             Memento.setlevel!(TESTLOG, "warn")
-            @test_warn(TESTLOG, "network data should specify time_elapsed, using 1.0 as a default", PowerModels.run_mn_opf_strg(mn_data, PowerModels.ACPPowerModel, juniper_solver))
+            @test_warn(TESTLOG, "network data should specify time_elapsed, using 1.0 as a default", PowerModels.solve_mn_opf_strg(mn_data, PowerModels.ACPPowerModel, juniper_solver))
             Memento.setlevel!(TESTLOG, "error")
         end
     end
@@ -428,13 +428,13 @@ TESTLOG = Memento.getlogger(PowerModels)
     @testset "test solution feedback" begin
         mn_data = build_mn_data("../test/data/matpower/case5_asym.m")
 
-        opf_result = PowerModels.run_mn_opf(mn_data, ACPPowerModel, ipopt_solver)
+        opf_result = PowerModels.solve_mn_opf(mn_data, ACPPowerModel, ipopt_solver)
         @test opf_result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(opf_result["objective"], 35103.8; atol = 1e0)
 
         PowerModels.update_data!(mn_data, opf_result["solution"])
 
-        pf_result = PowerModels._run_mn_pf(mn_data, ACPPowerModel, ipopt_solver)
+        pf_result = PowerModels._solve_mn_pf(mn_data, ACPPowerModel, ipopt_solver)
         @test pf_result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(pf_result["objective"], 0.0; atol = 1e-3)
 
@@ -482,7 +482,7 @@ TESTLOG = Memento.getlogger(PowerModels)
         @test_nowarn PowerModels.correct_reference_buses!(mn_data)
         Memento.setlevel!(TESTLOG, "error")
 
-        @test_throws(TESTLOG, ErrorException, PowerModels.run_ac_opf(mn_data, ipopt_solver))
+        @test_throws(TESTLOG, ErrorException, PowerModels.solve_ac_opf(mn_data, ipopt_solver))
     end
 
 end

--- a/test/opb.jl
+++ b/test/opb.jl
@@ -2,67 +2,67 @@
 
 @testset "test nfa opb" begin
     @testset "3-bus case" begin
-        result = run_opb("../test/data/matpower/case3.m", NFAPowerModel, ipopt_solver)
+        result = solve_opb("../test/data/matpower/case3.m", NFAPowerModel, ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 5638.97; atol = 1e0)
     end
     @testset "5-bus tranformer swap case" begin
-        result = run_opb("../test/data/matpower/case5.m", NFAPowerModel, ipopt_solver)
+        result = solve_opb("../test/data/matpower/case5.m", NFAPowerModel, ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 14810.0; atol = 1e0)
     end
     @testset "5-bus asymmetric case" begin
-        result = run_opb("../test/data/matpower/case5_asym.m", NFAPowerModel, ipopt_solver)
+        result = solve_opb("../test/data/matpower/case5_asym.m", NFAPowerModel, ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 14810.0; atol = 1e0)
     end
     @testset "5-bus gap case" begin
-        result = run_opb("../test/data/matpower/case5_gap.m", NFAPowerModel, ipopt_solver)
+        result = solve_opb("../test/data/matpower/case5_gap.m", NFAPowerModel, ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], -27410.0; atol = 1e0)
     end
     @testset "5-bus with dcline costs" begin
-        result = run_opb("../test/data/matpower/case5_dc.m", NFAPowerModel, ipopt_solver)
+        result = solve_opb("../test/data/matpower/case5_dc.m", NFAPowerModel, ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 14810.0; atol = 1e0)
     end
     @testset "5-bus with asymmetric line charge" begin
-        result = run_opb("../test/data/pti/case5_alc.raw", NFAPowerModel, ipopt_solver)
+        result = solve_opb("../test/data/pti/case5_alc.raw", NFAPowerModel, ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 1000.0; atol = 1e0)
     end
     @testset "5-bus with negative generators" begin
-        result = run_opb("../test/data/matpower/case5_npg.m", NFAPowerModel, ipopt_solver)
+        result = solve_opb("../test/data/matpower/case5_npg.m", NFAPowerModel, ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], -6844.0; atol = 1e0)
     end
     @testset "5-bus with only current limit data" begin
-        result = run_opb("../test/data/matpower/case5_clm.m", NFAPowerModel, ipopt_solver)
+        result = solve_opb("../test/data/matpower/case5_clm.m", NFAPowerModel, ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 14810.0; atol = 1e0)
     end
     @testset "5-bus with pwl costs" begin
-        result = run_opb("../test/data/matpower/case5_pwlc.m", NFAPowerModel, ipopt_solver)
+        result = solve_opb("../test/data/matpower/case5_pwlc.m", NFAPowerModel, ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 42565.8; atol = 1e0)
     end
     @testset "6-bus case" begin
-        result = run_opb("../test/data/matpower/case6.m", NFAPowerModel, ipopt_solver)
+        result = solve_opb("../test/data/matpower/case6.m", NFAPowerModel, ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 11277.9; atol = 1e0)
     end
     @testset "24-bus rts case" begin
-        result = run_opb("../test/data/matpower/case24.m", NFAPowerModel, ipopt_solver)
+        result = solve_opb("../test/data/matpower/case24.m", NFAPowerModel, ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 61001.2; atol = 1e0)
@@ -72,25 +72,25 @@ end
 
 @testset "test dcp opb" begin
     @testset "3-bus case" begin
-        result = run_opb("../test/data/matpower/case3.m", DCPPowerModel, ipopt_solver)
+        result = solve_opb("../test/data/matpower/case3.m", DCPPowerModel, ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 5638.97; atol = 1e0)
     end
     @testset "5-bus with pwl costs" begin
-        result = run_opb("../test/data/matpower/case5_pwlc.m", DCPPowerModel, ipopt_solver)
+        result = solve_opb("../test/data/matpower/case5_pwlc.m", DCPPowerModel, ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 42565.8; atol = 1e0)
     end
     @testset "6-bus case" begin
-        result = run_opb("../test/data/matpower/case6.m", DCPPowerModel, ipopt_solver)
+        result = solve_opb("../test/data/matpower/case6.m", DCPPowerModel, ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 11277.9; atol = 1e0)
     end
     @testset "24-bus case" begin
-        result = run_opb("../test/data/matpower/case24.m", DCPPowerModel, ipopt_solver)
+        result = solve_opb("../test/data/matpower/case24.m", DCPPowerModel, ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 61001.2; atol = 1e0)
@@ -100,25 +100,25 @@ end
 
 @testset "test soc wr opb" begin
     @testset "3-bus case" begin
-        result = run_opb("../test/data/matpower/case3.m", SOCWRPowerModel, ipopt_solver)
+        result = solve_opb("../test/data/matpower/case3.m", SOCWRPowerModel, ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 5638.97; atol = 1e0)
     end
     @testset "5-bus with pwl costs" begin
-        result = run_opb("../test/data/matpower/case5_pwlc.m", SOCWRPowerModel, ipopt_solver)
+        result = solve_opb("../test/data/matpower/case5_pwlc.m", SOCWRPowerModel, ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 42565.7; atol = 1e0)
     end
     @testset "6-bus case" begin
-        result = run_opb("../test/data/matpower/case6.m", SOCWRPowerModel, ipopt_solver)
+        result = solve_opb("../test/data/matpower/case6.m", SOCWRPowerModel, ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 11277.9; atol = 1e0)
     end
     @testset "24-bus case" begin
-        result = run_opb("../test/data/matpower/case24.m", SOCWRPowerModel, ipopt_solver)
+        result = solve_opb("../test/data/matpower/case24.m", SOCWRPowerModel, ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 61001.2; atol = 1e0)

--- a/test/opf-obj.jl
+++ b/test/opf-obj.jl
@@ -7,21 +7,21 @@
     data["gen"]["5"]["cost"] = []
 
     @testset "nlp solver" begin
-        result = run_ac_opf(data, ipopt_solver)
+        result = solve_ac_opf(data, ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 5420.3; atol = 1e0)
     end
 
     @testset "conic solver" begin
-        result = run_opf(data, SOCWRConicPowerModel, scs_solver)
+        result = solve_opf(data, SOCWRConicPowerModel, scs_solver)
 
         @test result["termination_status"] == OPTIMAL
         @test isapprox(result["objective"], 3095.88; atol = 1e0)
     end
 
     @testset "lp solver" begin
-        result = run_dc_opf(data, cbc_solver)
+        result = solve_dc_opf(data, cbc_solver)
 
         @test result["termination_status"] == OPTIMAL
         # @test isapprox(result["objective"], 4679.05; atol = 1e0)  # Problem upstream with JuMP.SecondOrderCone or JuMP.RotatedSecondOrderCone?
@@ -35,14 +35,14 @@ end
     data["gen"]["5"]["cost"] = []
 
     @testset "nlp solver" begin
-        result = run_ac_opf(data, ipopt_solver)
+        result = solve_ac_opf(data, ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 5420.46; atol = 1e0)
     end
 
     @testset "conic solver" begin
-        result = run_opf(data, SOCWRConicPowerModel, scs_solver)
+        result = solve_opf(data, SOCWRConicPowerModel, scs_solver)
 
         @test result["termination_status"] == OPTIMAL
         @test isapprox(result["objective"], 3096.04; atol = 1e0)
@@ -56,14 +56,14 @@ end
     data["gen"]["5"]["cost"] = []
 
     @testset "opf objective" begin
-        result = run_ac_opf(data, ipopt_solver)
+        result = solve_ac_opf(data, ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 5452.04; atol = 1e0)
     end
 
     @testset "opb objective" begin
-        result = run_opb(data, SOCWRPowerModel, ipopt_solver)
+        result = solve_opb(data, SOCWRPowerModel, ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 2999.80; atol = 1e0)
@@ -77,7 +77,7 @@ end
 
     @testset "nlp objective" begin
         data["dcline"]["1"]["cost"] = [100.0, 300.0, 4000.0, 1.0]
-        result = run_ac_opf(data, ipopt_solver)
+        result = solve_ac_opf(data, ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 18160.3; atol = 1e0)
@@ -85,7 +85,7 @@ end
 
     @testset "qp objective" begin
         data["dcline"]["1"]["cost"] = [1.0, 4000.0, 1.0]
-        result = run_ac_opf(data, ipopt_solver)
+        result = solve_ac_opf(data, ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 18157.2; atol = 1e0)
@@ -93,7 +93,7 @@ end
 
     @testset "linear objective" begin
         data["dcline"]["1"]["cost"] = [4000.0, 1.0]
-        result = run_ac_opf(data, ipopt_solver)
+        result = solve_ac_opf(data, ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 18157.2; atol = 1e0)
@@ -101,7 +101,7 @@ end
 
     @testset "constant objective" begin
         data["dcline"]["1"]["cost"] = [1.0]
-        result = run_ac_opf(data, ipopt_solver)
+        result = solve_ac_opf(data, ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 17757.2; atol = 1e0)
@@ -109,7 +109,7 @@ end
 
     @testset "empty objective" begin
         data["dcline"]["1"]["cost"] = []
-        result = run_ac_opf(data, ipopt_solver)
+        result = solve_ac_opf(data, ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 17756.2; atol = 1e0)

--- a/test/opf-ptdf.jl
+++ b/test/opf-ptdf.jl
@@ -4,8 +4,8 @@ TESTLOG = Memento.getlogger(PowerModels)
 @testset "test ptdf-based dc opf" begin
     @testset "5-bus case, LP solver" begin
         data = PowerModels.parse_file("../test/data/matpower/case5.m")
-        result_va = PowerModels.run_opf(data, DCPPowerModel, cbc_solver)
-        result_pg = PowerModels.run_opf_ptdf(data, DCPPowerModel, cbc_solver)
+        result_va = PowerModels.solve_opf(data, DCPPowerModel, cbc_solver)
+        result_pg = PowerModels.solve_opf_ptdf(data, DCPPowerModel, cbc_solver)
 
         @test result_va["termination_status"] == OPTIMAL
         @test result_pg["termination_status"] == OPTIMAL
@@ -16,8 +16,8 @@ TESTLOG = Memento.getlogger(PowerModels)
     end
     @testset "5-bus gap case" begin
         data = PowerModels.parse_file("../test/data/matpower/case5_gap.m")
-        result_va = PowerModels.run_opf(data, DCPPowerModel, ipopt_solver)
-        result_pg = PowerModels.run_opf_ptdf(data, DCPPowerModel, ipopt_solver)
+        result_va = PowerModels.solve_opf(data, DCPPowerModel, ipopt_solver)
+        result_pg = PowerModels.solve_opf_ptdf(data, DCPPowerModel, ipopt_solver)
 
         @test result_va["termination_status"] == LOCALLY_SOLVED
         @test result_pg["termination_status"] == LOCALLY_SOLVED
@@ -29,8 +29,8 @@ TESTLOG = Memento.getlogger(PowerModels)
     @testset "5-bus with pwl costs" begin
         data = PowerModels.parse_file("../test/data/matpower/case5_pwlc.m")
         data["dcline"] = Dict()
-        result_va = PowerModels.run_opf(data, DCPPowerModel, ipopt_solver)
-        result_pg = PowerModels.run_opf_ptdf(data, DCPPowerModel, ipopt_solver)
+        result_va = PowerModels.solve_opf(data, DCPPowerModel, ipopt_solver)
+        result_pg = PowerModels.solve_opf_ptdf(data, DCPPowerModel, ipopt_solver)
 
         @test result_va["termination_status"] == LOCALLY_SOLVED
         @test result_pg["termination_status"] == LOCALLY_SOLVED
@@ -41,8 +41,8 @@ TESTLOG = Memento.getlogger(PowerModels)
     end
     @testset "14-bus case" begin
         data = PowerModels.parse_file("../test/data/matpower/case14.m")
-        result_va = PowerModels.run_opf(data, DCPPowerModel, ipopt_solver)
-        result_pg = PowerModels.run_opf_ptdf(data, DCPPowerModel, ipopt_solver)
+        result_va = PowerModels.solve_opf(data, DCPPowerModel, ipopt_solver)
+        result_pg = PowerModels.solve_opf_ptdf(data, DCPPowerModel, ipopt_solver)
 
         @test result_va["termination_status"] == LOCALLY_SOLVED
         @test result_pg["termination_status"] == LOCALLY_SOLVED
@@ -55,19 +55,19 @@ TESTLOG = Memento.getlogger(PowerModels)
     @testset "no support for zero reference buses" begin
         data = PowerModels.parse_file("../test/data/matpower/case5.m")
         data["bus"]["4"]["bus_type"] = 2
-        @test_throws(TESTLOG, ErrorException, PowerModels.run_opf_ptdf(data, DCPPowerModel, ipopt_solver))
+        @test_throws(TESTLOG, ErrorException, PowerModels.solve_opf_ptdf(data, DCPPowerModel, ipopt_solver))
     end
 
     @testset "no support for multiple connected components" begin
-        @test_throws(TESTLOG, ErrorException, PowerModels.run_opf_ptdf("../test/data/matpower/case6.m", DCPPowerModel, ipopt_solver))
+        @test_throws(TESTLOG, ErrorException, PowerModels.solve_opf_ptdf("../test/data/matpower/case6.m", DCPPowerModel, ipopt_solver))
     end
 
     @testset "no support for dclines" begin
-        @test_throws(TESTLOG, ErrorException, PowerModels.run_opf_ptdf("../test/data/matpower/case3.m", DCPPowerModel, ipopt_solver))
+        @test_throws(TESTLOG, ErrorException, PowerModels.solve_opf_ptdf("../test/data/matpower/case3.m", DCPPowerModel, ipopt_solver))
     end
 
     @testset "no support for switches" begin
-        @test_throws(TESTLOG, ErrorException, PowerModels.run_opf_ptdf("../test/data/matpower/case5_sw.m", DCPPowerModel, ipopt_solver))
+        @test_throws(TESTLOG, ErrorException, PowerModels.solve_opf_ptdf("../test/data/matpower/case5_sw.m", DCPPowerModel, ipopt_solver))
     end
 
 end

--- a/test/opf-var.jl
+++ b/test/opf-var.jl
@@ -16,20 +16,20 @@ end
     @testset "test ac polar opf" begin
         @testset "5-bus case" begin
             data = build_current_data("../test/data/matpower/case5.m")
-            result = PowerModels._run_opf_cl(data, ACPPowerModel, ipopt_solver)
+            result = PowerModels._solve_opf_cl(data, ACPPowerModel, ipopt_solver)
 
             @test result["termination_status"] == LOCALLY_SOLVED
             @test isapprox(result["objective"], 15669.8; atol = 1e0)
         end
         @testset "5-bus current limit case" begin
-           result = PowerModels._run_opf_cl("../test/data/matpower/case5_clm.m", ACPPowerModel, ipopt_solver)
+           result = PowerModels._solve_opf_cl("../test/data/matpower/case5_clm.m", ACPPowerModel, ipopt_solver)
 
            @test result["termination_status"] == LOCALLY_SOLVED
            @test isapprox(result["objective"], 17015.5; atol = 1e0)
         end
         @testset "14-bus no limits case" begin
             data = build_current_data("../test/data/matpower/case14.m")
-            result = PowerModels._run_opf_cl(data, ACPPowerModel, ipopt_solver)
+            result = PowerModels._solve_opf_cl(data, ACPPowerModel, ipopt_solver)
 
             @test result["termination_status"] == LOCALLY_SOLVED
             @test isapprox(result["objective"], 8081.52; atol = 1e0)
@@ -39,14 +39,14 @@ end
     @testset "test ac rect opf" begin
         @testset "5-bus case" begin
             data = build_current_data("../test/data/matpower/case5.m")
-            result = PowerModels._run_opf_cl(data, ACRPowerModel, ipopt_solver)
+            result = PowerModels._solve_opf_cl(data, ACRPowerModel, ipopt_solver)
 
             @test result["termination_status"] == LOCALLY_SOLVED
             @test isapprox(result["objective"], 15669.8; atol = 1e0)
         end
         @testset "14-bus no limits case" begin
             data = build_current_data("../test/data/matpower/case14.m")
-            result = PowerModels._run_opf_cl(data, ACRPowerModel, ipopt_solver)
+            result = PowerModels._solve_opf_cl(data, ACRPowerModel, ipopt_solver)
 
             @test result["termination_status"] == LOCALLY_SOLVED
             @test isapprox(result["objective"], 8081.52; atol = 1e0)
@@ -56,14 +56,14 @@ end
     @testset "test ac tan opf" begin
         @testset "5-bus case" begin
             data = build_current_data("../test/data/matpower/case5.m")
-            result = PowerModels._run_opf_cl(data, ACTPowerModel, ipopt_solver)
+            result = PowerModels._solve_opf_cl(data, ACTPowerModel, ipopt_solver)
 
             @test result["termination_status"] == LOCALLY_SOLVED
             @test isapprox(result["objective"], 15669.8; atol = 1e0)
         end
         @testset "14-bus no limits case" begin
             data = build_current_data("../test/data/matpower/case14.m")
-            result = PowerModels._run_opf_cl(data, ACTPowerModel, ipopt_solver)
+            result = PowerModels._solve_opf_cl(data, ACTPowerModel, ipopt_solver)
 
             @test result["termination_status"] == LOCALLY_SOLVED
             @test isapprox(result["objective"], 8081.52; atol = 1e0)
@@ -73,14 +73,14 @@ end
     @testset "test dc opf" begin
         @testset "5-bus case" begin
             data = build_current_data("../test/data/matpower/case5.m")
-            result = PowerModels._run_opf_cl(data, DCPPowerModel, ipopt_solver)
+            result = PowerModels._solve_opf_cl(data, DCPPowerModel, ipopt_solver)
 
             @test result["termination_status"] == LOCALLY_SOLVED
             @test isapprox(result["objective"], 16154.5; atol = 1e0)
         end
         @testset "14-bus no limits case" begin
             data = build_current_data("../test/data/matpower/case14.m")
-            result = PowerModels._run_opf_cl(data, DCPPowerModel, ipopt_solver)
+            result = PowerModels._solve_opf_cl(data, DCPPowerModel, ipopt_solver)
 
             @test result["termination_status"] == LOCALLY_SOLVED
             @test isapprox(result["objective"], 7642.59; atol = 1e0)
@@ -90,14 +90,14 @@ end
     @testset "test dc+ll opf" begin
         @testset "5-bus case" begin
             data = build_current_data("../test/data/matpower/case5.m")
-            result = PowerModels._run_opf_cl(data, DCPLLPowerModel, ipopt_solver)
+            result = PowerModels._solve_opf_cl(data, DCPLLPowerModel, ipopt_solver)
 
             @test result["termination_status"] == LOCALLY_SOLVED
             @test isapprox(result["objective"], 16282.6; atol = 1e0)
         end
         @testset "14-bus no limits case" begin
             data = build_current_data("../test/data/matpower/case14.m")
-            result = PowerModels._run_opf_cl(data, DCPLLPowerModel, ipopt_solver)
+            result = PowerModels._solve_opf_cl(data, DCPLLPowerModel, ipopt_solver)
 
             @test result["termination_status"] == LOCALLY_SOLVED
             @test isapprox(result["objective"], 8110.61; atol = 1e0)
@@ -107,14 +107,14 @@ end
     @testset "test soc (BIM) opf" begin
         @testset "5-bus case" begin
             data = build_current_data("../test/data/matpower/case5.m")
-            result = PowerModels._run_opf_cl(data, SOCWRPowerModel, ipopt_solver)
+            result = PowerModels._solve_opf_cl(data, SOCWRPowerModel, ipopt_solver)
 
             @test result["termination_status"] == LOCALLY_SOLVED
             @test isapprox(result["objective"], 15047.7; atol = 1e0)
         end
         @testset "14-bus no limits case" begin
             data = build_current_data("../test/data/matpower/case14.m")
-            result = PowerModels._run_opf_cl(data, SOCWRPowerModel, ipopt_solver)
+            result = PowerModels._solve_opf_cl(data, SOCWRPowerModel, ipopt_solver)
 
             @test result["termination_status"] == LOCALLY_SOLVED
             @test isapprox(result["objective"], 8075.12; atol = 1e0)
@@ -124,14 +124,14 @@ end
     @testset "test sdp opf" begin
         @testset "3-bus case" begin
             data = build_current_data("../test/data/matpower/case3.m")
-            result = PowerModels._run_opf_cl(data, SDPWRMPowerModel, scs_solver)
+            result = PowerModels._solve_opf_cl(data, SDPWRMPowerModel, scs_solver)
 
             @test result["termination_status"] == OPTIMAL
             @test isapprox(result["objective"], 5747.32; atol = 1e0)
         end
         #@testset "5-bus case" begin
         #    data = build_current_data("../test/data/matpower/case5.m")
-        #    result = PowerModels._run_opf_cl(data, SDPWRMPowerModel, scs_solver)
+        #    result = PowerModels._solve_opf_cl(data, SDPWRMPowerModel, scs_solver)
 
         #    @test result["termination_status"] == OPTIMAL
         #    @test isapprox(result["objective"], 15418.4; atol = 1e0)
@@ -140,7 +140,7 @@ end
         # too slow of unit tests
         # @testset "14-bus case" begin
         #     data = build_current_data("../test/data/matpower/case14.m")
-        #     result = PowerModels._run_opf_cl(data, SDPWRMPowerModel, scs_solver)
+        #     result = PowerModels._solve_opf_cl(data, SDPWRMPowerModel, scs_solver)
 
         #     @test result["termination_status"] == OPTIMAL
         #     @test isapprox(result["objective"], 8081.52; atol = 1e0)
@@ -155,7 +155,7 @@ end
 
     @testset "test ac polar mld" begin
         @testset "5-bus case" begin
-            result = PowerModels._run_mld("../test/data/matpower/case5.m", ACPPowerModel, ipopt_solver)
+            result = PowerModels._solve_mld("../test/data/matpower/case5.m", ACPPowerModel, ipopt_solver)
 
             @test result["termination_status"] == LOCALLY_SOLVED
             @test isapprox(result["objective"], 10.0; atol = 1e-2)
@@ -165,7 +165,7 @@ end
 
         end
         @testset "14-bus current" begin
-            result = PowerModels._run_mld("../test/data/matpower/case14.m", ACPPowerModel, ipopt_solver)
+            result = PowerModels._solve_mld("../test/data/matpower/case14.m", ACPPowerModel, ipopt_solver)
 
             @test result["termination_status"] == LOCALLY_SOLVED
             @test isapprox(result["objective"], 3.59; atol = 1e-2)
@@ -183,7 +183,7 @@ end
 
     @testset "test ac rect mld" begin
         @testset "5-bus case" begin
-            result = PowerModels._run_mld("../test/data/matpower/case5.m", ACRPowerModel, ipopt_solver)
+            result = PowerModels._solve_mld("../test/data/matpower/case5.m", ACRPowerModel, ipopt_solver)
 
             @test result["termination_status"] == LOCALLY_SOLVED
             @test isapprox(result["objective"], 10.0; atol = 1e-2)
@@ -192,7 +192,7 @@ end
             @test all_shunts_on(result)
         end
         @testset "14-bus case" begin
-            result = PowerModels._run_mld("../test/data/matpower/case14.m", ACRPowerModel, ipopt_solver)
+            result = PowerModels._solve_mld("../test/data/matpower/case14.m", ACRPowerModel, ipopt_solver)
 
             @test result["termination_status"] == LOCALLY_SOLVED
             @test isapprox(result["objective"], 3.59; atol = 1e-2)
@@ -204,7 +204,7 @@ end
 
     @testset "test ac tan mld" begin
         @testset "5-bus case" begin
-            result = PowerModels._run_mld("../test/data/matpower/case5.m", ACTPowerModel, ipopt_solver)
+            result = PowerModels._solve_mld("../test/data/matpower/case5.m", ACTPowerModel, ipopt_solver)
 
             @test result["termination_status"] == LOCALLY_SOLVED
             @test isapprox(result["objective"], 10.0; atol = 1e-2)
@@ -213,7 +213,7 @@ end
             @test all_shunts_on(result)
         end
         @testset "14-bus case" begin
-            result = PowerModels._run_mld("../test/data/matpower/case14.m", ACTPowerModel, ipopt_solver)
+            result = PowerModels._solve_mld("../test/data/matpower/case14.m", ACTPowerModel, ipopt_solver)
 
             @test result["termination_status"] == LOCALLY_SOLVED
             @test isapprox(result["objective"], 3.59; atol = 1e-2)
@@ -225,7 +225,7 @@ end
 
     @testset "test nfa mld" begin
         @testset "5-bus case" begin
-            result = PowerModels._run_mld("../test/data/matpower/case5.m", NFAPowerModel, ipopt_solver)
+            result = PowerModels._solve_mld("../test/data/matpower/case5.m", NFAPowerModel, ipopt_solver)
 
             @test result["termination_status"] == LOCALLY_SOLVED
             @test isapprox(result["objective"], 10.0; atol = 1e-2)
@@ -234,7 +234,7 @@ end
             @test all_shunts_on(result)
         end
         @testset "14-bus case" begin
-            result = PowerModels._run_mld("../test/data/matpower/case14.m", NFAPowerModel, ipopt_solver)
+            result = PowerModels._solve_mld("../test/data/matpower/case14.m", NFAPowerModel, ipopt_solver)
 
             @test result["termination_status"] == LOCALLY_SOLVED
             @test isapprox(result["objective"], 3.59; atol = 1e-2)
@@ -246,7 +246,7 @@ end
 
     @testset "test dc mld" begin
         @testset "5-bus case" begin
-            result = PowerModels._run_mld("../test/data/matpower/case5.m", DCPPowerModel, ipopt_solver)
+            result = PowerModels._solve_mld("../test/data/matpower/case5.m", DCPPowerModel, ipopt_solver)
 
             @test result["termination_status"] == LOCALLY_SOLVED
             @test isapprox(result["objective"], 10.0; atol = 1e-2)
@@ -255,7 +255,7 @@ end
             @test all_shunts_on(result)
         end
         @testset "14-bus case" begin
-            result = PowerModels._run_mld("../test/data/matpower/case14.m", DCPPowerModel, ipopt_solver)
+            result = PowerModels._solve_mld("../test/data/matpower/case14.m", DCPPowerModel, ipopt_solver)
 
             @test result["termination_status"] == LOCALLY_SOLVED
             @test isapprox(result["objective"], 3.59; atol = 1e-2)
@@ -267,7 +267,7 @@ end
 
     @testset "test soc (BIM) mld" begin
         @testset "5-bus case" begin
-            result = PowerModels._run_mld("../test/data/matpower/case5.m", SOCWRPowerModel, ipopt_solver)
+            result = PowerModels._solve_mld("../test/data/matpower/case5.m", SOCWRPowerModel, ipopt_solver)
 
             @test result["termination_status"] == LOCALLY_SOLVED
             @test isapprox(result["objective"], 10.0; atol = 1e-2)
@@ -276,7 +276,7 @@ end
             @test all_shunts_on(result)
         end
         @testset "14-bus case" begin
-            result = PowerModels._run_mld("../test/data/matpower/case14.m", SOCWRPowerModel, ipopt_solver)
+            result = PowerModels._solve_mld("../test/data/matpower/case14.m", SOCWRPowerModel, ipopt_solver)
 
             @test result["termination_status"] == LOCALLY_SOLVED
             @test isapprox(result["objective"], 3.59; atol = 1e-2)
@@ -288,7 +288,7 @@ end
 
     @testset "test soc conic (BIM) mld" begin
         @testset "5-bus case" begin
-            result = PowerModels._run_mld("../test/data/matpower/case5.m", SOCWRConicPowerModel, scs_solver)
+            result = PowerModels._solve_mld("../test/data/matpower/case5.m", SOCWRConicPowerModel, scs_solver)
 
             @test result["termination_status"] == OPTIMAL
             @test isapprox(result["objective"], 10.0; atol = 1e-2)
@@ -297,7 +297,7 @@ end
             @test all_shunts_on(result)
         end
         @testset "14-bus case" begin
-            result = PowerModels._run_mld("../test/data/matpower/case14.m", SOCWRConicPowerModel, scs_solver)
+            result = PowerModels._solve_mld("../test/data/matpower/case14.m", SOCWRConicPowerModel, scs_solver)
 
             @test result["termination_status"] == OPTIMAL
             @test isapprox(result["objective"], 3.59; atol = 1e-2)
@@ -309,7 +309,7 @@ end
 
     @testset "test sdp mld" begin
         @testset "5-bus case" begin
-            result = PowerModels._run_mld("../test/data/matpower/case5.m", SOCWRConicPowerModel, scs_solver)
+            result = PowerModels._solve_mld("../test/data/matpower/case5.m", SOCWRConicPowerModel, scs_solver)
 
             @test result["termination_status"] == OPTIMAL
             @test isapprox(result["objective"], 10.0; atol = 1e-2)
@@ -318,7 +318,7 @@ end
             @test all_shunts_on(result)
         end
         @testset "14-bus case" begin
-            result = PowerModels._run_mld("../test/data/matpower/case14.m", SOCWRConicPowerModel, scs_solver)
+            result = PowerModels._solve_mld("../test/data/matpower/case14.m", SOCWRConicPowerModel, scs_solver)
 
             @test result["termination_status"] == OPTIMAL
             @test isapprox(result["objective"], 3.59; atol = 1e-2)
@@ -333,7 +333,7 @@ end
         settings = Dict("output" => Dict("duals" => true))
 
         @testset "ac case" begin
-            result = PowerModels._run_mld("../test/data/matpower/case5.m", ACPPowerModel, ipopt_solver, setting=settings)
+            result = PowerModels._solve_mld("../test/data/matpower/case5.m", ACPPowerModel, ipopt_solver, setting=settings)
 
             @test result["termination_status"] == LOCALLY_SOLVED
             @test isapprox(result["objective"], 10.0; atol = 1e-2)
@@ -346,7 +346,7 @@ end
         end
 
         @testset "soc case" begin
-            result = PowerModels._run_mld("../test/data/matpower/case5.m", SOCWRPowerModel, ipopt_solver, setting=settings)
+            result = PowerModels._solve_mld("../test/data/matpower/case5.m", SOCWRPowerModel, ipopt_solver, setting=settings)
 
             @test result["termination_status"] == LOCALLY_SOLVED
             @test isapprox(result["objective"], 10.0; atol = 1e-2)
@@ -359,7 +359,7 @@ end
         end
 
         @testset "dc case" begin
-            result = PowerModels._run_mld("../test/data/matpower/case5.m", SOCWRPowerModel, ipopt_solver, setting=settings)
+            result = PowerModels._solve_mld("../test/data/matpower/case5.m", SOCWRPowerModel, ipopt_solver, setting=settings)
 
             @test result["termination_status"] == LOCALLY_SOLVED
             @test isapprox(result["objective"], 10.0; atol = 1e-2)
@@ -378,7 +378,7 @@ end
 
     @testset "test ac opf" begin
         @testset "5-bus uc case" begin
-            result = PowerModels._run_ucopf("../test/data/matpower/case5_uc.m", ACPPowerModel, juniper_solver)
+            result = PowerModels._solve_ucopf("../test/data/matpower/case5_uc.m", ACPPowerModel, juniper_solver)
 
             @test result["termination_status"] == LOCALLY_SOLVED
             @test isapprox(result["objective"], 18270.0; atol = 1e0)
@@ -388,7 +388,7 @@ end
 
     @testset "test soc opf" begin
         @testset "5-bus uc case" begin
-            result = PowerModels._run_ucopf("../test/data/matpower/case5_uc.m", SOCWRPowerModel, juniper_solver)
+            result = PowerModels._solve_ucopf("../test/data/matpower/case5_uc.m", SOCWRPowerModel, juniper_solver)
 
             @test result["termination_status"] == LOCALLY_SOLVED
             @test isapprox(result["objective"], 15057.09; atol = 1e0)
@@ -398,7 +398,7 @@ end
 
     @testset "test dc opf" begin
         @testset "5-bus uc case" begin
-            result = PowerModels._run_ucopf("../test/data/matpower/case5_uc.m", DCPPowerModel, cbc_solver)
+            result = PowerModels._solve_ucopf("../test/data/matpower/case5_uc.m", DCPPowerModel, cbc_solver)
 
             @test result["termination_status"] == OPTIMAL
             @test isapprox(result["objective"], 17613.2; atol = 1e0)
@@ -409,7 +409,7 @@ end
 
     @testset "test ac opf" begin
         @testset "5-bus uc storage case" begin
-            result = PowerModels._run_ucopf("../test/data/matpower/case5_uc_strg.m", ACPPowerModel, juniper_solver)
+            result = PowerModels._solve_ucopf("../test/data/matpower/case5_uc_strg.m", ACPPowerModel, juniper_solver)
 
             @test result["termination_status"] == LOCALLY_SOLVED
             @test isapprox(result["objective"], 17740.9; atol = 1e0)
@@ -422,7 +422,7 @@ end
 
     @testset "test soc opf" begin
         @testset "5-bus uc storage case" begin
-            result = PowerModels._run_ucopf("../test/data/matpower/case5_uc_strg.m", SOCWRPowerModel, juniper_solver)
+            result = PowerModels._solve_ucopf("../test/data/matpower/case5_uc_strg.m", SOCWRPowerModel, juniper_solver)
 
             @test result["termination_status"] == LOCALLY_SOLVED
             @test isapprox(result["objective"], 14525.0; atol = 1e0)
@@ -435,7 +435,7 @@ end
 
     @testset "test dc opf" begin
         @testset "5-bus uc storage case" begin
-            result = PowerModels._run_ucopf("../test/data/matpower/case5_uc_strg.m", DCPPowerModel, cbc_solver)
+            result = PowerModels._solve_ucopf("../test/data/matpower/case5_uc_strg.m", DCPPowerModel, cbc_solver)
 
             @test result["termination_status"] == OPTIMAL
             @test isapprox(result["objective"], 16833.2; atol = 1e0)
@@ -454,7 +454,7 @@ end
 
     @testset "test ac opf" begin
         @testset "5-bus sw case" begin
-            result = PowerModels._run_opf_sw("../test/data/matpower/case5_sw.m", ACPPowerModel, ipopt_solver)
+            result = PowerModels._solve_opf_sw("../test/data/matpower/case5_sw.m", ACPPowerModel, ipopt_solver)
 
             @test result["termination_status"] == LOCALLY_SOLVED
             @test isapprox(result["objective"], 16641.2; atol = 1e0)
@@ -467,7 +467,7 @@ end
         end
 
         @testset "5-bus sw nb case" begin
-            result = PowerModels._run_opf_sw("../test/data/matpower/case5_sw_nb.m", ACPPowerModel, ipopt_solver)
+            result = PowerModels._solve_opf_sw("../test/data/matpower/case5_sw_nb.m", ACPPowerModel, ipopt_solver)
 
             @test result["termination_status"] == LOCALLY_SOLVED
             @test isapprox(result["objective"], 17915.3; atol = 1e0)
@@ -476,7 +476,7 @@ end
 
     @testset "test dc opf" begin
         @testset "5-bus sw case" begin
-            result = PowerModels._run_opf_sw("../test/data/matpower/case5_sw.m", DCPPowerModel, cbc_solver)
+            result = PowerModels._solve_opf_sw("../test/data/matpower/case5_sw.m", DCPPowerModel, cbc_solver)
 
             @test result["termination_status"] == OPTIMAL
             @test isapprox(result["objective"], 16554.7; atol = 1e0)
@@ -487,7 +487,7 @@ end
         end
 
         @testset "5-bus sw nb case" begin
-            result = PowerModels._run_opf_sw("../test/data/matpower/case5_sw_nb.m", DCPPowerModel, cbc_solver)
+            result = PowerModels._solve_opf_sw("../test/data/matpower/case5_sw_nb.m", DCPPowerModel, cbc_solver)
 
             @test result["termination_status"] == OPTIMAL
             @test isapprox(result["objective"], 17751.3; atol = 1e0)
@@ -496,7 +496,7 @@ end
 
     @testset "test soc opf" begin
         @testset "5-bus sw case" begin
-            result = PowerModels._run_opf_sw("../test/data/matpower/case5_sw.m", SOCWRPowerModel, ipopt_solver)
+            result = PowerModels._solve_opf_sw("../test/data/matpower/case5_sw.m", SOCWRPowerModel, ipopt_solver)
 
             @test result["termination_status"] == LOCALLY_SOLVED
             @test isapprox(result["objective"], 15110.0; atol = 1e0)
@@ -507,7 +507,7 @@ end
         end
 
         @testset "5-bus sw nb case" begin
-            result = PowerModels._run_opf_sw("../test/data/matpower/case5_sw_nb.m", SOCWRPowerModel, ipopt_solver)
+            result = PowerModels._solve_opf_sw("../test/data/matpower/case5_sw_nb.m", SOCWRPowerModel, ipopt_solver)
 
             @test result["termination_status"] == LOCALLY_SOLVED
             @test isapprox(result["objective"], 15192.8; atol = 1e0)
@@ -521,7 +521,7 @@ end
 
     @testset "test ac oswpf" begin
         @testset "5-bus sw case" begin
-            result = PowerModels._run_oswpf("../test/data/matpower/case5_sw.m", ACPPowerModel, juniper_solver)
+            result = PowerModels._solve_oswpf("../test/data/matpower/case5_sw.m", ACPPowerModel, juniper_solver)
 
             @test result["termination_status"] == LOCALLY_SOLVED
             @test isapprox(result["objective"], 15053.6; atol = 1e0)
@@ -535,7 +535,7 @@ end
         end
 
         @testset "5-bus sw nb case" begin
-            result = PowerModels._run_oswpf("../test/data/matpower/case5_sw_nb.m", ACPPowerModel, juniper_solver)
+            result = PowerModels._solve_oswpf("../test/data/matpower/case5_sw_nb.m", ACPPowerModel, juniper_solver)
 
             @test result["termination_status"] == LOCALLY_SOLVED
             @test isapprox(result["objective"], 17915.2; atol = 1e0)
@@ -547,7 +547,7 @@ end
 
     @testset "test dc oswpf" begin
         @testset "5-bus sw case" begin
-            result = PowerModels._run_oswpf("../test/data/matpower/case5_sw.m", DCPPowerModel, cbc_solver)
+            result = PowerModels._solve_oswpf("../test/data/matpower/case5_sw.m", DCPPowerModel, cbc_solver)
 
             @test result["termination_status"] == OPTIMAL
             @test isapprox(result["objective"], 15054.1; atol = 1e0)
@@ -562,7 +562,7 @@ end
         end
 
         @testset "5-bus sw nb case" begin
-            result = PowerModels._run_oswpf("../test/data/matpower/case5_sw_nb.m", DCPPowerModel, cbc_solver)
+            result = PowerModels._solve_oswpf("../test/data/matpower/case5_sw_nb.m", DCPPowerModel, cbc_solver)
 
             @test result["termination_status"] == OPTIMAL
             @test isapprox(result["objective"], 15141.2; atol = 1e0)
@@ -574,7 +574,7 @@ end
 
     @testset "test soc oswpf" begin
         @testset "5-bus sw case" begin
-            result = PowerModels._run_oswpf("../test/data/matpower/case5_sw.m", SOCWRPowerModel, juniper_solver)
+            result = PowerModels._solve_oswpf("../test/data/matpower/case5_sw.m", SOCWRPowerModel, juniper_solver)
 
             @test result["termination_status"] == LOCALLY_SOLVED
             @test isapprox(result["objective"], 15053.6; atol = 1e0)
@@ -588,7 +588,7 @@ end
         end
 
         @testset "5-bus sw nb case" begin
-            result = PowerModels._run_oswpf("../test/data/matpower/case5_sw_nb.m", SOCWRPowerModel, juniper_solver)
+            result = PowerModels._solve_oswpf("../test/data/matpower/case5_sw_nb.m", SOCWRPowerModel, juniper_solver)
 
             @test result["termination_status"] == LOCALLY_SOLVED
             @test isapprox(result["objective"], 15175.7; atol = 1e0)
@@ -606,7 +606,7 @@ end
 
     @testset "test ac oswpf node-breaker" begin
         @testset "5-bus sw nb case" begin
-            result = PowerModels._run_oswpf_nb("../test/data/matpower/case5_sw_nb.m", ACPPowerModel, juniper_solver)
+            result = PowerModels._solve_oswpf_nb("../test/data/matpower/case5_sw_nb.m", ACPPowerModel, juniper_solver)
 
             @test result["termination_status"] == LOCALLY_SOLVED
             @test isapprox(result["objective"], 15350.4; atol = 1e0)
@@ -621,7 +621,7 @@ end
 
     @testset "test dc oswpf node-breaker" begin
         @testset "5-bus sw nb case" begin
-            result = PowerModels._run_oswpf_nb("../test/data/matpower/case5_sw_nb.m", DCPPowerModel, cbc_solver)
+            result = PowerModels._solve_oswpf_nb("../test/data/matpower/case5_sw_nb.m", DCPPowerModel, cbc_solver)
 
             @test result["termination_status"] == OPTIMAL
             @test isapprox(result["objective"], 15141.2; atol = 1e0)
@@ -636,7 +636,7 @@ end
 
     @testset "test soc oswpf node-breaker" begin
         @testset "5-bus sw nb case" begin
-            result = PowerModels._run_oswpf_nb("../test/data/matpower/case5_sw_nb.m", SOCWRPowerModel, juniper_solver)
+            result = PowerModels._solve_oswpf_nb("../test/data/matpower/case5_sw_nb.m", SOCWRPowerModel, juniper_solver)
 
             @test result["termination_status"] == LOCALLY_SOLVED
             @test isapprox(result["objective"], 15175.7; atol = 1e0)
@@ -656,7 +656,7 @@ end
 
     @testset "test acp polar opf" begin
         @testset "5-bus case" begin
-            result = PowerModels._run_opf_strg("../test/data/matpower/case5_strg.m", PowerModels.ACPPowerModel, ipopt_solver)
+            result = PowerModels._solve_opf_strg("../test/data/matpower/case5_strg.m", PowerModels.ACPPowerModel, ipopt_solver)
 
             @test result["termination_status"] == LOCALLY_SOLVED
             @test isapprox(result["objective"], 17039.7; atol = 1e0)
@@ -670,7 +670,7 @@ end
 
     @testset "test mi acp polar opf" begin
         @testset "5-bus case" begin
-            result = PowerModels._run_opf_strg_mi("../test/data/matpower/case5_strg.m", PowerModels.ACPPowerModel, juniper_solver)
+            result = PowerModels._solve_opf_strg_mi("../test/data/matpower/case5_strg.m", PowerModels.ACPPowerModel, juniper_solver)
 
             @test result["termination_status"] == LOCALLY_SOLVED
             @test isapprox(result["objective"], 17039.7; atol = 1e0)
@@ -685,7 +685,7 @@ end
 
     @testset "test acr polar opf" begin
         @testset "5-bus case" begin
-            result = PowerModels._run_opf_strg("../test/data/matpower/case5_strg.m", PowerModels.ACRPowerModel, ipopt_solver)
+            result = PowerModels._solve_opf_strg("../test/data/matpower/case5_strg.m", PowerModels.ACRPowerModel, ipopt_solver)
 
             @test result["termination_status"] == LOCALLY_SOLVED
             @test isapprox(result["objective"], 17039.7; atol = 1e0)
@@ -699,7 +699,7 @@ end
 
     @testset "test mi acr polar opf" begin
         @testset "5-bus case" begin
-            result = PowerModels._run_opf_strg_mi("../test/data/matpower/case5_strg.m", PowerModels.ACRPowerModel, juniper_solver)
+            result = PowerModels._solve_opf_strg_mi("../test/data/matpower/case5_strg.m", PowerModels.ACRPowerModel, juniper_solver)
 
             @test result["termination_status"] == LOCALLY_SOLVED
             @test isapprox(result["objective"], 17039.7; atol = 1e0)
@@ -714,7 +714,7 @@ end
 
     @testset "test soc polar opf" begin
         @testset "5-bus case" begin
-            result = PowerModels._run_opf_strg("../test/data/matpower/case5_strg.m", PowerModels.SOCWRPowerModel, ipopt_solver)
+            result = PowerModels._solve_opf_strg("../test/data/matpower/case5_strg.m", PowerModels.SOCWRPowerModel, ipopt_solver)
 
             @test result["termination_status"] == LOCALLY_SOLVED
             @test isapprox(result["objective"], 13799.5; atol = 1e0)
@@ -728,7 +728,7 @@ end
 
     @testset "test mi soc polar opf" begin
         @testset "5-bus case" begin
-            result = PowerModels._run_opf_strg_mi("../test/data/matpower/case5_strg.m", PowerModels.SOCWRPowerModel, juniper_solver)
+            result = PowerModels._solve_opf_strg_mi("../test/data/matpower/case5_strg.m", PowerModels.SOCWRPowerModel, juniper_solver)
 
             @test result["termination_status"] == LOCALLY_SOLVED
             @test isapprox(result["objective"], 13799.5; atol = 1e0)
@@ -743,7 +743,7 @@ end
 
     @testset "test dc opf" begin
         @testset "5-bus case" begin
-            result = PowerModels._run_opf_strg("../test/data/matpower/case5_strg.m", PowerModels.DCPPowerModel, ipopt_solver)
+            result = PowerModels._solve_opf_strg("../test/data/matpower/case5_strg.m", PowerModels.DCPPowerModel, ipopt_solver)
 
             @test result["termination_status"] == LOCALLY_SOLVED
             @test isapprox(result["objective"], 16840.7; atol = 1e0)
@@ -757,7 +757,7 @@ end
 
     @testset "test mi dc opf" begin
         @testset "5-bus case" begin
-            result = PowerModels._run_opf_strg_mi("../test/data/matpower/case5_strg.m", PowerModels.DCPPowerModel, cbc_solver)
+            result = PowerModels._solve_opf_strg_mi("../test/data/matpower/case5_strg.m", PowerModels.DCPPowerModel, cbc_solver)
 
             @test result["termination_status"] == OPTIMAL
             @test isapprox(result["objective"], 16840.7; atol = 1e0)
@@ -772,7 +772,7 @@ end
 
     @testset "test dc+ll opf" begin
         @testset "5-bus case" begin
-            result = PowerModels._run_opf_strg("../test/data/matpower/case5_strg.m", PowerModels.DCPLLPowerModel, ipopt_solver)
+            result = PowerModels._solve_opf_strg("../test/data/matpower/case5_strg.m", PowerModels.DCPLLPowerModel, ipopt_solver)
 
             @test result["termination_status"] == LOCALLY_SOLVED
             @test isapprox(result["objective"], 17048.4; atol = 1e0)
@@ -788,7 +788,7 @@ end
         mp_data = PowerModels.parse_file("../test/data/matpower/case5_strg.m")
         delete!(mp_data, "time_elapsed")
         Memento.setlevel!(TESTLOG, "warn")
-        @test_warn(TESTLOG, "network data should specify time_elapsed, using 1.0 as a default", PowerModels._run_opf_strg(mp_data, PowerModels.ACPPowerModel, ipopt_solver))
+        @test_warn(TESTLOG, "network data should specify time_elapsed, using 1.0 as a default", PowerModels._solve_opf_strg(mp_data, PowerModels.ACPPowerModel, ipopt_solver))
         Memento.setlevel!(TESTLOG, "error")
     end
 
@@ -833,31 +833,31 @@ end
     end
 
     @testset "3-bus case" begin
-        result = run_model("../test/data/matpower/case3.m", ACPPowerModel, ipopt_solver, build_opf_var)
+        result = solve_model("../test/data/matpower/case3.m", ACPPowerModel, ipopt_solver, build_opf_var)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 5907; atol = 1e0)
     end
     @testset "5-bus asymmetric case" begin
-        result = run_model("../test/data/matpower/case5_asym.m", ACPPowerModel, ipopt_solver, build_opf_var)
+        result = solve_model("../test/data/matpower/case5_asym.m", ACPPowerModel, ipopt_solver, build_opf_var)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 17551; atol = 1e0)
     end
     @testset "5-bus gap case" begin
-        result = run_model("../test/data/matpower/case5_gap.m", ACPPowerModel, ipopt_solver, build_opf_var)
+        result = solve_model("../test/data/matpower/case5_gap.m", ACPPowerModel, ipopt_solver, build_opf_var)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], -27497.7; atol = 1e0)
     end
     @testset "5-bus with dcline costs" begin
-        result = run_model("../test/data/matpower/case5_dc.m", ACPPowerModel, ipopt_solver, build_opf_var)
+        result = solve_model("../test/data/matpower/case5_dc.m", ACPPowerModel, ipopt_solver, build_opf_var)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 18156.2; atol = 1e0)
     end
     @testset "6-bus case" begin
-        result = run_model("../test/data/matpower/case6.m", ACPPowerModel, ipopt_solver, build_opf_var)
+        result = solve_model("../test/data/matpower/case6.m", ACPPowerModel, ipopt_solver, build_opf_var)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 11625.3; atol = 1e0)
@@ -865,7 +865,7 @@ end
         @test isapprox(result["solution"]["bus"]["4"]["va"], 0.0; atol = 1e-4)
     end
     @testset "24-bus rts case" begin
-        result = run_model("../test/data/matpower/case24.m", ACPPowerModel, ipopt_solver, build_opf_var)
+        result = solve_model("../test/data/matpower/case24.m", ACPPowerModel, ipopt_solver, build_opf_var)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 79805; atol = 1e0)
@@ -878,7 +878,7 @@ end
         @testset "3-bus case with fixed phase shift / tap" begin
             file = "../test/data/matpower/case3_oltc_pst.m"
             data = PowerModels.parse_file(file)
-            result = PowerModels.run_opf(data, ACPPowerModel, ipopt_solver)
+            result = PowerModels.solve_opf(data, ACPPowerModel, ipopt_solver)
 
             @test result["termination_status"] == LOCALLY_SOLVED
             @test isapprox(result["objective"], 5820.1; atol = 1e0)
@@ -887,7 +887,7 @@ end
         @testset "3-bus case with optimal phase shifting / tap changing" begin
             file = "../test/data/matpower/case3_oltc_pst.m"
             data = PowerModels.parse_file(file)
-            result = PowerModels._run_opf_oltc_pst(data, ACPPowerModel, ipopt_solver)
+            result = PowerModels._solve_opf_oltc_pst(data, ACPPowerModel, ipopt_solver)
 
             @test result["termination_status"] == LOCALLY_SOLVED
             @test isapprox(result["objective"], 5738.6; atol = 1e0)
@@ -913,7 +913,7 @@ end
                 branch["tm_min"] = branch["tap"]
                 branch["tm_max"] = branch["tap"]
             end
-            result = PowerModels._run_opf_oltc_pst(data, ACPPowerModel, ipopt_solver)
+            result = PowerModels._solve_opf_oltc_pst(data, ACPPowerModel, ipopt_solver)
 
             @test result["termination_status"] == LOCALLY_SOLVED
             @test isapprox(result["objective"], 5820.1; atol = 1e0)

--- a/test/opf.jl
+++ b/test/opf.jl
@@ -2,43 +2,43 @@
 
 @testset "test ac polar opf" begin
     @testset "3-bus case" begin
-        result = run_ac_opf("../test/data/matpower/case3.m", ipopt_solver)
+        result = solve_ac_opf("../test/data/matpower/case3.m", ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 5907; atol = 1e0)
     end
     @testset "5-bus tranformer swap case" begin
-        result = run_ac_opf("../test/data/matpower/case5.m", ipopt_solver)
+        result = solve_ac_opf("../test/data/matpower/case5.m", ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 18269; atol = 1e0)
     end
     @testset "5-bus asymmetric case" begin
-        result = run_ac_opf("../test/data/matpower/case5_asym.m", ipopt_solver)
+        result = solve_ac_opf("../test/data/matpower/case5_asym.m", ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 17551; atol = 1e0)
     end
     @testset "5-bus gap case" begin
-        result = run_ac_opf("../test/data/matpower/case5_gap.m", ipopt_solver)
+        result = solve_ac_opf("../test/data/matpower/case5_gap.m", ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], -27497.7; atol = 1e0)
     end
     @testset "5-bus with dcline costs" begin
-        result = run_ac_opf("../test/data/matpower/case5_dc.m", ipopt_solver)
+        result = solve_ac_opf("../test/data/matpower/case5_dc.m", ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 18156.2; atol = 1e0)
     end
     @testset "5-bus with asymmetric line charge" begin
-        result = run_ac_opf("../test/data/pti/case5_alc.raw", ipopt_solver)
+        result = solve_ac_opf("../test/data/pti/case5_alc.raw", ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 1005.31; atol = 1e0)
     end
     @testset "5-bus with negative generators" begin
-        result = run_ac_opf("../test/data/matpower/case5_npg.m", ipopt_solver)
+        result = solve_ac_opf("../test/data/matpower/case5_npg.m", ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 8190.09; atol = 1e0)
@@ -46,31 +46,31 @@
     @testset "5-bus with only current limit data" begin
         data = PowerModels.parse_file("../test/data/matpower/case5_clm.m")
         calc_thermal_limits!(data)
-        result = run_ac_opf(data, ipopt_solver)
+        result = solve_ac_opf(data, ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 16513.6; atol = 1e0)
     end
     @testset "5-bus with pwl costs" begin
-        result = run_ac_opf("../test/data/matpower/case5_pwlc.m", ipopt_solver)
+        result = solve_ac_opf("../test/data/matpower/case5_pwlc.m", ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 42895; atol = 1e0)
     end
     @testset "5-bus with gen lb" begin
-        result = run_ac_opf("../test/data/matpower/case5_uc.m", ipopt_solver)
+        result = solve_ac_opf("../test/data/matpower/case5_uc.m", ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 18742.2; atol = 1e0)
     end
     @testset "5-bus with dangling bus" begin
-        result = run_ac_opf("../test/data/matpower/case5_db.m", ipopt_solver)
+        result = solve_ac_opf("../test/data/matpower/case5_db.m", ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 16739.1; atol = 1e0)
     end
     @testset "6-bus case" begin
-        result = run_ac_opf("../test/data/matpower/case6.m", ipopt_solver)
+        result = solve_ac_opf("../test/data/matpower/case6.m", ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 11625.3; atol = 1e0)
@@ -78,7 +78,7 @@
         @test isapprox(result["solution"]["bus"]["4"]["va"], 0.0; atol = 1e-4)
     end
     @testset "24-bus rts case" begin
-        result = run_opf("../test/data/matpower/case24.m", ACPPowerModel, ipopt_solver)
+        result = solve_opf("../test/data/matpower/case24.m", ACPPowerModel, ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 79805; atol = 1e0)
@@ -94,7 +94,7 @@ end
     #=
     # numerical issue
     @testset "3-bus case" begin
-        result = run_opf("../test/data/matpower/case3.m", ACRPowerModel, ipopt_solver)
+        result = solve_opf("../test/data/matpower/case3.m", ACRPowerModel, ipopt_solver)
 
         #@test result["termination_status"] == LOCALLY_SOLVED
         #@test isapprox(result["objective"], 5812; atol = 1e0)
@@ -102,31 +102,31 @@ end
     end
     =#
     @testset "5-bus asymmetric case" begin
-        result = run_opf("../test/data/matpower/case5_asym.m", ACRPowerModel, ipopt_solver)
+        result = solve_opf("../test/data/matpower/case5_asym.m", ACRPowerModel, ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 17551; atol = 1e0)
     end
     @testset "5-bus gap case" begin
-        result = run_opf("../test/data/matpower/case5_gap.m", ACRPowerModel, ipopt_solver)
+        result = solve_opf("../test/data/matpower/case5_gap.m", ACRPowerModel, ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], -27497.7; atol = 1e0)
     end
     @testset "5-bus with asymmetric line charge" begin
-        result = run_opf("../test/data/pti/case5_alc.raw", ACRPowerModel, ipopt_solver)
+        result = solve_opf("../test/data/pti/case5_alc.raw", ACRPowerModel, ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 1005.31; atol = 1e0)
     end
     @testset "5-bus with pwl costs" begin
-        result = run_ac_opf("../test/data/matpower/case5_pwlc.m", ipopt_solver)
+        result = solve_ac_opf("../test/data/matpower/case5_pwlc.m", ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 42895; atol = 1e0)
     end
     @testset "6-bus case" begin
-        result = run_opf("../test/data/matpower/case6.m", ACRPowerModel, ipopt_solver)
+        result = solve_opf("../test/data/matpower/case6.m", ACRPowerModel, ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 11625.3; atol = 1e0)
@@ -134,7 +134,7 @@ end
         @test isapprox(result["solution"]["bus"]["4"]["vi"], 0.0; atol = 1e-4)
     end
     @testset "24-bus rts case" begin
-        result = run_opf("../test/data/matpower/case24.m", ACRPowerModel, ipopt_solver)
+        result = solve_opf("../test/data/matpower/case24.m", ACRPowerModel, ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 79805; atol = 1e0)
@@ -148,37 +148,37 @@ end
 
 @testset "test ac tan opf" begin
     @testset "3-bus case" begin
-        result = run_opf("../test/data/matpower/case3.m", ACTPowerModel, ipopt_solver)
+        result = solve_opf("../test/data/matpower/case3.m", ACTPowerModel, ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 5907; atol = 1e0)
     end
     @testset "5-bus asymmetric case" begin
-        result = run_opf("../test/data/matpower/case5_asym.m", ACTPowerModel, ipopt_solver)
+        result = solve_opf("../test/data/matpower/case5_asym.m", ACTPowerModel, ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 17551; atol = 1e0)
     end
     @testset "5-bus gap case" begin
-        result = run_opf("../test/data/matpower/case5_gap.m", ACTPowerModel, ipopt_solver)
+        result = solve_opf("../test/data/matpower/case5_gap.m", ACTPowerModel, ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], -27438.7; atol = 1e0)
     end
     @testset "5-bus with asymmetric line charge" begin
-        result = run_opf("../test/data/pti/case5_alc.raw", ACTPowerModel, ipopt_solver)
+        result = solve_opf("../test/data/pti/case5_alc.raw", ACTPowerModel, ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 1005.31; atol = 1e0)
     end
     @testset "5-bus with pwl costs" begin
-        result = run_opf("../test/data/matpower/case5_pwlc.m", ACTPowerModel, ipopt_solver)
+        result = solve_opf("../test/data/matpower/case5_pwlc.m", ACTPowerModel, ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 42895; atol = 1e0)
     end
     @testset "6-bus case" begin
-        result = run_opf("../test/data/matpower/case6.m", ACTPowerModel, ipopt_solver)
+        result = solve_opf("../test/data/matpower/case6.m", ACTPowerModel, ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 11625.3; atol = 1e0)
@@ -186,7 +186,7 @@ end
         @test isapprox(result["solution"]["bus"]["4"]["va"], 0.0; atol = 1e-4)
     end
     @testset "24-bus rts case" begin
-        result = run_opf("../test/data/matpower/case24.m", ACTPowerModel, ipopt_solver)
+        result = solve_opf("../test/data/matpower/case24.m", ACTPowerModel, ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 79804; atol = 1e0)
@@ -200,38 +200,38 @@ end
 
 @testset "test iv opf" begin
     @testset "3-bus case" begin
-        result = run_opf_iv("../test/data/matpower/case3.m", IVRPowerModel, ipopt_solver)
+        result = solve_opf_iv("../test/data/matpower/case3.m", IVRPowerModel, ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 5907; atol = 1e0)
     end
     @testset "5-bus asymmetric case" begin
-        result = run_opf_iv("../test/data/matpower/case5_asym.m", IVRPowerModel, ipopt_solver)
+        result = solve_opf_iv("../test/data/matpower/case5_asym.m", IVRPowerModel, ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 17551; atol = 1e0)
     end
     @testset "5-bus gap case" begin
-        result = run_opf_iv("../test/data/matpower/case5_gap.m", IVRPowerModel, ipopt_solver)
+        result = solve_opf_iv("../test/data/matpower/case5_gap.m", IVRPowerModel, ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], -27497.7; atol = 1e2) #numerically challenging , returns 27438.7
     end
     @testset "5-bus with asymmetric line charge" begin
-        result = run_opf_iv("../test/data/pti/case5_alc.raw", IVRPowerModel, ipopt_solver)
+        result = solve_opf_iv("../test/data/pti/case5_alc.raw", IVRPowerModel, ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 1005.31; atol = 1e0)
     end
 
     @testset "5-bus with pwl costs" begin
-        result = run_opf_iv("../test/data/matpower/case5_pwlc.m", IVRPowerModel, ipopt_solver)
+        result = solve_opf_iv("../test/data/matpower/case5_pwlc.m", IVRPowerModel, ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 42895; atol = 1e0)
     end
     @testset "6-bus case" begin
-        result = run_opf_iv("../test/data/matpower/case6.m", IVRPowerModel, ipopt_solver)
+        result = solve_opf_iv("../test/data/matpower/case6.m", IVRPowerModel, ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 11625.3; atol = 1e0)
@@ -239,7 +239,7 @@ end
         @test isapprox(result["solution"]["bus"]["4"]["vi"], 0.0; atol = 1e-4)
     end
     @testset "24-bus rts case" begin
-        result = run_opf_iv("../test/data/matpower/case24.m", IVRPowerModel, ipopt_solver)
+        result = solve_opf_iv("../test/data/matpower/case24.m", IVRPowerModel, ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 79804; atol = 1e0)
@@ -254,55 +254,55 @@ end
 
 @testset "test dc opf" begin
     @testset "3-bus case" begin
-        result = run_dc_opf("../test/data/matpower/case3.m", ipopt_solver)
+        result = solve_dc_opf("../test/data/matpower/case3.m", ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 5782; atol = 1e0)
     end
     @testset "5-bus case, LP solver" begin
-        result = run_dc_opf("../test/data/matpower/case5.m", cbc_solver)
+        result = solve_dc_opf("../test/data/matpower/case5.m", cbc_solver)
 
         @test result["termination_status"] == OPTIMAL
         @test isapprox(result["objective"], 17613; atol = 1e0)
     end
     @testset "5-bus asymmetric case" begin
-        result = run_dc_opf("../test/data/matpower/case5_asym.m", ipopt_solver)
+        result = solve_dc_opf("../test/data/matpower/case5_asym.m", ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 17479; atol = 1e0)
     end
     @testset "5-bus gap case" begin
-        result = run_dc_opf("../test/data/matpower/case5_gap.m", ipopt_solver)
+        result = solve_dc_opf("../test/data/matpower/case5_gap.m", ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], -27410.0; atol = 1e0)
     end
     @testset "5-bus with asymmetric line charge" begin
-        result = run_dc_opf("../test/data/pti/case5_alc.raw", ipopt_solver)
+        result = solve_dc_opf("../test/data/pti/case5_alc.raw", ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 1000.0; atol = 1e0)
     end
     @testset "5-bus with pwl costs" begin
-        result = run_dc_opf("../test/data/matpower/case5_pwlc.m", ipopt_solver)
+        result = solve_dc_opf("../test/data/matpower/case5_pwlc.m", ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 42565; atol = 1e0)
     end
     @testset "5-bus with gen lb" begin
-        result = run_dc_opf("../test/data/matpower/case5_uc.m", ipopt_solver)
+        result = solve_dc_opf("../test/data/matpower/case5_uc.m", ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 18064.5; atol = 1e0)
     end
     @testset "5-bus with dangling bus" begin
-        result = run_dc_opf("../test/data/matpower/case5_db.m", ipopt_solver)
+        result = solve_dc_opf("../test/data/matpower/case5_db.m", ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 16710.0; atol = 1e0)
     end
     @testset "6-bus case" begin
-        result = run_dc_opf("../test/data/matpower/case6.m", ipopt_solver)
+        result = solve_dc_opf("../test/data/matpower/case6.m", ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 11391.8; atol = 1e0)
@@ -311,7 +311,7 @@ end
     end
     # TODO verify this is really infeasible
     #@testset "24-bus rts case" begin
-    #    result = run_opf("../test/data/matpower/case24.m", DCPPowerModel, ipopt_solver)
+    #    result = solve_opf("../test/data/matpower/case24.m", DCPPowerModel, ipopt_solver)
 
     #    @test result["termination_status"] == LOCALLY_SOLVED
     #    @test isapprox(result["objective"], 79804; atol = 1e0)
@@ -325,7 +325,7 @@ end
 
 @testset "test matpower dc opf" begin
     @testset "5-bus case with matpower DCMP model" begin
-        result = run_opf("../test/data/matpower/case5.m", DCMPPowerModel, ipopt_solver)
+        result = solve_opf("../test/data/matpower/case5.m", DCMPPowerModel, ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
 
@@ -340,43 +340,43 @@ end
 
 @testset "test nfa opf" begin
     @testset "3-bus case" begin
-        result = run_opf("../test/data/matpower/case3.m", NFAPowerModel, ipopt_solver)
+        result = solve_opf("../test/data/matpower/case3.m", NFAPowerModel, ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 5638.97; atol = 1e0)
     end
     @testset "5-bus asymmetric case" begin
-        result = run_opf("../test/data/matpower/case5_asym.m", NFAPowerModel, ipopt_solver)
+        result = solve_opf("../test/data/matpower/case5_asym.m", NFAPowerModel, ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 14810.0; atol = 1e0)
     end
     @testset "5-bus gap case" begin
-        result = run_opf("../test/data/matpower/case5_gap.m", NFAPowerModel, ipopt_solver)
+        result = solve_opf("../test/data/matpower/case5_gap.m", NFAPowerModel, ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], -27410.0; atol = 1e0)
     end
     @testset "5-bus with asymmetric line charge" begin
-        result = run_opf("../test/data/pti/case5_alc.raw", NFAPowerModel, ipopt_solver)
+        result = solve_opf("../test/data/pti/case5_alc.raw", NFAPowerModel, ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 1000.0; atol = 1e0)
     end
     @testset "5-bus with pwl costs" begin
-        result = run_opf("../test/data/matpower/case5_pwlc.m", NFAPowerModel, ipopt_solver)
+        result = solve_opf("../test/data/matpower/case5_pwlc.m", NFAPowerModel, ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 42565.8; atol = 1e0)
     end
     @testset "6-bus case" begin
-        result = run_opf("../test/data/matpower/case6.m", NFAPowerModel, ipopt_solver)
+        result = solve_opf("../test/data/matpower/case6.m", NFAPowerModel, ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 11277.9; atol = 1e0)
     end
     @testset "24-bus rts case" begin
-        result = run_opf("../test/data/matpower/case24.m", NFAPowerModel, ipopt_solver)
+        result = solve_opf("../test/data/matpower/case24.m", NFAPowerModel, ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 61001.2; atol = 1e0)
@@ -389,37 +389,37 @@ end
 
 @testset "test dc+ll opf" begin
     @testset "3-bus case" begin
-        result = run_opf("../test/data/matpower/case3.m", DCPLLPowerModel, ipopt_solver)
+        result = solve_opf("../test/data/matpower/case3.m", DCPLLPowerModel, ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 5885; atol = 1e0)
     end
     @testset "5-bus asymmetric case" begin
-        result = run_opf("../test/data/matpower/case5_asym.m", DCPLLPowerModel, ipopt_solver)
+        result = solve_opf("../test/data/matpower/case5_asym.m", DCPLLPowerModel, ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 17693; atol = 1e0)
     end
     @testset "5-bus gap case" begin
-        result = run_opf("../test/data/matpower/case5_gap.m", DCPLLPowerModel, ipopt_solver)
+        result = solve_opf("../test/data/matpower/case5_gap.m", DCPLLPowerModel, ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], -32710.0; atol = 1e0)
     end
     @testset "5-bus with asymmetric line charge" begin
-        result = run_opf("../test/data/pti/case5_alc.raw", DCPLLPowerModel, ipopt_solver)
+        result = solve_opf("../test/data/pti/case5_alc.raw", DCPLLPowerModel, ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 1001.17; atol = 1e0)
     end
     @testset "5-bus with pwl costs" begin
-        result = run_opf("../test/data/matpower/case5_pwlc.m", DCPLLPowerModel, ipopt_solver)
+        result = solve_opf("../test/data/matpower/case5_pwlc.m", DCPLLPowerModel, ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 42937; atol = 1e0)
     end
     @testset "6-bus case" begin
-        result = run_opf("../test/data/matpower/case6.m", DCPLLPowerModel, ipopt_solver)
+        result = solve_opf("../test/data/matpower/case6.m", DCPLLPowerModel, ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 11574.3; atol = 1e0)
@@ -427,7 +427,7 @@ end
         @test isapprox(result["solution"]["bus"]["4"]["va"], 0.0; atol = 1e-4)
     end
     @testset "24-bus rts case" begin
-        result = run_opf("../test/data/matpower/case24.m", DCPLLPowerModel, ipopt_solver)
+        result = solve_opf("../test/data/matpower/case24.m", DCPLLPowerModel, ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 82240; atol = 1e0)
@@ -441,43 +441,43 @@ end
 
 @testset "test lpac-c opf" begin
     @testset "3-bus case" begin
-        result = run_opf("../test/data/matpower/case3.m", LPACCPowerModel, ipopt_solver)
+        result = solve_opf("../test/data/matpower/case3.m", LPACCPowerModel, ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 5908.98; atol = 1e0)
     end
     @testset "5-bus tranformer swap case" begin
-        result = run_opf("../test/data/matpower/case5.m", LPACCPowerModel, ipopt_solver)
+        result = solve_opf("../test/data/matpower/case5.m", LPACCPowerModel, ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 18288.1; atol = 1e0)
     end
     @testset "5-bus asymmetric case" begin
-        result = run_opf("../test/data/matpower/case5_asym.m", LPACCPowerModel, ipopt_solver)
+        result = solve_opf("../test/data/matpower/case5_asym.m", LPACCPowerModel, ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 17645.6; atol = 1e0)
     end
     @testset "5-bus gap case" begin
-        result = run_opf("../test/data/matpower/case5_gap.m", LPACCPowerModel, ipopt_solver)
+        result = solve_opf("../test/data/matpower/case5_gap.m", LPACCPowerModel, ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], -27554.5; atol = 1e0)
     end
     @testset "5-bus with dcline costs" begin
-        result = run_opf("../test/data/matpower/case5_dc.m", LPACCPowerModel, ipopt_solver)
+        result = solve_opf("../test/data/matpower/case5_dc.m", LPACCPowerModel, ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 18253.0; atol = 1e0)
     end
     @testset "5-bus with asymmetric line charge" begin
-        result = run_opf("../test/data/pti/case5_alc.raw", LPACCPowerModel, ipopt_solver)
+        result = solve_opf("../test/data/pti/case5_alc.raw", LPACCPowerModel, ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 1004.58; atol = 1e0)
     end
     @testset "5-bus with negative generators" begin
-        result = run_opf("../test/data/matpower/case5_npg.m", LPACCPowerModel, ipopt_solver)
+        result = solve_opf("../test/data/matpower/case5_npg.m", LPACCPowerModel, ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 8082.54; atol = 1e0)
@@ -485,19 +485,19 @@ end
     @testset "5-bus with only current limit data" begin
         data = PowerModels.parse_file("../test/data/matpower/case5_clm.m")
         calc_thermal_limits!(data)
-        result = run_opf(data, LPACCPowerModel, ipopt_solver)
+        result = solve_opf(data, LPACCPowerModel, ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 16559.3; atol = 1e0)
     end
     @testset "5-bus with pwl costs" begin
-        result = run_opf("../test/data/matpower/case5_pwlc.m", LPACCPowerModel, ipopt_solver)
+        result = solve_opf("../test/data/matpower/case5_pwlc.m", LPACCPowerModel, ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 42853.4; atol = 1e0)
     end
     @testset "6-bus case" begin
-        result = run_opf("../test/data/matpower/case6.m", LPACCPowerModel, ipopt_solver)
+        result = solve_opf("../test/data/matpower/case6.m", LPACCPowerModel, ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 11615.1; atol = 1e0)
@@ -506,7 +506,7 @@ end
     end
     # TODO uderstand why this is infeasible
     #@testset "24-bus rts case" begin
-    #    result = run_opf("../test/data/matpower/case24.m", LPACCPowerModel, ipopt_solver)
+    #    result = solve_opf("../test/data/matpower/case24.m", LPACCPowerModel, ipopt_solver)
 
     #    @test result["termination_status"] == LOCALLY_SOLVED
     #    @test isapprox(result["objective"], 79805; atol = 1e0)
@@ -520,61 +520,61 @@ end
 
 @testset "test soc (BIM) opf" begin
     @testset "3-bus case" begin
-        result = run_opf("../test/data/matpower/case3.m", SOCWRPowerModel, ipopt_solver)
+        result = solve_opf("../test/data/matpower/case3.m", SOCWRPowerModel, ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 5746.7; atol = 1e0)
     end
     @testset "5-bus transformer swap case" begin
-        result = run_opf("../test/data/matpower/case5.m", SOCWRPowerModel, ipopt_solver)
+        result = solve_opf("../test/data/matpower/case5.m", SOCWRPowerModel, ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 15051; atol = 1e0)
     end
     @testset "5-bus asymmetric case" begin
-        result = run_opf("../test/data/matpower/case5_asym.m", SOCWRPowerModel, ipopt_solver)
+        result = solve_opf("../test/data/matpower/case5_asym.m", SOCWRPowerModel, ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 14999; atol = 1e0)
     end
     @testset "5-bus gap case" begin
-        result = run_opf("../test/data/matpower/case5_gap.m", SOCWRPowerModel, ipopt_solver)
+        result = solve_opf("../test/data/matpower/case5_gap.m", SOCWRPowerModel, ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], -28237.3; atol = 1e0)
     end
     @testset "5-bus with asymmetric line charge" begin
-        result = run_opf("../test/data/pti/case5_alc.raw", SOCWRPowerModel, ipopt_solver)
+        result = solve_opf("../test/data/pti/case5_alc.raw", SOCWRPowerModel, ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 1005.27; atol = 1e0)
     end
     @testset "5-bus with negative generators" begin
-        result = run_opf("../test/data/matpower/case5_npg.m", SOCWRPowerModel, ipopt_solver)
+        result = solve_opf("../test/data/matpower/case5_npg.m", SOCWRPowerModel, ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 3603.91; atol = 1e0)
     end
     @testset "5-bus with pwl costs" begin
-        result = run_opf("../test/data/matpower/case5_pwlc.m", SOCWRPowerModel, ipopt_solver)
+        result = solve_opf("../test/data/matpower/case5_pwlc.m", SOCWRPowerModel, ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 42895; atol = 1e0)
     end
     @testset "5-bus with dangling bus" begin
-        result = run_opf("../test/data/matpower/case5_db.m", SOCWRPowerModel, ipopt_solver)
+        result = solve_opf("../test/data/matpower/case5_db.m", SOCWRPowerModel, ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 16739.1; atol = 1e0)
     end
     @testset "6-bus case" begin
-        result = run_opf("../test/data/matpower/case6.m", SOCWRPowerModel, ipopt_solver)
+        result = solve_opf("../test/data/matpower/case6.m", SOCWRPowerModel, ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 11472.3; atol = 1e0)
     end
     @testset "24-bus rts case" begin
-        result = run_opf("../test/data/matpower/case24.m", SOCWRPowerModel, ipopt_solver)
+        result = solve_opf("../test/data/matpower/case24.m", SOCWRPowerModel, ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 70690.7; atol = 1e0)
@@ -587,60 +587,60 @@ end
 
 @testset "test soc conic form opf" begin
     @testset "3-bus case" begin
-        result = run_opf("../test/data/matpower/case3.m", SOCWRConicPowerModel, scs_solver)
+        result = solve_opf("../test/data/matpower/case3.m", SOCWRConicPowerModel, scs_solver)
 
         @test result["termination_status"] == OPTIMAL
         @test isapprox(result["objective"], 5746.61; atol = 2e0)
     end
     @testset "5-bus transformer swap case" begin
-        result = run_opf("../test/data/matpower/case5.m", SOCWRConicPowerModel, scs_solver)
+        result = solve_opf("../test/data/matpower/case5.m", SOCWRConicPowerModel, scs_solver)
 
         @test result["termination_status"] == OPTIMAL
         @test isapprox(result["objective"], 15051.4; atol = 1e1)
     end
     # convergence issue encountered when update to, SCS.jl v0.6.3
     #@testset "5-bus asymmetric case" begin
-    #    result = run_opf("../test/data/matpower/case5_asym.m", SOCWRConicPowerModel, scs_solver)
+    #    result = solve_opf("../test/data/matpower/case5_asym.m", SOCWRConicPowerModel, scs_solver)
 
     #    @test result["termination_status"] == OPTIMAL
     #    @test isapprox(result["objective"], 14999.7; atol = 1e0)
     #end
     # convergence issue encountered when linear objective used, SCS.jl v0.4.1
     @testset "5-bus gap case" begin
-        result = run_opf("../test/data/matpower/case5_gap.m", SOCWRConicPowerModel, scs_solver)
+        result = solve_opf("../test/data/matpower/case5_gap.m", SOCWRConicPowerModel, scs_solver)
 
         @test result["termination_status"] == OPTIMAL
         @test isapprox(result["objective"], -28236.8; atol = 1e0)
     end
     @testset "5-bus with asymmetric line charge" begin
-        result = run_opf("../test/data/pti/case5_alc.raw", SOCWRConicPowerModel, scs_solver)
+        result = solve_opf("../test/data/pti/case5_alc.raw", SOCWRConicPowerModel, scs_solver)
 
         @test result["termination_status"] == OPTIMAL
         @test isapprox(result["objective"], 1005.27; atol = 1e0)
     end
     # does not converge in SCS.jl v0.4.0
     #@testset "5-bus with negative generators" begin
-    #    result = run_opf("../test/data/matpower/case5_npg.m", SOCWRConicPowerModel, scs_solver)
+    #    result = solve_opf("../test/data/matpower/case5_npg.m", SOCWRConicPowerModel, scs_solver)
 
     #    @test result["termination_status"] == OPTIMAL
     #    @test isapprox(result["objective"], 3613.72; atol = 40)
     #end
     # TODO: figure out why this test fails
     # @testset "5-bus with pwl costs" begin
-    #     result = run_opf("../test/data/matpower/case5_pwlc.m", SOCWRConicPowerModel, scs_solver)
+    #     result = solve_opf("../test/data/matpower/case5_pwlc.m", SOCWRConicPowerModel, scs_solver)
     #
     #     @test result["termination_status"] == OPTIMAL
     #     @test isapprox(result["objective"], 42895; atol = 1e0)
     # end
     # Turn off due to numerical stability
     @testset "6-bus case" begin
-        result = run_opf("../test/data/matpower/case6.m", SOCWRConicPowerModel, scs_solver)
+        result = solve_opf("../test/data/matpower/case6.m", SOCWRConicPowerModel, scs_solver)
 
         @test result["termination_status"] == OPTIMAL
         @test isapprox(result["objective"], 11472.2; atol = 3e0)
     end
     @testset "24-bus rts case" begin
-        result = run_opf("../test/data/matpower/case24.m", SOCWRConicPowerModel, scs_solver)
+        result = solve_opf("../test/data/matpower/case24.m", SOCWRConicPowerModel, scs_solver)
 
         @test result["termination_status"] == OPTIMAL
         @test isapprox(result["objective"], 70688.5; atol = 1e0)
@@ -653,49 +653,49 @@ end
 
 @testset "test soc distflow opf_bf" begin
     @testset "3-bus case" begin
-        result = run_opf_bf("../test/data/matpower/case3.m", SOCBFPowerModel, ipopt_solver)
+        result = solve_opf_bf("../test/data/matpower/case3.m", SOCBFPowerModel, ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 5746.7; atol = 1e0)
     end
     @testset "5-bus transformer swap case" begin
-        result = run_opf_bf("../test/data/matpower/case5.m", SOCBFPowerModel, ipopt_solver)
+        result = solve_opf_bf("../test/data/matpower/case5.m", SOCBFPowerModel, ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 15051; atol = 1e0)
     end
     @testset "5-bus asymmetric case" begin
-        result = run_opf_bf("../test/data/matpower/case5_asym.m", SOCBFPowerModel, ipopt_solver)
+        result = solve_opf_bf("../test/data/matpower/case5_asym.m", SOCBFPowerModel, ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 14999; atol = 1e0)
     end
     @testset "5-bus gap case" begin
-        result = run_opf_bf("../test/data/matpower/case5_gap.m", SOCBFPowerModel, ipopt_solver)
+        result = solve_opf_bf("../test/data/matpower/case5_gap.m", SOCBFPowerModel, ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], -27659.8; atol = 1e0)
     end
     @testset "5-bus with asymmetric line charge" begin
-        result = run_opf_bf("../test/data/pti/case5_alc.raw", SOCBFPowerModel, ipopt_solver)
+        result = solve_opf_bf("../test/data/pti/case5_alc.raw", SOCBFPowerModel, ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 1005.27; atol = 1e0)
     end
     @testset "5-bus with pwl costs" begin
-        result = run_opf_bf("../test/data/matpower/case5_pwlc.m", SOCBFPowerModel, ipopt_solver)
+        result = solve_opf_bf("../test/data/matpower/case5_pwlc.m", SOCBFPowerModel, ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 42895; atol = 1e0)
     end
     @testset "6-bus case" begin
-        result = run_opf_bf("../test/data/matpower/case6.m", SOCBFPowerModel, ipopt_solver)
+        result = solve_opf_bf("../test/data/matpower/case6.m", SOCBFPowerModel, ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 11472.3; atol = 1e0)
     end
     @testset "24-bus rts case" begin
-        result = run_opf_bf("../test/data/matpower/case24.m", SOCBFPowerModel, ipopt_solver)
+        result = solve_opf_bf("../test/data/matpower/case24.m", SOCBFPowerModel, ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 70690.7; atol = 1e0)
@@ -703,7 +703,7 @@ end
     @testset "3-bus case w/ r,x=0 on branch" begin
         mp_data = PowerModels.parse_file("../test/data/matpower/case3.m")
         mp_data["branch"]["1"]["br_r"] = mp_data["branch"]["1"]["br_x"] = 0.0
-        result = run_opf_bf(mp_data, SOCBFPowerModel, ipopt_solver)
+        result = solve_opf_bf(mp_data, SOCBFPowerModel, ipopt_solver)
         @test result["termination_status"] == LOCALLY_SOLVED
     end
     @testset "14-bus variable bounds" begin
@@ -714,25 +714,25 @@ end
 
 @testset "test soc conic distflow opf_bf" begin
     @testset "3-bus case" begin
-        result = run_opf_bf("../test/data/matpower/case3.m", SOCBFConicPowerModel, scs_solver)
+        result = solve_opf_bf("../test/data/matpower/case3.m", SOCBFConicPowerModel, scs_solver)
 
         @test result["termination_status"] == OPTIMAL
         @test isapprox(result["objective"], 5746.7; atol = 5e1)
     end
     @testset "5-bus transformer swap case" begin
-        result = run_opf_bf("../test/data/matpower/case5.m", SOCBFConicPowerModel, scs_solver)
+        result = solve_opf_bf("../test/data/matpower/case5.m", SOCBFConicPowerModel, scs_solver)
 
         @test result["termination_status"] == OPTIMAL
         @test isapprox(result["objective"], 15051; atol = 1e1)
     end
     @testset "5-bus asymmetric case" begin
-        result = run_opf_bf("../test/data/matpower/case5_asym.m", SOCBFConicPowerModel, scs_solver)
+        result = solve_opf_bf("../test/data/matpower/case5_asym.m", SOCBFConicPowerModel, scs_solver)
 
         @test result["termination_status"] == OPTIMAL
         @test isapprox(result["objective"], 14999; atol = 1e1)
     end
     @testset "5-bus with negative generators" begin
-        result = run_opf_bf("../test/data/matpower/case5_npg.m", SOCBFConicPowerModel, scs_solver)
+        result = solve_opf_bf("../test/data/matpower/case5_npg.m", SOCBFConicPowerModel, scs_solver)
 
         @test result["termination_status"] == OPTIMAL
         @test isapprox(result["objective"], 3593.0; atol = 1e1)
@@ -745,14 +745,14 @@ end
 
 @testset "test linear distflow opf_bf" begin
     @testset "3-bus case" begin
-        result = run_opf_bf("../test/data/matpower/case3.m", BFAPowerModel, ipopt_solver)
+        result = solve_opf_bf("../test/data/matpower/case3.m", BFAPowerModel, ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 5658.22; atol = 1e0)
     end
     @testset "5-bus transformer swap case" begin
         data = PowerModels.parse_file("../test/data/matpower/case5.m")
-        result = run_opf_bf(data, BFAPowerModel, ipopt_solver)
+        result = solve_opf_bf(data, BFAPowerModel, ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 14810; atol = 1e0)
@@ -761,37 +761,37 @@ end
             atol = 1e-3)
     end
     @testset "5-bus asymmetric case" begin
-        result = run_opf_bf("../test/data/matpower/case5_asym.m", BFAPowerModel, ipopt_solver)
+        result = solve_opf_bf("../test/data/matpower/case5_asym.m", BFAPowerModel, ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 14810; atol = 1e0)
     end
     @testset "5-bus gap case" begin
-        result = run_opf_bf("../test/data/matpower/case5_gap.m", BFAPowerModel, ipopt_solver)
+        result = solve_opf_bf("../test/data/matpower/case5_gap.m", BFAPowerModel, ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], -27410.0; atol = 1e0)
     end
     @testset "5-bus with asymmetric line charge" begin
-        result = run_opf_bf("../test/data/pti/case5_alc.raw", BFAPowerModel, ipopt_solver)
+        result = solve_opf_bf("../test/data/pti/case5_alc.raw", BFAPowerModel, ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 1002.46; atol = 1e0)
     end
     @testset "5-bus with pwl costs" begin
-        result = run_opf_bf("../test/data/matpower/case5_pwlc.m", BFAPowerModel, ipopt_solver)
+        result = solve_opf_bf("../test/data/matpower/case5_pwlc.m", BFAPowerModel, ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 42565.8; atol = 1e0)
     end
     @testset "6-bus case" begin
-        result = run_opf_bf("../test/data/matpower/case6.m", BFAPowerModel, ipopt_solver)
+        result = solve_opf_bf("../test/data/matpower/case6.m", BFAPowerModel, ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 11277.9; atol = 1e0)
     end
     # @testset "24-bus rts case" begin
-    #     result = run_opf_bf("../test/data/matpower/case24.m", BFAPowerModel, ipopt_solver)
+    #     result = solve_opf_bf("../test/data/matpower/case24.m", BFAPowerModel, ipopt_solver)
     #
     #     @test result["termination_status"] == LOCALLY_SOLVED
     #     @test isapprox(result["objective"], 70690.7; atol = 1e0)
@@ -799,7 +799,7 @@ end
     @testset "3-bus case w/ r,x=0 on branch" begin
         mp_data = PowerModels.parse_file("../test/data/matpower/case3.m")
         mp_data["branch"]["1"]["br_r"] = mp_data["branch"]["1"]["br_x"] = 0.0
-        result = run_opf_bf(mp_data, BFAPowerModel, ipopt_solver)
+        result = solve_opf_bf(mp_data, BFAPowerModel, ipopt_solver)
         @test result["termination_status"] == LOCALLY_SOLVED
     end
     @testset "14-bus variable bounds" begin
@@ -810,37 +810,37 @@ end
 
 @testset "test qc opf" begin
     @testset "3-bus case" begin
-        result = run_opf("../test/data/matpower/case3.m", QCRMPowerModel, ipopt_solver)
+        result = solve_opf("../test/data/matpower/case3.m", QCRMPowerModel, ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 5780; atol = 1e0)
     end
     @testset "5-bus asymmetric case" begin
-        result = run_opf("../test/data/matpower/case5_asym.m", QCRMPowerModel, ipopt_solver)
+        result = solve_opf("../test/data/matpower/case5_asym.m", QCRMPowerModel, ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 15921; atol = 1e0)
     end
     @testset "5-bus gap case" begin
-        result = run_opf("../test/data/matpower/case5_gap.m", QCRMPowerModel, ipopt_solver)
+        result = solve_opf("../test/data/matpower/case5_gap.m", QCRMPowerModel, ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], -27659.8; atol = 1e0)
     end
     @testset "5-bus with asymmetric line charge" begin
-        result = run_opf("../test/data/pti/case5_alc.raw", QCRMPowerModel, ipopt_solver)
+        result = solve_opf("../test/data/pti/case5_alc.raw", QCRMPowerModel, ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 1005.27; atol = 1e0)
     end
     @testset "5-bus with pwl costs" begin
-        result = run_opf("../test/data/matpower/case5_pwlc.m", QCRMPowerModel, ipopt_solver)
+        result = solve_opf("../test/data/matpower/case5_pwlc.m", QCRMPowerModel, ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 42895; atol = 1e0)
     end
     @testset "6-bus case" begin
-        result = run_opf("../test/data/matpower/case6.m", QCRMPowerModel, ipopt_solver)
+        result = solve_opf("../test/data/matpower/case6.m", QCRMPowerModel, ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 11484.2; atol = 1e0)
@@ -848,7 +848,7 @@ end
         @test isapprox(result["solution"]["bus"]["4"]["va"], 0.0; atol = 1e-4)
     end
     @testset "24-bus rts case" begin
-        result = run_opf("../test/data/matpower/case24.m", QCRMPowerModel, ipopt_solver)
+        result = solve_opf("../test/data/matpower/case24.m", QCRMPowerModel, ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 76599.9; atol = 1e0)
@@ -861,25 +861,25 @@ end
 
 @testset "test qc opf with trilinear convexhull relaxation" begin
     @testset "3-bus case" begin
-        result = run_opf("../test/data/matpower/case3.m", QCLSPowerModel, ipopt_solver)
+        result = solve_opf("../test/data/matpower/case3.m", QCLSPowerModel, ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 5817.91; atol = 1e0)
     end
     @testset "5-bus asymmetric case" begin
-        result = run_opf("../test/data/matpower/case5_asym.m", QCLSPowerModel, ipopt_solver)
+        result = solve_opf("../test/data/matpower/case5_asym.m", QCLSPowerModel, ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 15929.2; atol = 1e0)
     end
     @testset "5-bus gap case" begin
-        result = run_opf("../test/data/matpower/case5_gap.m", QCLSPowerModel, ipopt_solver)
+        result = solve_opf("../test/data/matpower/case5_gap.m", QCLSPowerModel, ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], -27659.8; atol = 1e0)
     end
     @testset "6-bus case" begin
-        result = run_opf("../test/data/matpower/case6.m", QCLSPowerModel, ipopt_solver)
+        result = solve_opf("../test/data/matpower/case6.m", QCLSPowerModel, ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 11512.9; atol = 1e0)
@@ -887,7 +887,7 @@ end
         @test isapprox(result["solution"]["bus"]["4"]["va"], 0.0; atol = 1e-4)
     end
     @testset "24-bus rts case" begin
-        result = run_opf("../test/data/matpower/case24.m", QCLSPowerModel, ipopt_solver)
+        result = solve_opf("../test/data/matpower/case24.m", QCLSPowerModel, ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 76785.4; atol = 1e0)
@@ -901,53 +901,53 @@ end
 
 @testset "test sdp opf" begin
     @testset "3-bus case" begin
-        result = run_opf("../test/data/matpower/case3.m", SDPWRMPowerModel, scs_solver)
+        result = solve_opf("../test/data/matpower/case3.m", SDPWRMPowerModel, scs_solver)
 
         @test result["termination_status"] == OPTIMAL
         @test isapprox(result["objective"], 5851.23; atol = 1e1)
     end
     # TODO see if convergence time can be improved
     @testset "5-bus asymmetric case" begin
-        result = run_opf("../test/data/matpower/case5_asym.m", SDPWRMPowerModel, scs_solver)
+        result = solve_opf("../test/data/matpower/case5_asym.m", SDPWRMPowerModel, scs_solver)
 
         @test result["termination_status"] == OPTIMAL
         @test isapprox(result["objective"], 16662.0; atol = 1e1)
     end
     @testset "5-bus gap case" begin
-        result = run_opf("../test/data/matpower/case5_gap.m", SDPWRMPowerModel, scs_solver)
+        result = solve_opf("../test/data/matpower/case5_gap.m", SDPWRMPowerModel, scs_solver)
 
         @test result["termination_status"] == OPTIMAL
         @test isapprox(result["objective"], -28236.1; atol = 1e1)
     end
     # convergence issue encounterd when updated to SCS v0.6.3
     #@testset "5-bus with asymmetric line charge" begin
-    #    result = run_opf("../test/data/pti/case5_alc.raw", SDPWRMPowerModel, scs_solver)
+    #    result = solve_opf("../test/data/pti/case5_alc.raw", SDPWRMPowerModel, scs_solver)
 
     #    @test result["termination_status"] == OPTIMAL
     #    @test isapprox(result["objective"], 1005.31; atol = 1e-1)
     #end
     @testset "5-bus with negative generators" begin
-        result = run_opf("../test/data/matpower/case5_npg.m", SDPWRMPowerModel, scs_solver)
+        result = solve_opf("../test/data/matpower/case5_npg.m", SDPWRMPowerModel, scs_solver)
 
         @test result["termination_status"] == OPTIMAL
         @test isapprox(result["objective"], 6827.34; atol = 1e0)
     end
     # too slow for unit tests
     # @testset "14-bus case" begin
-    #     result = run_opf("../test/data/matpower/case14.m", SDPWRMPowerModel, scs_solver)
+    #     result = solve_opf("../test/data/matpower/case14.m", SDPWRMPowerModel, scs_solver)
 
     #     @test result["termination_status"] == OPTIMAL
     #     @test isapprox(result["objective"], 8081.52; atol = 1e0)
     # end
     @testset "6-bus case" begin
-        result = run_opf("../test/data/matpower/case6.m", SDPWRMPowerModel, scs_solver)
+        result = solve_opf("../test/data/matpower/case6.m", SDPWRMPowerModel, scs_solver)
 
         @test result["termination_status"] == OPTIMAL
         @test isapprox(result["objective"], 11580.8; atol = 1e1)
     end
     # TODO replace this with smaller case, way too slow for unit testing
     #@testset "24-bus rts case" begin
-    #    result = run_opf("../test/data/matpower/case24.m", SDPWRMPowerModel, scs_solver)
+    #    result = solve_opf("../test/data/matpower/case24.m", SDPWRMPowerModel, scs_solver)
 
     #    @test result["termination_status"] == OPTIMAL
     #    @test isapprox(result["objective"], 75153; atol = 1e0)
@@ -961,26 +961,26 @@ end
 
 @testset "test sdp opf with constraint decomposition" begin
     @testset "3-bus case" begin
-        result = run_opf("../test/data/matpower/case3.m", SparseSDPWRMPowerModel, scs_solver)
+        result = solve_opf("../test/data/matpower/case3.m", SparseSDPWRMPowerModel, scs_solver)
 
         @test result["termination_status"] == OPTIMAL
         @test isapprox(result["objective"], 5851.23; atol = 1e1)
     end
     @testset "5-bus with asymmetric line charge" begin
-        result = run_opf("../test/data/pti/case5_alc.raw", SparseSDPWRMPowerModel, scs_solver)
+        result = solve_opf("../test/data/pti/case5_alc.raw", SparseSDPWRMPowerModel, scs_solver)
 
         @test result["termination_status"] == OPTIMAL
         @test isapprox(result["objective"], 1005.31; atol = 1e0)
     end
     @testset "9-bus cholesky PosDefException" begin
-        result = run_opf("../test/data/matpower/case9.m", SparseSDPWRMPowerModel, scs_solver)
+        result = solve_opf("../test/data/matpower/case9.m", SparseSDPWRMPowerModel, scs_solver)
 
         @test result["termination_status"] == OPTIMAL
         @test isapprox(result["objective"], 347.746; atol = 1e0)
     end
     # too slow for unit tests
     # @testset "14-bus case" begin
-    #     result = run_opf("../test/data/matpower/case14.m", SparseSDPWRMPowerModel, scs_solver)
+    #     result = solve_opf("../test/data/matpower/case14.m", SparseSDPWRMPowerModel, scs_solver)
 
     #     @test result["termination_status"] == OPTIMAL
     #     @test isapprox(result["objective"], 8081.5; atol = 1e0)
@@ -989,7 +989,7 @@ end
     # multiple components are not currently supported by this form
     #=
     @testset "6-bus case" begin
-        result = run_opf("../test/data/matpower/case6.m", SparseSDPWRMPowerModel, scs_solver)
+        result = solve_opf("../test/data/matpower/case6.m", SparseSDPWRMPowerModel, scs_solver)
 
         @test result["termination_status"] == OPTIMAL
         @test isapprox(result["objective"], 11578.8; atol = 1e0)

--- a/test/ots.jl
+++ b/test/ots.jl
@@ -13,7 +13,7 @@ end
 
 @testset "test ac ots" begin
     @testset "3-bus case" begin
-        result = run_ots("../test/data/matpower/case3.m", ACPPowerModel, juniper_solver)
+        result = solve_ots("../test/data/matpower/case3.m", ACPPowerModel, juniper_solver)
 
         check_br_status(result["solution"], 3, 3)
 
@@ -24,7 +24,7 @@ end
     #=
     # remove due to linux stability issue
     @testset "5-bus case" begin
-        result = run_ots("../test/data/matpower/case5.m", ACPPowerModel, juniper_solver)
+        result = solve_ots("../test/data/matpower/case5.m", ACPPowerModel, juniper_solver)
 
         check_br_status(result["solution"], 0, 0)
 
@@ -35,7 +35,7 @@ end
     end
     =#
     @testset "5-bus with asymmetric line charge" begin
-        result = run_ots("../test/data/pti/case5_alc.raw", ACPPowerModel, juniper_solver)
+        result = solve_ots("../test/data/pti/case5_alc.raw", ACPPowerModel, juniper_solver)
 
         check_br_status(result["solution"], 4, 4)
 
@@ -44,7 +44,7 @@ end
     end
     #Omitting this test, returns local infeasible
     #@testset "6-bus case" begin
-    #    result = run_ots("../test/data/matpower/case6.m", ACPPowerModel, juniper_solver)
+    #    result = solve_ots("../test/data/matpower/case6.m", ACPPowerModel, juniper_solver)
 
     #    check_br_status(result["solution"], 0, 0)
 
@@ -57,7 +57,7 @@ end
 
 @testset "test dc ots" begin
     @testset "3-bus case" begin
-        result = run_ots("../test/data/matpower/case3.m", DCPPowerModel, juniper_solver)
+        result = solve_ots("../test/data/matpower/case3.m", DCPPowerModel, juniper_solver)
 
         check_br_status(result["solution"], 3, 3)
 
@@ -65,7 +65,7 @@ end
         @test isapprox(result["objective"], 5782.0; atol = 1e0)
     end
     @testset "5-bus case" begin
-        result = run_ots("../test/data/matpower/case5.m", DCPPowerModel, juniper_solver)
+        result = solve_ots("../test/data/matpower/case5.m", DCPPowerModel, juniper_solver)
 
         check_br_status(result["solution"], 5, 5)
 
@@ -73,7 +73,7 @@ end
         @test isapprox(result["objective"], 14991.2; atol = 1e0)
     end
     @testset "5-bus case, MIP solver" begin
-        result = run_ots("../test/data/matpower/case5.m", DCPPowerModel, cbc_solver)
+        result = solve_ots("../test/data/matpower/case5.m", DCPPowerModel, cbc_solver)
 
         check_br_status(result["solution"], 5, 5)
 
@@ -81,7 +81,7 @@ end
         @test isapprox(result["objective"], 14991.3; atol = 1e0)
     end
     @testset "6-bus case" begin
-        result = run_ots("../test/data/matpower/case6.m", DCPPowerModel, juniper_solver)
+        result = solve_ots("../test/data/matpower/case6.m", DCPPowerModel, juniper_solver)
 
         check_br_status(result["solution"], 6, 6)
 
@@ -93,7 +93,7 @@ end
 
 @testset "test dc+ll ots" begin
     @testset "3-bus case" begin
-        result = run_ots("../test/data/matpower/case3.m", DCPLLPowerModel, juniper_solver)
+        result = solve_ots("../test/data/matpower/case3.m", DCPLLPowerModel, juniper_solver)
 
         check_br_status(result["solution"], 3, 3)
 
@@ -101,7 +101,7 @@ end
         @test isapprox(result["objective"], 5885.2; atol = 1e0)
     end
     @testset "5-bus case" begin
-        result = run_ots("../test/data/matpower/case5.m", DCPLLPowerModel, juniper_solver)
+        result = solve_ots("../test/data/matpower/case5.m", DCPLLPowerModel, juniper_solver)
 
         check_br_status(result["solution"], 5, 5)
 
@@ -109,7 +109,7 @@ end
         @test isapprox(result["objective"], 15275.2; atol = 1e0)
     end
     @testset "6-bus case" begin
-        result = run_ots("../test/data/matpower/case6.m", DCPLLPowerModel, juniper_solver)
+        result = solve_ots("../test/data/matpower/case6.m", DCPLLPowerModel, juniper_solver)
 
         check_br_status(result["solution"], 6, 6)
 
@@ -121,7 +121,7 @@ end
 
 @testset "test soc ots" begin
     @testset "3-bus case" begin
-        result = run_ots("../test/data/matpower/case3.m", SOCWRPowerModel, juniper_solver)
+        result = solve_ots("../test/data/matpower/case3.m", SOCWRPowerModel, juniper_solver)
 
         check_br_status(result["solution"], 3, 3)
 
@@ -129,7 +129,7 @@ end
         @test isapprox(result["objective"], 5746.7; atol = 1e0)
     end
     @testset "5-bus case" begin
-        result = run_ots("../test/data/matpower/case5.m", SOCWRPowerModel, juniper_solver)
+        result = solve_ots("../test/data/matpower/case5.m", SOCWRPowerModel, juniper_solver)
 
         check_br_status(result["solution"], 5, 5)
 
@@ -137,7 +137,7 @@ end
         @test isapprox(result["objective"], 15051.4; atol = 5e1)
     end
     @testset "5-bus with asymmetric line charge" begin
-        result = run_ots("../test/data/pti/case5_alc.raw", SOCWRPowerModel, juniper_solver)
+        result = solve_ots("../test/data/pti/case5_alc.raw", SOCWRPowerModel, juniper_solver)
 
         check_br_status(result["solution"], 4, 4)
 
@@ -145,7 +145,7 @@ end
         @test isapprox(result["objective"], 1004.8; atol = 5e0)
     end
     @testset "6-bus case" begin
-        result = run_ots("../test/data/matpower/case6.m", SOCWRPowerModel, juniper_solver)
+        result = solve_ots("../test/data/matpower/case6.m", SOCWRPowerModel, juniper_solver)
 
         check_br_status(result["solution"], 6, 6)
 
@@ -157,7 +157,7 @@ end
 
 @testset "test qc ots" begin
     @testset "3-bus case" begin
-        result = run_ots("../test/data/matpower/case3.m", QCRMPowerModel, juniper_solver)
+        result = solve_ots("../test/data/matpower/case3.m", QCRMPowerModel, juniper_solver)
 
         check_br_status(result["solution"], 3, 3)
 
@@ -165,7 +165,7 @@ end
         @test isapprox(result["objective"], 5746.7; atol = 1e0)
     end
     @testset "5-bus case" begin
-        result = run_ots("../test/data/matpower/case5.m", QCRMPowerModel, juniper_solver)
+        result = solve_ots("../test/data/matpower/case5.m", QCRMPowerModel, juniper_solver)
 
         check_br_status(result["solution"], 5, 5)
 
@@ -173,7 +173,7 @@ end
         @test isapprox(result["objective"], 15051.4; atol = 5e1)
     end
     @testset "5-bus asymmetric case" begin
-        result = run_ots("../test/data/matpower/case5_asym.m", QCRMPowerModel, juniper_solver)
+        result = solve_ots("../test/data/matpower/case5_asym.m", QCRMPowerModel, juniper_solver)
 
         check_br_status(result["solution"], 6, 6)
 
@@ -181,7 +181,7 @@ end
         @test isapprox(result["objective"], 14999.7; atol = 1e0)
     end
     @testset "5-bus with asymmetric line charge" begin
-        result = run_ots("../test/data/pti/case5_alc.raw", QCRMPowerModel, juniper_solver)
+        result = solve_ots("../test/data/pti/case5_alc.raw", QCRMPowerModel, juniper_solver)
 
         check_br_status(result["solution"], 4, 4)
 
@@ -189,7 +189,7 @@ end
         @test isapprox(result["objective"], 1003.97; atol = 5e0)
     end
     @testset "6-bus case" begin
-        result = run_ots("../test/data/matpower/case6.m", QCRMPowerModel, juniper_solver)
+        result = solve_ots("../test/data/matpower/case6.m", QCRMPowerModel, juniper_solver)
 
         check_br_status(result["solution"], 6, 6)
 
@@ -201,7 +201,7 @@ end
 
 @testset "test lpac ots" begin
     @testset "3-bus case" begin
-        result = run_ots("../test/data/matpower/case3.m", LPACCPowerModel, juniper_solver)
+        result = solve_ots("../test/data/matpower/case3.m", LPACCPowerModel, juniper_solver)
 
         check_br_status(result["solution"], 3, 3)
 
@@ -209,7 +209,7 @@ end
         @test isapprox(result["objective"], 5908.98; atol = 1e0)
     end
     @testset "5-bus case" begin
-        result = run_ots("../test/data/matpower/case5.m", LPACCPowerModel, juniper_solver)
+        result = solve_ots("../test/data/matpower/case5.m", LPACCPowerModel, juniper_solver)
 
         check_br_status(result["solution"], 5, 5)
 
@@ -217,7 +217,7 @@ end
         @test isapprox(result["objective"], 15241.4; atol = 5e1)
     end
     @testset "5-bus asymmetric case" begin
-        result = run_ots("../test/data/matpower/case5_asym.m", LPACCPowerModel, juniper_solver)
+        result = solve_ots("../test/data/matpower/case5_asym.m", LPACCPowerModel, juniper_solver)
 
         check_br_status(result["solution"], 5, 5)
 
@@ -225,7 +225,7 @@ end
         @test isapprox(result["objective"], 15246.9; atol = 1e0)
     end
     @testset "5-bus with asymmetric line charge" begin
-        result = run_ots("../test/data/pti/case5_alc.raw", LPACCPowerModel, juniper_solver)
+        result = solve_ots("../test/data/pti/case5_alc.raw", LPACCPowerModel, juniper_solver)
 
         check_br_status(result["solution"], 4, 4)
 
@@ -233,7 +233,7 @@ end
         @test isapprox(result["objective"], 998.4; atol = 5e0)
     end
     @testset "6-bus case" begin
-        result = run_ots("../test/data/matpower/case6.m", LPACCPowerModel, juniper_solver)
+        result = solve_ots("../test/data/matpower/case6.m", LPACCPowerModel, juniper_solver)
 
         check_br_status(result["solution"], 6, 6)
 

--- a/test/output.jl
+++ b/test/output.jl
@@ -1,7 +1,7 @@
 
 @testset "test output api" begin
     @testset "24-bus rts case" begin
-        result = run_opf("../test/data/matpower/case24.m", ACPPowerModel, ipopt_solver)
+        result = solve_opf("../test/data/matpower/case24.m", ACPPowerModel, ipopt_solver)
 
         @test haskey(result, "optimizer") == true
         @test haskey(result, "termination_status") == true
@@ -29,7 +29,7 @@
                 gen["cost"] = gen["cost"][length(gen["cost"])-1:end]
             end
         end
-        result = run_opf(data, DCPPowerModel, cbc_solver)
+        result = solve_opf(data, DCPPowerModel, cbc_solver)
 
         @test haskey(result, "optimizer")
         @test haskey(result, "termination_status")
@@ -44,7 +44,7 @@ end
 
 @testset "test branch flow output" begin
     @testset "24-bus rts case ac opf" begin
-        result = run_opf("../test/data/matpower/case24.m", ACPPowerModel, ipopt_solver)
+        result = solve_opf("../test/data/matpower/case24.m", ACPPowerModel, ipopt_solver)
 
         @test haskey(result, "optimizer") == true
         @test haskey(result, "termination_status") == true
@@ -70,7 +70,7 @@ end
 
     # A DCPPowerModel test is important because it does have variables for the reverse side of the branchs
     @testset "3-bus case dc opf" begin
-        result = run_opf("../test/data/matpower/case3.m", DCPPowerModel, ipopt_solver)
+        result = solve_opf("../test/data/matpower/case3.m", DCPPowerModel, ipopt_solver)
 
         @test haskey(result, "solution") == true
         @test haskey(result["solution"], "branch") == true
@@ -89,7 +89,7 @@ end
     end
 
     @testset "24-bus rts case ac pf" begin
-        result = run_pf("../test/data/matpower/case24.m", ACPPowerModel, ipopt_solver)
+        result = solve_pf("../test/data/matpower/case24.m", ACPPowerModel, ipopt_solver)
 
         @test haskey(result, "optimizer") == true
         @test haskey(result, "termination_status") == true
@@ -115,7 +115,7 @@ end
 
     # A DCPPowerModel test is important because it does have variables for the reverse side of the branchs
     @testset "3-bus case dc pf" begin
-        result = run_pf("../test/data/matpower/case3.m", DCPPowerModel, ipopt_solver)
+        result = solve_pf("../test/data/matpower/case3.m", DCPPowerModel, ipopt_solver)
 
         @test haskey(result, "solution") == true
         @test haskey(result["solution"], "branch") == false
@@ -138,7 +138,7 @@ end
     settings = Dict("output" => Dict("duals" => true))
     data = PowerModels.parse_file("../test/data/matpower/case14.m")
     calc_thermal_limits!(data)
-    result = run_dc_opf(data, ipopt_solver, setting = settings)
+    result = solve_dc_opf(data, ipopt_solver, setting = settings)
 
     PowerModels.make_mixed_units!(result["solution"])
     @testset "14 bus - kcl duals" begin
@@ -158,7 +158,7 @@ end
     end
 
 
-    result = run_dc_opf("../test/data/matpower/case5.m", ipopt_solver, setting = settings)
+    result = solve_dc_opf("../test/data/matpower/case5.m", ipopt_solver, setting = settings)
 
     PowerModels.make_mixed_units!(result["solution"])
     @testset "5 bus - kcl duals" begin
@@ -180,7 +180,7 @@ end
     end
 
 
-    result = run_opf("../test/data/matpower/case5.m", SOCWRPowerModel, ipopt_solver, setting = settings)
+    result = solve_opf("../test/data/matpower/case5.m", SOCWRPowerModel, ipopt_solver, setting = settings)
     @testset "5 bus - kcl duals soc qp" begin
         for (i, bus) in result["solution"]["bus"]
             @test bus["lam_kcl_r"] <= -2900.00
@@ -190,7 +190,7 @@ end
         end
     end
 
-    result = run_opf("../test/data/matpower/case5.m", SOCWRConicPowerModel, scs_solver, setting = settings)
+    result = solve_opf("../test/data/matpower/case5.m", SOCWRConicPowerModel, scs_solver, setting = settings)
     @testset "5 bus - kcl duals soc conic" begin
         for (i, bus) in result["solution"]["bus"]
             @test bus["lam_kcl_r"] <= -2900.00
@@ -200,7 +200,7 @@ end
         end
     end
 
-    result = run_opf("../test/data/matpower/case5.m", ACPPowerModel, ipopt_solver, setting = settings)
+    result = solve_opf("../test/data/matpower/case5.m", ACPPowerModel, ipopt_solver, setting = settings)
     @testset "5 bus - kcl duals acp" begin
         for (i, bus) in result["solution"]["bus"]
             @test bus["lam_kcl_r"] <= -1000.00
@@ -210,7 +210,7 @@ end
         end
     end
 
-    result = run_opf("../test/data/matpower/case5.m", ACRPowerModel, ipopt_solver, setting = settings)
+    result = solve_opf("../test/data/matpower/case5.m", ACRPowerModel, ipopt_solver, setting = settings)
     @testset "5 bus - kcl duals acr" begin
         for (i, bus) in result["solution"]["bus"]
             @test bus["lam_kcl_r"] <= -1000.00
@@ -220,7 +220,7 @@ end
         end
     end
 
-    result = run_opf("../test/data/matpower/case5.m", ACTPowerModel, ipopt_solver, setting = settings)
+    result = solve_opf("../test/data/matpower/case5.m", ACTPowerModel, ipopt_solver, setting = settings)
     @testset "5 bus - kcl duals act" begin
         for (i, bus) in result["solution"]["bus"]
             @test bus["lam_kcl_r"] <= -1000.00
@@ -237,7 +237,7 @@ end
     # test case where generator status is 1 but the gen_bus status is 0
     data = parse_file("../test/data/matpower/case5.m")
     data["bus"]["4"]["bus_type"] = 4
-    result = run_ac_opf(data, ipopt_solver)
+    result = solve_ac_opf(data, ipopt_solver)
 
     @test result["termination_status"] == LOCALLY_SOLVED
     @test isapprox(result["objective"], 10128.6; atol = 1e0)
@@ -246,7 +246,7 @@ end
 
 @testset "test solution processors" begin
     @testset "sol_vr_to_vp" begin
-        result = run_opf("../test/data/matpower/case5.m", ACRPowerModel, ipopt_solver, solution_processors=[sol_data_model!])
+        result = solve_opf("../test/data/matpower/case5.m", ACRPowerModel, ipopt_solver, solution_processors=[sol_data_model!])
 
         for (i,bus) in result["solution"]["bus"]
             @test haskey(bus, "vm") && haskey(bus, "va")
@@ -254,7 +254,7 @@ end
     end
 
     @testset "sol_w_to_vm" begin
-        result = run_opf("../test/data/matpower/case5.m", SOCWRPowerModel, ipopt_solver, solution_processors=[sol_data_model!])
+        result = solve_opf("../test/data/matpower/case5.m", SOCWRPowerModel, ipopt_solver, solution_processors=[sol_data_model!])
 
         for (i,bus) in result["solution"]["bus"]
             @test haskey(bus, "vm")
@@ -263,7 +263,7 @@ end
     end
 
     @testset "sol_phi_to_vm" begin
-        result = run_opf("../test/data/matpower/case5.m", LPACCPowerModel, ipopt_solver, solution_processors=[sol_data_model!])
+        result = solve_opf("../test/data/matpower/case5.m", LPACCPowerModel, ipopt_solver, solution_processors=[sol_data_model!])
 
         for (i,bus) in result["solution"]["bus"]
             @test haskey(bus, "vm")
@@ -278,13 +278,13 @@ end
 
     function solution_feedback(case, ac_opf_obj)
         data = PowerModels.parse_file(case)
-        opf_result = run_ac_opf(data, ipopt_solver)
+        opf_result = solve_ac_opf(data, ipopt_solver)
         @test opf_result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(opf_result["objective"], ac_opf_obj; atol = 1e0)
 
         PowerModels.update_data!(data, opf_result["solution"])
 
-        pf_result = run_ac_pf(data, ipopt_solver)
+        pf_result = solve_ac_pf(data, ipopt_solver)
         @test pf_result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(pf_result["objective"], 0.0; atol = 1e-3)
 

--- a/test/pf-native.jl
+++ b/test/pf-native.jl
@@ -2,7 +2,7 @@
     # degenerate due to no slack bus
     # @testset "3-bus case" begin
     #     data = PowerModels.parse_file("../test/data/matpower/case3.m")
-    #     result = run_dc_pf(data, ipopt_solver)
+    #     result = solve_dc_pf(data, ipopt_solver)
     #     native = compute_dc_pf(data)
 
     #     for (i,bus) in data["bus"]
@@ -13,7 +13,7 @@
     # end
     @testset "5-bus case" begin
         data = PowerModels.parse_file("../test/data/matpower/case5.m")
-        result = run_dc_pf(data, ipopt_solver)
+        result = solve_dc_pf(data, ipopt_solver)
         native = compute_dc_pf(data)
 
         for (i,bus) in data["bus"]
@@ -24,7 +24,7 @@
     end
     @testset "5-bus asymmetric case" begin
         data = PowerModels.parse_file("../test/data/matpower/case5_asym.m")
-        result = run_dc_pf(data, ipopt_solver)
+        result = solve_dc_pf(data, ipopt_solver)
         native = compute_dc_pf(data)
 
         for (i,bus) in data["bus"]
@@ -36,7 +36,7 @@
     # compute_dc_pf does not yet support multiple slack buses
     # @testset "6-bus case" begin
     #     data = PowerModels.parse_file("../test/data/matpower/case6.m")
-    #     result = run_dc_pf(data, ipopt_solver)
+    #     result = solve_dc_pf(data, ipopt_solver)
     #     native = compute_dc_pf(data)
 
     #     for (i,bus) in data["bus"]
@@ -47,7 +47,7 @@
     # end
     @testset "24-bus rts case" begin
         data = PowerModels.parse_file("../test/data/matpower/case24.m")
-        result = run_dc_pf(data, ipopt_solver)
+        result = solve_dc_pf(data, ipopt_solver)
         native = compute_dc_pf(data)
 
         for (i,bus) in data["bus"]
@@ -63,7 +63,7 @@ end
     # requires dc line support in ac solver
     # @testset "3-bus case" begin
     #     data = PowerModels.parse_file("../test/data/matpower/case3.m")
-    #     result = run_dc_pf(data, ipopt_solver)
+    #     result = solve_dc_pf(data, ipopt_solver)
     #     native = compute_dc_pf(data)
 
     #     @test result["termination_status"] == LOCALLY_SOLVED
@@ -84,7 +84,7 @@ end
     # end
     @testset "5-bus case" begin
         data = PowerModels.parse_file("../test/data/matpower/case5.m")
-        result = run_ac_pf(data, ipopt_solver)
+        result = solve_ac_pf(data, ipopt_solver)
         native = compute_ac_pf(data)
 
         @test result["termination_status"] == LOCALLY_SOLVED
@@ -106,7 +106,7 @@ end
     end
     @testset "5-bus asymmetric case" begin
         data = PowerModels.parse_file("../test/data/matpower/case5_asym.m")
-        result = run_ac_pf(data, ipopt_solver)
+        result = solve_ac_pf(data, ipopt_solver)
         native = compute_ac_pf(data)
 
         @test result["termination_status"] == LOCALLY_SOLVED
@@ -129,7 +129,7 @@ end
     # compute_ac_pf does not yet support multiple slack buses
     # @testset "6-bus case" begin
     #     data = PowerModels.parse_file("../test/data/matpower/case6.m")
-    #     result = run_ac_pf(data, ipopt_solver)
+    #     result = solve_ac_pf(data, ipopt_solver)
     #     native = compute_ac_pf(data)
 
     #     @test result["termination_status"] == LOCALLY_SOLVED
@@ -150,7 +150,7 @@ end
     # end
     @testset "14-bus case, vm fixed non-1.0 value" begin
         data = PowerModels.parse_file("../test/data/matpower/case14.m")
-        result = run_ac_pf(data, ipopt_solver)
+        result = solve_ac_pf(data, ipopt_solver)
         native = compute_ac_pf(data)
 
         @test result["termination_status"] == LOCALLY_SOLVED
@@ -172,7 +172,7 @@ end
     end
     @testset "24-bus rts case" begin
         data = PowerModels.parse_file("../test/data/matpower/case24.m")
-        result = run_ac_pf(data, ipopt_solver)
+        result = solve_ac_pf(data, ipopt_solver)
         native = compute_ac_pf(data)
 
         @test result["termination_status"] == LOCALLY_SOLVED
@@ -303,15 +303,15 @@ end
         # TODO extract number of iterations and test there is a reduction
         # Ipopt log can be used for manual verification, for now
         data = PowerModels.parse_file("../test/data/matpower/case24.m")
-        result = run_ac_pf(data, ipopt_solver)
-        #result = run_ac_pf(data, JuMP.with_optimizer(Ipopt.Optimizer, tol=1e-6))
+        result = solve_ac_pf(data, ipopt_solver)
+        #result = solve_ac_pf(data, JuMP.with_optimizer(Ipopt.Optimizer, tol=1e-6))
         @test result["termination_status"] == LOCALLY_SOLVED
 
         update_data!(data, result["solution"])
         set_ac_pf_start_values!(data)
 
-        result_ws = run_ac_pf(data, ipopt_solver)
-        #result_ws = run_ac_pf(data, JuMP.with_optimizer(Ipopt.Optimizer, tol=1e-6))
+        result_ws = solve_ac_pf(data, ipopt_solver)
+        #result_ws = solve_ac_pf(data, JuMP.with_optimizer(Ipopt.Optimizer, tol=1e-6))
         @test result_ws["termination_status"] == LOCALLY_SOLVED
 
         bus_pg_ini = bus_gen_values(data, result["solution"], "pg")
@@ -364,7 +364,7 @@ end
 @testset "test native ac pf solver options" begin
     @testset "5-bus case, finite_differencing" begin
         data = PowerModels.parse_file("../test/data/matpower/case5.m")
-        result = run_ac_pf(data, ipopt_solver)
+        result = solve_ac_pf(data, ipopt_solver)
         native = compute_ac_pf("../test/data/matpower/case5.m", finite_differencing=true)
 
         @test result["termination_status"] == LOCALLY_SOLVED
@@ -386,7 +386,7 @@ end
     end
     @testset "5-bus case, flat_start" begin
         data = PowerModels.parse_file("../test/data/matpower/case5.m")
-        result = run_ac_pf(data, ipopt_solver)
+        result = solve_ac_pf(data, ipopt_solver)
         native = compute_ac_pf("../test/data/matpower/case5.m", flat_start=true)
 
         @test result["termination_status"] == LOCALLY_SOLVED

--- a/test/pf.jl
+++ b/test/pf.jl
@@ -1,6 +1,6 @@
 @testset "test ac polar pf" begin
     @testset "3-bus case" begin
-        result = run_ac_pf("../test/data/matpower/case3.m", ipopt_solver)
+        result = solve_ac_pf("../test/data/matpower/case3.m", ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 0; atol = 1e-2)
@@ -21,19 +21,19 @@
         #@test isapprox(result["solution"]["dcline"]["1"]["qt"],  0.0647562; atol = 1e-5)
     end
     @testset "5-bus transformer swap case" begin
-        result = run_pf("../test/data/matpower/case5.m", ACPPowerModel, ipopt_solver)
+        result = solve_pf("../test/data/matpower/case5.m", ACPPowerModel, ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 0; atol = 1e-2)
     end
     @testset "5-bus asymmetric case" begin
-        result = run_pf("../test/data/matpower/case5_asym.m", ACPPowerModel, ipopt_solver)
+        result = solve_pf("../test/data/matpower/case5_asym.m", ACPPowerModel, ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 0; atol = 1e-2)
     end
     @testset "5-bus case with hvdc line" begin
-        result = run_ac_pf("../test/data/matpower/case5_dc.m", ipopt_solver)
+        result = solve_ac_pf("../test/data/matpower/case5_dc.m", ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 0; atol = 1e-2)
@@ -53,7 +53,7 @@
 
     end
     @testset "6-bus case" begin
-        result = run_pf("../test/data/matpower/case6.m", ACPPowerModel, ipopt_solver)
+        result = solve_pf("../test/data/matpower/case6.m", ACPPowerModel, ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 0; atol = 1e-2)
@@ -63,7 +63,7 @@
         @test isapprox(result["solution"]["bus"]["4"]["va"], 0.00000; atol = 1e-3)
     end
     @testset "24-bus rts case" begin
-        result = run_pf("../test/data/matpower/case24.m", ACPPowerModel, ipopt_solver)
+        result = solve_pf("../test/data/matpower/case24.m", ACPPowerModel, ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 0; atol = 1e-2)
@@ -73,7 +73,7 @@ end
 
 @testset "test ac rect pf" begin
     @testset "5-bus asymmetric case" begin
-        result = run_pf("../test/data/matpower/case5_asym.m", ACRPowerModel, ipopt_solver)
+        result = solve_pf("../test/data/matpower/case5_asym.m", ACRPowerModel, ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 0; atol = 1e-2)
@@ -81,7 +81,7 @@ end
     #=
     # numerical issues with ipopt, likely div. by zero issue in jacobian
     @testset "5-bus case with hvdc line" begin
-        result = run_pf("../test/data/matpower/case5_dc.m", ACRPowerModel, ipopt_solver, setting = Dict("output" => Dict("branch_flows" => true)))
+        result = solve_pf("../test/data/matpower/case5_dc.m", ACRPowerModel, ipopt_solver, setting = Dict("output" => Dict("branch_flows" => true)))
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 0; atol = 1e-2)
@@ -105,13 +105,13 @@ end
 
 @testset "test ac tan pf" begin
     @testset "5-bus asymmetric case" begin
-        result = run_pf("../test/data/matpower/case5_asym.m", ACTPowerModel, ipopt_solver)
+        result = solve_pf("../test/data/matpower/case5_asym.m", ACTPowerModel, ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 0; atol = 1e-2)
     end
     @testset "5-bus case with hvdc line" begin
-        result = run_pf("../test/data/matpower/case5_dc.m", ACTPowerModel, ipopt_solver, solution_processors=[sol_data_model!])
+        result = solve_pf("../test/data/matpower/case5_dc.m", ACTPowerModel, ipopt_solver, solution_processors=[sol_data_model!])
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 0; atol = 1e-2)
@@ -135,7 +135,7 @@ end
 
 @testset "test iv pf" begin
     @testset "3-bus case" begin
-        result = run_pf_iv("../test/data/matpower/case3.m", IVRPowerModel, ipopt_solver, solution_processors=[sol_data_model!])
+        result = solve_pf_iv("../test/data/matpower/case3.m", IVRPowerModel, ipopt_solver, solution_processors=[sol_data_model!])
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 0; atol = 1e-2)
@@ -154,7 +154,7 @@ end
         # @test isapprox(result["solution"]["dcline"]["1"]["qt"],  0.0647562; atol = 1e-5) #no reason to expect this is unique
     end
     @testset "5-bus case with hvdc line" begin
-        result = run_pf_iv("../test/data/matpower/case5_dc.m", IVRPowerModel, ipopt_solver, solution_processors=[sol_data_model!])
+        result = solve_pf_iv("../test/data/matpower/case5_dc.m", IVRPowerModel, ipopt_solver, solution_processors=[sol_data_model!])
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 0; atol = 1e-2)
@@ -177,7 +177,7 @@ end
 
 @testset "test dc pf" begin
     @testset "3-bus case" begin
-        result = run_dc_pf("../test/data/matpower/case3.m", ipopt_solver)
+        result = solve_dc_pf("../test/data/matpower/case3.m", ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 0; atol = 1e-2)
@@ -189,13 +189,13 @@ end
         @test isapprox(result["solution"]["bus"]["3"]["va"], -0.28291891895; atol = 1e-5)
     end
     @testset "5-bus asymmetric case" begin
-        result = run_dc_pf("../test/data/matpower/case5_asym.m", ipopt_solver)
+        result = solve_dc_pf("../test/data/matpower/case5_asym.m", ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 0; atol = 1e-2)
     end
     @testset "6-bus case" begin
-        result = run_dc_pf("../test/data/matpower/case6.m", ipopt_solver)
+        result = solve_dc_pf("../test/data/matpower/case6.m", ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 0; atol = 1e-2)
@@ -203,7 +203,7 @@ end
         @test isapprox(result["solution"]["bus"]["4"]["va"], 0.00000; atol = 1e-5)
     end
     @testset "24-bus rts case" begin
-        result = run_pf("../test/data/matpower/case24.m", DCPPowerModel, ipopt_solver)
+        result = solve_pf("../test/data/matpower/case24.m", DCPPowerModel, ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 0; atol = 1e-2)
@@ -213,7 +213,7 @@ end
 
 @testset "test matpower dc pf" begin
     @testset "5-bus case with matpower DCMP model" begin
-        result = run_pf("../test/data/matpower/case5.m", DCMPPowerModel, ipopt_solver)
+        result = solve_pf("../test/data/matpower/case5.m", DCMPPowerModel, ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
 
@@ -228,7 +228,7 @@ end
 @testset "test soc pf" begin
     # started failing 05/22/2020 when ipopt moved to jll artifacts
     # @testset "3-bus case" begin
-    #     result = run_pf("../test/data/matpower/case3.m", SOCWRPowerModel, ipopt_solver, solution_processors=[sol_data_model!])
+    #     result = solve_pf("../test/data/matpower/case3.m", SOCWRPowerModel, ipopt_solver, solution_processors=[sol_data_model!])
 
     #     @test result["termination_status"] == LOCALLY_SOLVED
     #     @test isapprox(result["objective"], 0; atol = 1e-2)
@@ -247,13 +247,13 @@ end
     # end
     # started failing 05/22/2020 when ipopt moved to jll artifacts (only on travis)
     # @testset "5-bus asymmetric case" begin
-    #     result = run_pf("../test/data/matpower/case5_asym.m", SOCWRPowerModel, ipopt_solver)
+    #     result = solve_pf("../test/data/matpower/case5_asym.m", SOCWRPowerModel, ipopt_solver)
 
     #     @test result["termination_status"] == LOCALLY_SOLVED
     #     @test isapprox(result["objective"], 0; atol = 1e-2)
     # end
     @testset "6-bus case" begin
-        result = run_pf("../test/data/matpower/case6.m", SOCWRPowerModel, ipopt_solver, solution_processors=[sol_data_model!])
+        result = solve_pf("../test/data/matpower/case6.m", SOCWRPowerModel, ipopt_solver, solution_processors=[sol_data_model!])
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 0; atol = 1e-2)
@@ -261,7 +261,7 @@ end
         @test isapprox(result["solution"]["bus"]["4"]["vm"], 1.09999; atol = 1e-3)
     end
     @testset "24-bus rts case" begin
-        result = run_pf("../test/data/matpower/case24.m", SOCWRPowerModel, ipopt_solver)
+        result = solve_pf("../test/data/matpower/case24.m", SOCWRPowerModel, ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 0; atol = 1e-2)
@@ -272,7 +272,7 @@ end
 
 @testset "test soc distflow pf_bf" begin
     @testset "3-bus case" begin
-        result = run_pf_bf("../test/data/matpower/case3.m", SOCBFPowerModel, ipopt_solver, solution_processors=[sol_data_model!])
+        result = solve_pf_bf("../test/data/matpower/case3.m", SOCBFPowerModel, ipopt_solver, solution_processors=[sol_data_model!])
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 0; atol = 1e-2)
@@ -290,19 +290,19 @@ end
         @test isapprox(result["solution"]["dcline"]["1"]["pt"], -0.10; atol = 1e-4)
     end
     @testset "5-bus asymmetric case" begin
-        result = run_pf_bf("../test/data/matpower/case5_asym.m", SOCBFPowerModel, ipopt_solver)
+        result = solve_pf_bf("../test/data/matpower/case5_asym.m", SOCBFPowerModel, ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 0; atol = 1e-2)
     end
     @testset "5-bus case with hvdc line" begin
-        result = run_pf_bf("../test/data/matpower/case5_dc.m", SOCBFPowerModel, ipopt_solver)
+        result = solve_pf_bf("../test/data/matpower/case5_dc.m", SOCBFPowerModel, ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 0; atol = 1e-2)
     end
     @testset "6-bus case" begin
-        result = run_pf_bf("../test/data/matpower/case6.m", SOCBFPowerModel, ipopt_solver, solution_processors=[sol_data_model!])
+        result = solve_pf_bf("../test/data/matpower/case6.m", SOCBFPowerModel, ipopt_solver, solution_processors=[sol_data_model!])
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 0; atol = 1e-2)
@@ -310,7 +310,7 @@ end
         @test isapprox(result["solution"]["bus"]["4"]["vm"], 1.09999; atol = 1e-3)
     end
     @testset "24-bus rts case" begin
-        result = run_pf_bf("../test/data/matpower/case24.m", SOCBFPowerModel, ipopt_solver)
+        result = solve_pf_bf("../test/data/matpower/case24.m", SOCBFPowerModel, ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 0; atol = 1e-2)
@@ -320,7 +320,7 @@ end
 
 @testset "test linear distflow pf_bf" begin
     @testset "3-bus case" begin
-        result = run_pf_bf("../test/data/matpower/case3.m", BFAPowerModel, ipopt_solver, solution_processors=[sol_data_model!])
+        result = solve_pf_bf("../test/data/matpower/case3.m", BFAPowerModel, ipopt_solver, solution_processors=[sol_data_model!])
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 0; atol = 1e-2)
@@ -338,19 +338,19 @@ end
         @test isapprox(result["solution"]["dcline"]["1"]["pt"], -0.10; atol = 1e-4)
     end
     @testset "5-bus asymmetric case" begin
-        result = run_pf_bf("../test/data/matpower/case5_asym.m", BFAPowerModel, ipopt_solver)
+        result = solve_pf_bf("../test/data/matpower/case5_asym.m", BFAPowerModel, ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 0; atol = 1e-2)
     end
     @testset "5-bus case with hvdc line" begin
-        result = run_pf_bf("../test/data/matpower/case5_dc.m", BFAPowerModel, ipopt_solver)
+        result = solve_pf_bf("../test/data/matpower/case5_dc.m", BFAPowerModel, ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 0; atol = 1e-2)
     end
     @testset "6-bus case" begin
-        result = run_pf_bf("../test/data/matpower/case6.m", BFAPowerModel, ipopt_solver, solution_processors=[sol_data_model!])
+        result = solve_pf_bf("../test/data/matpower/case6.m", BFAPowerModel, ipopt_solver, solution_processors=[sol_data_model!])
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 0; atol = 1e-2)
@@ -359,7 +359,7 @@ end
     end
     @testset "24-bus rts case" begin
         data = parse_file("../test/data/matpower/case24.m")
-        result = run_pf_bf(data, BFAPowerModel, ipopt_solver)
+        result = solve_pf_bf(data, BFAPowerModel, ipopt_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["objective"], 0; atol = 1e-2)
@@ -373,7 +373,7 @@ end
 @testset "test sdp pf" begin
     # note: may have issues on linux (04/02/18)
     @testset "3-bus case" begin
-        result = run_pf("../test/data/matpower/case3.m", SDPWRMPowerModel, scs_solver, solution_processors=[sol_data_model!])
+        result = solve_pf("../test/data/matpower/case3.m", SDPWRMPowerModel, scs_solver, solution_processors=[sol_data_model!])
 
         @test result["termination_status"] == OPTIMAL
         @test isapprox(result["objective"], 0; atol = 1e-2)
@@ -392,13 +392,13 @@ end
     end
     # note: may have issues on os x (05/07/18)
     @testset "5-bus asymmetric case" begin
-        result = run_pf("../test/data/matpower/case5_asym.m", SDPWRMPowerModel, scs_solver)
+        result = solve_pf("../test/data/matpower/case5_asym.m", SDPWRMPowerModel, scs_solver)
 
         @test result["termination_status"] == OPTIMAL
         @test isapprox(result["objective"], 0; atol = 1e-2)
     end
     @testset "6-bus case" begin
-        result = run_pf("../test/data/matpower/case6.m", SDPWRMPowerModel, scs_solver, solution_processors=[sol_data_model!])
+        result = solve_pf("../test/data/matpower/case6.m", SDPWRMPowerModel, scs_solver, solution_processors=[sol_data_model!])
 
         @test result["termination_status"] == OPTIMAL
         @test isapprox(result["objective"], 0; atol = 1e-2)
@@ -406,7 +406,7 @@ end
         @test isapprox(result["solution"]["bus"]["4"]["vm"], 1.09999; atol = 1e-3)
     end
     @testset "24-bus rts case" begin
-        result = run_pf("../test/data/matpower/case24.m", SDPWRMPowerModel, scs_solver)
+        result = solve_pf("../test/data/matpower/case24.m", SDPWRMPowerModel, scs_solver)
 
         @test result["termination_status"] == OPTIMAL
         @test isapprox(result["objective"], 0; atol = 1e-2)

--- a/test/psse.jl
+++ b/test/psse.jl
@@ -28,8 +28,8 @@ end
 
             set_costs!(data_mp)
 
-            result_pti = PowerModels.run_opf(data_pti, PowerModels.ACPPowerModel, ipopt_solver)
-            result_mp  = PowerModels.run_opf(data_mp, PowerModels.ACPPowerModel, ipopt_solver)
+            result_pti = PowerModels.solve_opf(data_pti, PowerModels.ACPPowerModel, ipopt_solver)
+            result_mp  = PowerModels.solve_opf(data_mp, PowerModels.ACPPowerModel, ipopt_solver)
 
             @test result_pti["termination_status"] == LOCALLY_SOLVED
             @test result_mp["termination_status"] == LOCALLY_SOLVED
@@ -42,8 +42,8 @@ end
 
             set_costs!(data_mp)
 
-            result_pti = PowerModels.run_opf(data_pti, PowerModels.ACPPowerModel, ipopt_solver)
-            result_mp  = PowerModels.run_opf(data_mp, PowerModels.ACPPowerModel, ipopt_solver)
+            result_pti = PowerModels.solve_opf(data_pti, PowerModels.ACPPowerModel, ipopt_solver)
+            result_mp  = PowerModels.solve_opf(data_mp, PowerModels.ACPPowerModel, ipopt_solver)
 
             @test result_pti["termination_status"] == LOCALLY_SOLVED
             @test result_mp["termination_status"] == LOCALLY_SOLVED
@@ -58,8 +58,8 @@ end
 
                 set_costs!(data_mp)
 
-                result_pti = PowerModels.run_opf(data_pti, PowerModels.ACPPowerModel, ipopt_solver)
-                result_mp  = PowerModels.run_opf(data_mp, PowerModels.ACPPowerModel, ipopt_solver)
+                result_pti = PowerModels.solve_opf(data_pti, PowerModels.ACPPowerModel, ipopt_solver)
+                result_mp  = PowerModels.solve_opf(data_mp, PowerModels.ACPPowerModel, ipopt_solver)
 
                 @test result_pti["termination_status"] == LOCALLY_SOLVED
                 @test result_mp["termination_status"] == LOCALLY_SOLVED
@@ -82,12 +82,12 @@ end
                 end
             end
 
-            result_opf = PowerModels.run_opf(data_pti, PowerModels.ACPPowerModel, ipopt_solver)
+            result_opf = PowerModels.solve_opf(data_pti, PowerModels.ACPPowerModel, ipopt_solver)
 
             @test result_opf["termination_status"] == LOCALLY_SOLVED
             @test isapprox(result_opf["objective"], 29.4043; atol=1e-4)
 
-            result_pf = PowerModels.run_pf(data_pti, PowerModels.ACPPowerModel, ipopt_solver)
+            result_pf = PowerModels.solve_pf(data_pti, PowerModels.ACPPowerModel, ipopt_solver)
 
             for (bus, vm, va) in zip(["1002", "1005", "1008", "1009"],
                                      [1.0032721, 1.0199983, 1.0203627, 1.03],
@@ -105,8 +105,8 @@ end
 
             set_costs!(data_mp)
 
-            result_pti = PowerModels.run_opf(data_pti, PowerModels.ACPPowerModel, ipopt_solver)
-            result_mp  = PowerModels.run_opf(data_mp, PowerModels.ACPPowerModel, ipopt_solver)
+            result_pti = PowerModels.solve_opf(data_pti, PowerModels.ACPPowerModel, ipopt_solver)
+            result_mp  = PowerModels.solve_opf(data_mp, PowerModels.ACPPowerModel, ipopt_solver)
 
             @test result_pti["termination_status"] == LOCALLY_SOLVED
             @test result_mp["termination_status"] == LOCALLY_SOLVED
@@ -123,8 +123,8 @@ end
 
             set_costs!(data_mp)
 
-            result_pti = PowerModels.run_opf(data_pti, PowerModels.ACPPowerModel, ipopt_solver)
-            result_mp  = PowerModels.run_opf(data_mp, PowerModels.ACPPowerModel, ipopt_solver)
+            result_pti = PowerModels.solve_opf(data_pti, PowerModels.ACPPowerModel, ipopt_solver)
+            result_mp  = PowerModels.solve_opf(data_mp, PowerModels.ACPPowerModel, ipopt_solver)
 
             @test result_pti["termination_status"] == LOCALLY_SOLVED
             @test result_mp["termination_status"] == LOCALLY_SOLVED
@@ -143,8 +143,8 @@ end
 
             set_costs!(data_mp)
 
-            result_pti = PowerModels.run_opf(data_pti, PowerModels.ACPPowerModel, ipopt_solver)
-            result_mp  = PowerModels.run_opf(data_mp, PowerModels.ACPPowerModel, ipopt_solver)
+            result_pti = PowerModels.solve_opf(data_pti, PowerModels.ACPPowerModel, ipopt_solver)
+            result_mp  = PowerModels.solve_opf(data_mp, PowerModels.ACPPowerModel, ipopt_solver)
 
             @test result_pti["termination_status"] == LOCALLY_SOLVED
             @test result_mp["termination_status"] == LOCALLY_SOLVED
@@ -161,8 +161,8 @@ end
 
             set_costs!(data_mp)
 
-            result_pti = PowerModels.run_opf(data_pti, PowerModels.ACPPowerModel, ipopt_solver)
-            result_mp  = PowerModels.run_opf(data_mp, PowerModels.ACPPowerModel, ipopt_solver)
+            result_pti = PowerModels.solve_opf(data_pti, PowerModels.ACPPowerModel, ipopt_solver)
+            result_mp  = PowerModels.solve_opf(data_mp, PowerModels.ACPPowerModel, ipopt_solver)
 
             @test result_pti["termination_status"] == LOCALLY_SOLVED
             @test result_mp["termination_status"] == LOCALLY_SOLVED
@@ -178,8 +178,8 @@ end
 
             set_costs!(data_mp)
 
-            result_pti = PowerModels.run_opf(data_pti, PowerModels.ACPPowerModel, ipopt_solver)
-            result_mp  = PowerModels.run_opf(data_mp, PowerModels.ACPPowerModel, ipopt_solver)
+            result_pti = PowerModels.solve_opf(data_pti, PowerModels.ACPPowerModel, ipopt_solver)
+            result_mp  = PowerModels.solve_opf(data_mp, PowerModels.ACPPowerModel, ipopt_solver)
 
             @test result_pti["termination_status"] == LOCALLY_SOLVED
             @test result_mp["termination_status"] == LOCALLY_SOLVED
@@ -196,8 +196,8 @@ end
 
             set_costs!(data_mp)
 
-            result_pti = PowerModels.run_opf(data_pti, PowerModels.ACPPowerModel, ipopt_solver)
-            result_mp  = PowerModels.run_opf(data_mp, PowerModels.ACPPowerModel, ipopt_solver)
+            result_pti = PowerModels.solve_opf(data_pti, PowerModels.ACPPowerModel, ipopt_solver)
+            result_mp  = PowerModels.solve_opf(data_mp, PowerModels.ACPPowerModel, ipopt_solver)
 
             @test result_pti["termination_status"] == LOCALLY_SOLVED
             @test result_mp["termination_status"] == LOCALLY_SOLVED
@@ -259,12 +259,12 @@ end
             @test length(data_pti["bus"]) == 8
             @test length(data_pti["branch"]) == 15
 
-            result_opf = PowerModels.run_opf(data_pti, PowerModels.ACPPowerModel, ipopt_solver)
+            result_opf = PowerModels.solve_opf(data_pti, PowerModels.ACPPowerModel, ipopt_solver)
 
             @test result_opf["termination_status"] == LOCALLY_SOLVED
             @test isapprox(result_opf["objective"], 10.00027; atol=1e-5)
 
-            result_pf = PowerModels.run_pf(data_pti, PowerModels.ACPPowerModel, ipopt_solver)
+            result_pf = PowerModels.solve_pf(data_pti, PowerModels.ACPPowerModel, ipopt_solver)
 
             bus_data = zip(
                 ["1001", "1002", "1003", "10002", "10003", "10004"],
@@ -303,12 +303,12 @@ end
             end
 
 
-            result_opf = PowerModels.run_opf(data_pti, PowerModels.ACPPowerModel, ipopt_solver)
+            result_opf = PowerModels.solve_opf(data_pti, PowerModels.ACPPowerModel, ipopt_solver)
 
             @test result_opf["termination_status"] == LOCALLY_SOLVED
             @test isapprox(result_opf["objective"], 10.0; atol=1e-5)
 
-            result_pf = PowerModels.run_pf(data_pti, PowerModels.ACPPowerModel, ipopt_solver)
+            result_pf = PowerModels.solve_pf(data_pti, PowerModels.ACPPowerModel, ipopt_solver)
 
             for (bus, vm, va) in zip(["1001", "1002", "1003", "10001"], [1.09, 1.0, 1.0, 0.997], [2.304, 0., 6.042244, 2.5901])
                 @test isapprox(result_pf["solution"]["bus"][bus]["vm"], vm; atol=1e-1)
@@ -327,12 +327,12 @@ end
             @test isapprox(data_pti["branch"]["1"]["g_fr"], 5e-3; atol=1e-4)
             @test isapprox(data_pti["branch"]["1"]["b_fr"], 6.74e-3; atol=1e-4)
 
-            result_opf = PowerModels.run_opf(data_pti, PowerModels.ACPPowerModel, ipopt_solver)
+            result_opf = PowerModels.solve_opf(data_pti, PowerModels.ACPPowerModel, ipopt_solver)
 
             @test result_opf["termination_status"] == LOCALLY_SOLVED
             @test isapprox(result_opf["objective"], 701.637157; atol=1e-5)
 
-            result_pf = PowerModels.run_pf(data_pti, PowerModels.ACPPowerModel, ipopt_solver)
+            result_pf = PowerModels.solve_pf(data_pti, PowerModels.ACPPowerModel, ipopt_solver)
 
             @test result_pf["termination_status"] == LOCALLY_SOLVED
             @test result_pf["objective"] == 0.0
@@ -351,12 +351,12 @@ end
             @test isapprox(data_pti["branch"]["1"]["g_fr"], 5e-3; atol=1e-4)
             @test isapprox(data_pti["branch"]["1"]["b_fr"], 6.74e-3; atol=1e-4)
 
-            result_opf = PowerModels.run_opf(data_pti, PowerModels.ACPPowerModel, ipopt_solver)
+            result_opf = PowerModels.solve_opf(data_pti, PowerModels.ACPPowerModel, ipopt_solver)
 
             @test result_opf["termination_status"] == LOCALLY_SOLVED
             @test isapprox(result_opf["objective"], 10.4001; atol=1e-2)
 
-            result_pf = PowerModels.run_pf(data_pti, PowerModels.ACPPowerModel, ipopt_solver)
+            result_pf = PowerModels.solve_pf(data_pti, PowerModels.ACPPowerModel, ipopt_solver)
 
             @test result_pf["termination_status"] == LOCALLY_SOLVED
             @test result_pf["objective"] == 0.0
@@ -412,7 +412,7 @@ end
                 end
             end
 
-            result = PowerModels.run_opf(data, PowerModels.ACPPowerModel, ipopt_solver)
+            result = PowerModels.solve_opf(data, PowerModels.ACPPowerModel, ipopt_solver)
 
             @test result["termination_status"] == LOCALLY_SOLVED
             @test isapprox(result["objective"], 297.878089; atol=1e-4)
@@ -465,11 +465,11 @@ end
             @test length(data["dcline"]) == 1
             @test length(data["dcline"]["1"]) == 26
 
-            opf = PowerModels.run_opf(data, PowerModels.ACPPowerModel, ipopt_solver)
+            opf = PowerModels.solve_opf(data, PowerModels.ACPPowerModel, ipopt_solver)
             @test opf["termination_status"] == LOCALLY_SOLVED
             @test isapprox(opf["objective"], 10.5; atol=1e-3)
 
-            pf = PowerModels.run_pf(data, PowerModels.ACPPowerModel, ipopt_solver)
+            pf = PowerModels.solve_pf(data, PowerModels.ACPPowerModel, ipopt_solver)
             @test pf["termination_status"] == LOCALLY_SOLVED
         end
 
@@ -479,11 +479,11 @@ end
             @test length(data["dcline"]) == 1
             @test length(data["dcline"]["1"]) == 26
 
-            opf = PowerModels.run_opf(data, PowerModels.ACPPowerModel, ipopt_solver)
+            opf = PowerModels.solve_opf(data, PowerModels.ACPPowerModel, ipopt_solver)
             @test opf["termination_status"] == LOCALLY_SOLVED
             @test isapprox(opf["objective"], 21.8842; atol=1e-3)
 
-            pf = PowerModels.run_pf(data, PowerModels.ACPPowerModel, ipopt_solver)
+            pf = PowerModels.solve_pf(data, PowerModels.ACPPowerModel, ipopt_solver)
             @test pf["termination_status"] == LOCALLY_SOLVED
         end
     end

--- a/test/tnep.jl
+++ b/test/tnep.jl
@@ -11,7 +11,7 @@ end
     @testset "3-bus case" begin
         data = PowerModels.parse_file("../test/data/matpower/case3_tnep.m")
         calc_thermal_limits!(data)
-        result = run_tnep(data, ACPPowerModel, juniper_solver)
+        result = solve_tnep(data, ACPPowerModel, juniper_solver)
 
         check_tnep_status(result["solution"])
 
@@ -20,7 +20,7 @@ end
     end
 
     @testset "5-bus case" begin
-        result = run_tnep("../test/data/matpower/case5_tnep.m", ACPPowerModel, juniper_solver)
+        result = solve_tnep("../test/data/matpower/case5_tnep.m", ACPPowerModel, juniper_solver)
 
         check_tnep_status(result["solution"])
 
@@ -34,7 +34,7 @@ end
     @testset "3-bus case" begin
         data = PowerModels.parse_file("../test/data/matpower/case3_tnep.m")
         calc_thermal_limits!(data)
-        result = run_tnep(data, SOCWRPowerModel, juniper_solver)
+        result = solve_tnep(data, SOCWRPowerModel, juniper_solver)
 
         check_tnep_status(result["solution"])
 
@@ -43,7 +43,7 @@ end
     end
 
     @testset "5-bus rts case" begin
-        result = run_tnep("../test/data/matpower/case5_tnep.m", SOCWRPowerModel, juniper_solver)
+        result = solve_tnep("../test/data/matpower/case5_tnep.m", SOCWRPowerModel, juniper_solver)
 
         check_tnep_status(result["solution"])
 
@@ -57,7 +57,7 @@ end
     @testset "3-bus case" begin
         data = PowerModels.parse_file("../test/data/matpower/case3_tnep.m")
         calc_thermal_limits!(data)
-        result = run_tnep(data, QCRMPowerModel, juniper_solver)
+        result = solve_tnep(data, QCRMPowerModel, juniper_solver)
 
         check_tnep_status(result["solution"])
 
@@ -66,7 +66,7 @@ end
     end
 
     @testset "5-bus rts case" begin
-        result = run_tnep("../test/data/matpower/case5_tnep.m", QCRMPowerModel, juniper_solver)
+        result = solve_tnep("../test/data/matpower/case5_tnep.m", QCRMPowerModel, juniper_solver)
 
         check_tnep_status(result["solution"])
 
@@ -80,7 +80,7 @@ end
     @testset "3-bus case" begin
         data = PowerModels.parse_file("../test/data/matpower/case3_tnep.m")
         calc_thermal_limits!(data)
-        result = run_tnep(data, DCPPowerModel, juniper_solver)
+        result = solve_tnep(data, DCPPowerModel, juniper_solver)
 
         check_tnep_status(result["solution"])
 
@@ -89,7 +89,7 @@ end
     end
 
     @testset "5-bus case" begin
-        result = run_tnep("../test/data/matpower/case5_tnep.m", DCPPowerModel, juniper_solver)
+        result = solve_tnep("../test/data/matpower/case5_tnep.m", DCPPowerModel, juniper_solver)
 
         check_tnep_status(result["solution"])
 
@@ -101,7 +101,7 @@ end
 
 @testset "test matpower dc tnep" begin
     @testset "5-bus case with matpower DCMP model and TNEP" begin
-        result = run_tnep("../test/data/matpower/case5_tnep.m", DCMPPowerModel, juniper_solver)
+        result = solve_tnep("../test/data/matpower/case5_tnep.m", DCMPPowerModel, juniper_solver)
 
         @test result["termination_status"] == LOCALLY_SOLVED
         @test isapprox(result["solution"]["ne_branch"]["1"]["built"], 1.0; atol = 1e-5)
@@ -116,7 +116,7 @@ end
     @testset "3-bus case" begin
         data = PowerModels.parse_file("../test/data/matpower/case3_tnep.m")
         calc_thermal_limits!(data)
-        result = run_tnep(data, DCPLLPowerModel, juniper_solver)
+        result = solve_tnep(data, DCPLLPowerModel, juniper_solver)
 
         check_tnep_status(result["solution"])
 
@@ -126,7 +126,7 @@ end
     =#
 
     @testset "5-bus case" begin
-        result = run_tnep("../test/data/matpower/case5_tnep.m", DCPLLPowerModel, juniper_solver)
+        result = solve_tnep("../test/data/matpower/case5_tnep.m", DCPLLPowerModel, juniper_solver)
 
         check_tnep_status(result["solution"])
 
@@ -139,7 +139,7 @@ end
     @testset "3-bus case" begin
         data = PowerModels.parse_file("../test/data/matpower/case3_tnep.m")
         calc_thermal_limits!(data)
-        result = run_tnep(data, LPACCPowerModel, juniper_solver)
+        result = solve_tnep(data, LPACCPowerModel, juniper_solver)
 
         check_tnep_status(result["solution"])
 
@@ -148,7 +148,7 @@ end
     end
 
     @testset "5-bus case" begin
-        result = run_tnep("../test/data/matpower/case5_tnep.m", LPACCPowerModel, juniper_solver)
+        result = solve_tnep("../test/data/matpower/case5_tnep.m", LPACCPowerModel, juniper_solver)
 
         check_tnep_status(result["solution"])
 
@@ -161,7 +161,7 @@ end
     @testset "3-bus case" begin
         data = PowerModels.parse_file("../test/data/matpower/case3_tnep.m")
         calc_thermal_limits!(data)
-        result = run_tnep(data, SOCWRPowerModel, juniper_solver)
+        result = solve_tnep(data, SOCWRPowerModel, juniper_solver)
 
         check_tnep_status(result["solution"])
 

--- a/test/util.jl
+++ b/test/util.jl
@@ -1,15 +1,15 @@
 
 @testset "obbt with trilinear convex hull relaxation" begin
     @testset "3-bus case" begin
-        result_ac = run_ac_opf("../test/data/matpower/case3.m", ipopt_solver);
+        result_ac = solve_ac_opf("../test/data/matpower/case3.m", ipopt_solver);
         upper_bound = result_ac["objective"]
 
-        data, stats = run_obbt_opf!("../test/data/matpower/case3.m", ipopt_solver, model_type=QCLSPowerModel);
+        data, stats = solve_obbt_opf!("../test/data/matpower/case3.m", ipopt_solver, model_type=QCLSPowerModel);
         @test isapprox(stats["final_relaxation_objective"], 5901.96; atol=1e0)
         @test isnan(stats["final_rel_gap_from_ub"])
         @test stats["iteration_count"] == 5
 
-        data, stats = run_obbt_opf!("../test/data/matpower/case3.m", ipopt_solver, 
+        data, stats = solve_obbt_opf!("../test/data/matpower/case3.m", ipopt_solver, 
             model_type = QCLSPowerModel,
             upper_bound = upper_bound, 
             upper_bound_constraint = true, 
@@ -23,15 +23,15 @@ end
 
 @testset "obbt with qc relaxation" begin
     @testset "3-bus case" begin
-        result_ac = run_ac_opf("../test/data/matpower/case3.m", ipopt_solver);
+        result_ac = solve_ac_opf("../test/data/matpower/case3.m", ipopt_solver);
         upper_bound = result_ac["objective"]
 
-        data, stats = run_obbt_opf!("../test/data/matpower/case3.m", ipopt_solver, model_type=QCRMPowerModel);
+        data, stats = solve_obbt_opf!("../test/data/matpower/case3.m", ipopt_solver, model_type=QCRMPowerModel);
         @test isapprox(stats["final_relaxation_objective"], 5900.04; atol=1e0)
         @test isnan(stats["final_rel_gap_from_ub"])
         @test stats["iteration_count"] == 5
 
-        data, stats = run_obbt_opf!("../test/data/matpower/case3.m", ipopt_solver, 
+        data, stats = solve_obbt_opf!("../test/data/matpower/case3.m", ipopt_solver, 
             model_type = QCRMPowerModel,
             upper_bound = upper_bound, 
             upper_bound_constraint = true, 
@@ -47,10 +47,10 @@ end
         data["gen"]["1"]["cost"] = data["gen"]["1"]["cost"][2:3]
         data["gen"]["2"]["cost"] = data["gen"]["2"]["cost"][2:3]
 
-        result_ac = run_ac_opf(data, ipopt_solver);
+        result_ac = solve_ac_opf(data, ipopt_solver);
         upper_bound = result_ac["objective"]
 
-        data, stats = run_obbt_opf!(data, ipopt_solver,
+        data, stats = solve_obbt_opf!(data, ipopt_solver,
             model_type=QCRMPowerModel,
             upper_bound = upper_bound,
             upper_bound_constraint = true);
@@ -63,8 +63,8 @@ end
 
 @testset "opf with flow cuts" begin
     @testset "ac 5-bus case" begin
-        result_base = run_opf("../test/data/matpower/case5.m", ACPPowerModel, ipopt_solver)
-        result_cuts = run_opf_flow_cuts("../test/data/matpower/case5.m", ACPPowerModel, ipopt_solver)
+        result_base = solve_opf("../test/data/matpower/case5.m", ACPPowerModel, ipopt_solver)
+        result_cuts = solve_opf_flow_cuts("../test/data/matpower/case5.m", ACPPowerModel, ipopt_solver)
 
         @test result_base["termination_status"] == LOCALLY_SOLVED
         @test result_cuts["termination_status"] == LOCALLY_SOLVED
@@ -75,8 +75,8 @@ end
         end
     end
     @testset "ac 14-bus case" begin
-        result_base = run_opf("../test/data/matpower/case14.m", ACPPowerModel, ipopt_solver)
-        result_cuts = run_opf_flow_cuts("../test/data/matpower/case14.m", ACPPowerModel, ipopt_solver)
+        result_base = solve_opf("../test/data/matpower/case14.m", ACPPowerModel, ipopt_solver)
+        result_cuts = solve_opf_flow_cuts("../test/data/matpower/case14.m", ACPPowerModel, ipopt_solver)
 
         @test result_base["termination_status"] == LOCALLY_SOLVED
         @test result_cuts["termination_status"] == LOCALLY_SOLVED
@@ -88,8 +88,8 @@ end
     end
 
     @testset "soc 5-bus case" begin
-        result_base = run_opf("../test/data/matpower/case5.m", SOCWRPowerModel, ipopt_solver)
-        result_cuts = run_opf_flow_cuts("../test/data/matpower/case5.m", SOCWRPowerModel, ipopt_solver)
+        result_base = solve_opf("../test/data/matpower/case5.m", SOCWRPowerModel, ipopt_solver)
+        result_cuts = solve_opf_flow_cuts("../test/data/matpower/case5.m", SOCWRPowerModel, ipopt_solver)
 
         @test result_base["termination_status"] == LOCALLY_SOLVED
         @test result_cuts["termination_status"] == LOCALLY_SOLVED
@@ -99,8 +99,8 @@ end
         end
     end
     @testset "soc 14-bus case" begin
-        result_base = run_opf("../test/data/matpower/case14.m", SOCWRPowerModel, ipopt_solver)
-        result_cuts = run_opf_flow_cuts("../test/data/matpower/case14.m", SOCWRPowerModel, ipopt_solver)
+        result_base = solve_opf("../test/data/matpower/case14.m", SOCWRPowerModel, ipopt_solver)
+        result_cuts = solve_opf_flow_cuts("../test/data/matpower/case14.m", SOCWRPowerModel, ipopt_solver)
 
         @test result_base["termination_status"] == LOCALLY_SOLVED
         @test result_cuts["termination_status"] == LOCALLY_SOLVED
@@ -111,8 +111,8 @@ end
     end
 
     @testset "dc 5-bus case" begin
-        result_base = run_opf("../test/data/matpower/case5.m", DCPPowerModel, cbc_solver)
-        result_cuts = run_opf_flow_cuts("../test/data/matpower/case5.m", DCPPowerModel, cbc_solver)
+        result_base = solve_opf("../test/data/matpower/case5.m", DCPPowerModel, cbc_solver)
+        result_cuts = solve_opf_flow_cuts("../test/data/matpower/case5.m", DCPPowerModel, cbc_solver)
 
         @test result_base["termination_status"] == OPTIMAL
         @test result_cuts["termination_status"] == OPTIMAL
@@ -122,8 +122,8 @@ end
         end
     end
     @testset "dc 14-bus case" begin
-        result_base = run_opf("../test/data/matpower/case14.m", DCPPowerModel, ipopt_solver)
-        result_cuts = run_opf_flow_cuts("../test/data/matpower/case14.m", DCPPowerModel, ipopt_solver)
+        result_base = solve_opf("../test/data/matpower/case14.m", DCPPowerModel, ipopt_solver)
+        result_cuts = solve_opf_flow_cuts("../test/data/matpower/case14.m", DCPPowerModel, ipopt_solver)
 
         @test result_base["termination_status"] == LOCALLY_SOLVED
         @test result_cuts["termination_status"] == LOCALLY_SOLVED
@@ -137,8 +137,8 @@ end
 
 @testset "ptdf opf with flow cuts" begin
     @testset "dc 5-bus case" begin
-        result_base = run_opf("../test/data/matpower/case5.m", DCPPowerModel, cbc_solver)
-        result_cuts = run_opf_ptdf_flow_cuts("../test/data/matpower/case5.m", cbc_solver)
+        result_base = solve_opf("../test/data/matpower/case5.m", DCPPowerModel, cbc_solver)
+        result_cuts = solve_opf_ptdf_flow_cuts("../test/data/matpower/case5.m", cbc_solver)
 
         @test result_base["termination_status"] == OPTIMAL
         @test result_cuts["termination_status"] == OPTIMAL
@@ -148,8 +148,8 @@ end
         end
     end
     @testset "dc 5-bus ext case" begin
-        result_base = run_opf("../test/data/matpower/case5_ext.m", DCPPowerModel, cbc_solver)
-        result_cuts = run_opf_ptdf_flow_cuts("../test/data/matpower/case5_ext.m", cbc_solver)
+        result_base = solve_opf("../test/data/matpower/case5_ext.m", DCPPowerModel, cbc_solver)
+        result_cuts = solve_opf_ptdf_flow_cuts("../test/data/matpower/case5_ext.m", cbc_solver)
 
         @test result_base["termination_status"] == OPTIMAL
         @test result_cuts["termination_status"] == OPTIMAL
@@ -159,8 +159,8 @@ end
         end
     end
     @testset "dc 14-bus case" begin
-        result_base = run_opf("../test/data/matpower/case14.m", DCPPowerModel, ipopt_solver)
-        result_cuts = run_opf_ptdf_flow_cuts("../test/data/matpower/case14.m", ipopt_solver)
+        result_base = solve_opf("../test/data/matpower/case14.m", DCPPowerModel, ipopt_solver)
+        result_cuts = solve_opf_ptdf_flow_cuts("../test/data/matpower/case14.m", ipopt_solver)
 
         @test result_base["termination_status"] == LOCALLY_SOLVED
         @test result_cuts["termination_status"] == LOCALLY_SOLVED

--- a/test/warmstart.jl
+++ b/test/warmstart.jl
@@ -40,32 +40,32 @@ end
 @testset "dc warm starts" begin
     @testset "5 bus case" begin
         data = PowerModels.parse_file("../test/data/matpower/case5.m")
-        result = run_dc_opf(data, ipopt_solver; setting = Dict("output" => Dict("branch_flows" => true)));
+        result = solve_dc_opf(data, ipopt_solver; setting = Dict("output" => Dict("branch_flows" => true)));
 
         PowerModels.update_data!(data, result["solution"])
 
         # 14 iterations
-        result = run_dc_opf(data, ipopt_solver);
+        result = solve_dc_opf(data, ipopt_solver);
 
         set_dc_start!(data)
 
         # 6 iterations
-        result = run_dc_opf(data, ipopt_ws_solver);
+        result = solve_dc_opf(data, ipopt_ws_solver);
     end
 
     @testset "5 bus pwl case" begin
         data = PowerModels.parse_file("../test/data/matpower/case5_pwlc.m")
-        result = run_dc_opf(data, ipopt_solver; setting = Dict("output" => Dict("branch_flows" => true)));
+        result = solve_dc_opf(data, ipopt_solver; setting = Dict("output" => Dict("branch_flows" => true)));
 
         PowerModels.update_data!(data, result["solution"])
 
         # 35 iterations
-        result = run_dc_opf(data, ipopt_solver);
+        result = solve_dc_opf(data, ipopt_solver);
 
         set_dc_start!(data)
 
         # 6 iterations
-        result = run_dc_opf(data, ipopt_ws_solver);
+        result = solve_dc_opf(data, ipopt_ws_solver);
     end
 end
 
@@ -73,32 +73,32 @@ end
 @testset "ac warm starts" begin
     @testset "5 bus case" begin
         data = PowerModels.parse_file("../test/data/matpower/case5.m")
-        result = run_ac_opf(data, ipopt_solver; setting = Dict("output" => Dict("branch_flows" => true)));
+        result = solve_ac_opf(data, ipopt_solver; setting = Dict("output" => Dict("branch_flows" => true)));
 
         PowerModels.update_data!(data, result["solution"])
 
         # 22 iterations
-        result = run_ac_opf(data, ipopt_solver);
+        result = solve_ac_opf(data, ipopt_solver);
 
         set_ac_start!(data)
 
         # 19 iterations
-        result = run_ac_opf(data, ipopt_ws_solver);
+        result = solve_ac_opf(data, ipopt_ws_solver);
     end
 
     @testset "5 bus pwl case" begin
         data = PowerModels.parse_file("../test/data/matpower/case5_pwlc.m")
-        result = run_ac_opf(data, ipopt_solver; setting = Dict("output" => Dict("branch_flows" => true)));
+        result = solve_ac_opf(data, ipopt_solver; setting = Dict("output" => Dict("branch_flows" => true)));
 
         PowerModels.update_data!(data, result["solution"])
 
         # 40 iterations
-        result = run_ac_opf(data, ipopt_solver);
+        result = solve_ac_opf(data, ipopt_solver);
 
         set_ac_start!(data)
 
         # 12 iterations
-        result = run_ac_opf(data, ipopt_ws_solver);
+        result = solve_ac_opf(data, ipopt_ws_solver);
     end
 end
 


### PR DESCRIPTION
To solve #649 issue. I add a few warning messages that ```run_*``` functions are deprecated.

```
julia> run_ac_opf("case3.m", with_optimizer(Ipopt.Optimizer))
┌ Warning: `with_optimizer` is deprecated. Adapt the following example to update your code:
│ `with_optimizer(Ipopt.Optimizer)` becomes `Ipopt.Optimizer`.
│   caller = top-level scope at REPL[5]:1
└ @ Core REPL[5]:1
┌ Warning: `run_ac_opf(file, optimizer; kwargs...)` is deprecated, use `solve_ac_opf(file, optimizer; kwargs...)` instead.
│   caller = top-level scope at REPL[5]:1
└ @ Core REPL[5]:1
```

Hope it is useful.
