### PR TITLE
building expression in two steps 

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -31,8 +31,9 @@ julia = "^1"
 Cbc = "9961bab8-2fa3-5c5a-9d89-47fab24efd76"
 Ipopt = "b6b21f68-93f8-5de0-b562-5493be1d77c9"
 Juniper = "2ddba703-00a4-53a7-87a5-e8b9971dde84"
+ParameterJuMP = "774612a8-9878-5177-865a-ca53ae2495f9"
 SCS = "c946c3f1-0d1f-5ce8-9dea-7daa1f7e2d13"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "Ipopt", "SCS", "Cbc", "Juniper"]
+test = ["Test", "Ipopt", "SCS", "Cbc", "Juniper", "ParameterJuMP"]

--- a/src/form/dcp.jl
+++ b/src/form/dcp.jl
@@ -209,7 +209,8 @@ function expression_bus_voltage(pm::AbstractPowerModel, n::Int, i, am::Union{Adm
         # this can be removed once, JuMP.jl/issues/2120 is resolved
         var(pm, n, :va)[i] = 0.0
     else
-        var(pm, n, :va)[i] = JuMP.@expression(pm.model, sum(f*inj_p[j] for (j,f) in inj_factors))
+        expr = sum(f*inj_p[j] for (j,f) in inj_factors)
+        var(pm, n, :va)[i] = JuMP.@expression(pm.model, expr)
     end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -12,6 +12,7 @@ import SCS
 import Juniper
 
 import JuMP
+import ParameterJuMP
 import JSON
 
 import LinearAlgebra


### PR DESCRIPTION
This PR resolves the following error when building a voltage angle expression with terms that are `::ParameterRef`:

```
ArgumentError: Cannot call `mutable_operate!(add_mul, ::ParameterJuMP.DoubleGenericAffExpr{Float64,VariableRef,ParameterRef}, ::Float64, ::ParameterJuMP.DoubleGenericAffExpr{Float64,VariableRef,ParameterRef})` as objects of type `ParameterJuMP.DoubleGenericAffExpr{Float64,VariableRef,ParameterRef}` cannot be modifed to equal the result of the operation. Use `operate!` instead which returns the value of the result (possibly modifying the first argument) to write generic code that also works when the type cannot be modified.
```