### PR TITLE
Jacobian Support for Basic Network

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Community-driven development and enhancement of PowerModels are welcome and enco
 This code has been developed as part of the Advanced Network Science Initiative at Los Alamos National Laboratory.
 The primary developer is Carleton Coffrin (@ccoffrin) with support from the following contributors,
 - Per Aaslid (@peraaslid) SINTEF ER, Branch flow storage model and linear branch flow formulation
-- Juan Luis Barbería (@jbarberia) UTN-BA, PSS(R)E v33 data export
+- Juan Luis Barbería (@jbarberia) UTN-BA, PSS(R)E v33 data export, Jacobian support for basic network data
 - Russell Bent (@rb004f) LANL, Matpower export, TNEP problem specification
 - Jose Daniel Lara (@jd-lara) Berkeley, Julia v1.0 compatibility
 - Jay Dave (@jay-dave) KU Leuven, LPAC for TNEP and OTS problems

--- a/src/core/data_basic.jl
+++ b/src/core/data_basic.jl
@@ -389,25 +389,19 @@ end
 Computes the jacobian submatrices
 H = dP/dδ
 L = dQ/dV
+
+The derivatives are ordered according to the bus number, 
+H[1, 1] is ∂P_1 / ∂δ_1
+H[1, 2] is ∂P_1 / ∂δ_2
+
+It does not exclude PV buses rows and columns
 """
 function calc_basic_decoupled_jacobian_matrices(data::Dict{String,<:Any})
-    if !get(data, "basic_network", false)
-        Memento.warn(_LOGGER, "calc_basic_jacobian_matrix requires basic network data and given data may be incompatible. make_basic_network can be used to transform data into the appropriate form.")
-    end
-    v = calc_basic_bus_voltage(data)
-    calc_basic_decoupled_jacobian_matrices(data, v)
-end
-
-"""
-Computes the jacobian submatrices
-H = dP/dδ
-L = dQ/dV
-"""
-function calc_basic_decoupled_jacobian_matrices(data::Dict{String,<:Any}, v::Vector{ComplexF64})
     if !get(data, "basic_network", false)
         Memento.warn(_LOGGER, "calc_basic_decoupled_jacobian_matrices requires basic network data and given data may be incompatible. make_basic_network can be used to transform data into the appropriate form.")
     end
     num_bus = length(data["bus"])
+    v = calc_basic_bus_voltage(data)
     vm, va = abs.(v), angle.(v)
     am = calc_admittance_matrix(data)
     neighbors = [Set{Int}([i]) for i in 1:num_bus]
@@ -462,7 +456,6 @@ function calc_basic_decoupled_jacobian_matrices(data::Dict{String,<:Any}, v::Vec
     return H, L
 end
 
-
 """
 given a basic network data dict, returns a sparse real valued Jacobian matrix
 of the ac power flow problem.  The power variables are ordered by p and then q
@@ -472,21 +465,8 @@ function calc_basic_jacobian_matrix(data::Dict{String,<:Any})
     if !get(data, "basic_network", false)
         Memento.warn(_LOGGER, "calc_basic_jacobian_matrix requires basic network data and given data may be incompatible. make_basic_network can be used to transform data into the appropriate form.")
     end
-    v = calc_basic_bus_voltage(data)
-    calc_basic_jacobian_matrix(data, v)
-end
-
-
-"""
-given a basic network data dict, returns a sparse real valued Jacobian matrix
-of the ac power flow problem.  The power variables are ordered by p and then q
-while voltage values are ordered by voltage angle and then voltage magnitude.
-"""
-function calc_basic_jacobian_matrix(data::Dict{String,<:Any}, v::Vector{ComplexF64})
-    if !get(data, "basic_network", false)
-        Memento.warn(_LOGGER, "calc_basic_jacobian_matrix requires basic network data and given data may be incompatible. make_basic_network can be used to transform data into the appropriate form.")
-    end
     num_bus = length(data["bus"])
+    v = calc_basic_bus_voltage(data)
     vm, va = abs.(v), angle.(v)
     am = calc_admittance_matrix(data)
     neighbors = [Set{Int}([i]) for i in 1:num_bus]
@@ -559,160 +539,4 @@ function calc_basic_jacobian_matrix(data::Dict{String,<:Any}, v::Vector{ComplexF
         end
     end
     return J
-end
-
-"""
-given a basic network data dict, computes a decoupled Newton Raphson AC power flow
-"""
-function compute_basic_decoupled_ac_pf!(data::Dict{String, Any})
-    if !get(data, "basic_network", false)
-        Memento.warn(_LOGGER, "compute_basic_decoupled_ac_pf! requires basic network data and given data may be incompatible. make_basic_network can be used to transform data into the appropriate form.")
-    end
-    bus_num = length(data["bus"])
-    gen_num = length(data["gen"])
-
-    # Count the number of generators per bus
-    gen_per_bus = Dict()
-    for (i, gen) in data["gen"]
-        bus_i = gen["gen_bus"]
-        gen_per_bus[bus_i] = get(gen_per_bus, bus_i, 0) + 1
-
-        # Update set point in PV buses
-        if data["bus"]["$bus_i"]["bus_type"] == 2
-            data["bus"]["$bus_i"]["vm"] = gen["vg"]
-        end
-    end
-
-    Y = calc_basic_admittance_matrix(data)
-    tol = 1e-4
-    itr_max = 20
-    itr = 0
-    while itr < itr_max
-        # STEP 1: Compute mismatch and check convergence
-        V = calc_basic_bus_voltage(data)
-        S = calc_basic_bus_injection(data)
-        Si = V .* conj(Y * V)
-        delta_P, delta_Q = real(S - Si), imag(S - Si)
-
-        if LinearAlgebra.normInf([delta_P; delta_Q]) < tol
-            break
-        end
-
-        # STEP 2: Compute the jacobian submatrices
-        H, L = calc_basic_decoupled_jacobian_matrices(data, V)
-
-        # STEP 3: Update step
-        va = H \ delta_P
-        vm = L \ delta_Q
-
-        # STEP 4
-        # update voltage variables
-        for i in 1:bus_num
-            bus_type = data["bus"]["$(i)"]["bus_type"]
-            if bus_type == 1
-                data["bus"]["$(i)"]["va"] = data["bus"]["$(i)"]["va"] + va[i]
-                data["bus"]["$(i)"]["vm"] = data["bus"]["$(i)"]["vm"] + vm[i] * data["bus"]["$(i)"]["vm"] 
-            end
-            if bus_type == 2
-                data["bus"]["$(i)"]["va"] = data["bus"]["$(i)"]["va"] + va[i]
-            end
-        end
-        # update power variables
-        for i in 1:gen_num
-            bus_i = data["gen"]["$i"]["gen_bus"]
-            bus_type = data["bus"]["$bus_i"]["bus_type"]
-            num_gens = gen_per_bus[bus_i]
-
-            if bus_type == 2
-                data["gen"]["$i"]["qg"] = data["gen"]["$i"]["qg"] - delta_Q[bus_i] / num_gens # TODO it is ok for multiples gens in same bus?
-            else bus_type == 3
-                data["gen"]["$i"]["qg"] = data["gen"]["$i"]["qg"] - delta_Q[bus_i] / num_gens
-                data["gen"]["$i"]["pg"] = data["gen"]["$i"]["pg"] - delta_P[bus_i] / num_gens
-            end
-        end
-        # update iteration counter
-        itr += 1
-    end
-
-    if itr == itr_max
-        Memento.warn(_LOGGER, "Max iteration limit")
-    end
-end
-
-"""
-given a basic network data dict, computes a Newton Raphson AC power flow
-"""
-function compute_basic_ac_pf!(data::Dict{String, Any})
-    if !get(data, "basic_network", false)
-        Memento.warn(_LOGGER, "compute_basic_ac_pf requires basic network data and given data may be incompatible. make_basic_network can be used to transform data into the appropriate form.")
-    end
-    bus_num = length(data["bus"])
-    gen_num = length(data["gen"])
-
-    # Count the number of generators per bus
-    gen_per_bus = Dict()
-    for (i, gen) in data["gen"]
-        bus_i = gen["gen_bus"]
-        gen_per_bus[bus_i] = get(gen_per_bus, bus_i, 0) + 1
-
-        # Update set point in PV buses
-        if data["bus"]["$bus_i"]["bus_type"] == 2
-            data["bus"]["$bus_i"]["vm"] = gen["vg"]
-        end
-    end
-
-    Y = calc_basic_admittance_matrix(data)
-    tol = 1e-4
-    itr_max = 20
-    itr = 0
-
-    while itr < itr_max
-        # STEP 1: Compute mismatch and check convergence
-        V = calc_basic_bus_voltage(data)
-        S = calc_basic_bus_injection(data)
-        Si = V .* conj(Y * V)
-        delta_P, delta_Q = real(S - Si), imag(S - Si)
-
-        if LinearAlgebra.normInf([delta_P; delta_Q]) < tol
-            break
-        end
-
-        # STEP 2: Compute the jacobian
-        J = calc_basic_jacobian_matrix(data, V)
-
-        # STEP 3: Update step
-        x = J \ [delta_P; delta_Q]
-
-        # STEP 4
-        # update voltage variables
-        for i in 1:bus_num
-            bus_type = data["bus"]["$(i)"]["bus_type"]
-            if bus_type == 1
-                data["bus"]["$(i)"]["va"] = data["bus"]["$(i)"]["va"] + x[i]
-                data["bus"]["$(i)"]["vm"] = data["bus"]["$(i)"]["vm"] + x[i+bus_num] * data["bus"]["$(i)"]["vm"] 
-            end
-            if bus_type == 2
-                data["bus"]["$(i)"]["va"] = data["bus"]["$(i)"]["va"] + x[i]
-            end
-        end
-        # update power variables
-        for i in 1:gen_num
-            bus_i = data["gen"]["$i"]["gen_bus"]
-            bus_type = data["bus"]["$bus_i"]["bus_type"]
-            num_gens = gen_per_bus[bus_i]
-
-            if bus_type == 2
-                data["gen"]["$i"]["qg"] = data["gen"]["$i"]["qg"] - delta_Q[bus_i] / num_gens # TODO it is ok for multiples gens in same bus?
-            else bus_type == 3
-                data["gen"]["$i"]["qg"] = data["gen"]["$i"]["qg"] - delta_Q[bus_i] / num_gens
-                data["gen"]["$i"]["pg"] = data["gen"]["$i"]["pg"] - delta_P[bus_i] / num_gens
-            end
-        end
-        # update iteration counter
-        itr += 1
-    end
-
-    if itr == itr_max
-        Memento.warn(_LOGGER, "Max iteration limit")
-    end
 end

--- a/test/common.jl
+++ b/test/common.jl
@@ -68,3 +68,81 @@ end
 function active_power_served(result)
     return sum([load["pd"] for (i,load) in result["solution"]["load"]])
 end
+
+"""
+An AC Power Flow Solver from scratch. 
+"""
+function compute_basic_ac_pf!(data::Dict{String, Any}; decoupled=false)
+    if !get(data, "basic_network", false)
+        Memento.warn(_LOGGER, "compute_basic_ac_pf requires basic network data and given data may be incompatible. make_basic_network can be used to transform data into the appropriate form.")
+    end
+    bus_num = length(data["bus"])
+    gen_num = length(data["gen"])
+
+    # Count the number of generators per bus
+    gen_per_bus = Dict()
+    for (i, gen) in data["gen"]
+        bus_i = gen["gen_bus"]
+        gen_per_bus[bus_i] = get(gen_per_bus, bus_i, 0) + 1
+        # Update set point in PV buses
+        if data["bus"]["$bus_i"]["bus_type"] == 2
+            data["bus"]["$bus_i"]["vm"] = gen["vg"]
+        end
+    end
+
+    Y = calc_basic_admittance_matrix(data)
+    tol = 1e-4
+    itr_max = 20
+    itr = 0
+
+    while itr < itr_max
+        # STEP 1: Compute mismatch and check convergence
+        V = calc_basic_bus_voltage(data)
+        S = calc_basic_bus_injection(data)
+        Si = V .* conj(Y * V)
+        delta_P, delta_Q = real(S - Si), imag(S - Si)
+        if LinearAlgebra.normInf([delta_P; delta_Q]) < tol
+            break
+        end
+        # STEP 2 and 3: Compute the jacobian and update step
+        if !decoupled
+            J = calc_basic_jacobian_matrix(data)
+            x = J \ [delta_P; delta_Q]
+        else
+            H, L = calc_basic_decoupled_jacobian_matrices(data)
+            va = H \ delta_P
+            vm = L \ delta_Q
+            x = [va; vm]
+        end
+        # STEP 4
+        # update voltage variables
+        for i in 1:bus_num
+            bus_type = data["bus"]["$(i)"]["bus_type"]
+            if bus_type == 1
+                data["bus"]["$(i)"]["va"] = data["bus"]["$(i)"]["va"] + x[i]
+                data["bus"]["$(i)"]["vm"] = data["bus"]["$(i)"]["vm"] + x[i+bus_num] * data["bus"]["$(i)"]["vm"] 
+            end
+            if bus_type == 2
+                data["bus"]["$(i)"]["va"] = data["bus"]["$(i)"]["va"] + x[i]
+            end
+        end
+        # update power variables
+        for i in 1:gen_num
+            bus_i = data["gen"]["$i"]["gen_bus"]
+            bus_type = data["bus"]["$bus_i"]["bus_type"]
+            num_gens = gen_per_bus[bus_i]
+            if bus_type == 2
+                data["gen"]["$i"]["qg"] = data["gen"]["$i"]["qg"] - delta_Q[bus_i] / num_gens # TODO it is ok for multiples gens in same bus?
+            else bus_type == 3
+                data["gen"]["$i"]["qg"] = data["gen"]["$i"]["qg"] - delta_Q[bus_i] / num_gens
+                data["gen"]["$i"]["pg"] = data["gen"]["$i"]["pg"] - delta_P[bus_i] / num_gens
+            end
+        end
+        # update iteration counter
+        itr += 1
+    end
+    if itr == itr_max
+        Memento.warn(_LOGGER, "Max iteration limit")
+        @assert false
+    end
+end

--- a/test/data-basic.jl
+++ b/test/data-basic.jl
@@ -189,39 +189,61 @@ end
         end
     end
 
-    @testset "test basic jacobian" begin  
+    @testset "test basic jacobian" begin
+        @testset "5-bus-case" begin
+            data = make_basic_network(PowerModels.parse_file("../test/data/matpower/case5.m"))
+            for (i, bus) in data["bus"] # All buses PQ
+                bus["bus_type"] = 1
+            end
+            J = PowerModels.calc_basic_jacobian_matrix(data);
+
+            num_bus = length(data["bus"])
+            
+            @test size(J)[2] == num_bus * 2
+            @test size(J)[1] == num_bus * 2
+            @test isapprox(LinearAlgebra.det(J), 1524.5588; atol=1e-4)
+            
+            # PQ bus - diagonal
+            @test isapprox(J[1, 1], 225.5254; atol=1e-4)                  # dP/dva diagonal
+            @test isapprox(J[num_bus+1, 1], -20.7074; atol=1e-4)          # dQ/dva diagonal
+            @test isapprox(J[1, num_bus+1], 23.7940; atol=1e-4)           # dP/dvm diagonal
+            @test isapprox(J[num_bus+1, num_bus+1], 219.4434; atol=1e-4)  # dQ/dvm diagonal
+        end
+        
         @testset "24-bus-case" begin
             data = make_basic_network(PowerModels.parse_file("../test/data/matpower/case24.m"))
             J = PowerModels.calc_basic_jacobian_matrix(data)
             
             num_bus = length(data["bus"])
-
+            
             @test size(J)[1] == num_bus * 2
             @test size(J)[2] == num_bus * 2
+            @test isapprox(LinearAlgebra.det(J), 3.133520767308452e+57)
+            @test isapprox(sum(J), -3.5289; atol=1e-4)
 
             # PV bus - diagonal
-            @test isapprox(J[1, 1], 90.2500; atol = 1e-4)                   # dP/dva diagonal
-            @test isapprox(J[num_bus+1, 1], -17.2488; atol = 1e-4)          # dQ/dva diagonal
-            @test isapprox(J[1, num_bus+1], 0.0; atol = 1e-4)               # dP/dvm diagonal
-            @test isapprox(J[num_bus+1, num_bus+1], 1.0; atol = 1e-4)       # dQ/dvm diagonal
+            @test isapprox(J[1, 1], 90.2500; atol=1e-4)                   # dP/dva diagonal
+            @test isapprox(J[num_bus+1, 1], -17.2488; atol=1e-4)          # dQ/dva diagonal
+            @test isapprox(J[1, num_bus+1], 0.0; atol=1e-4)               # dP/dvm diagonal
+            @test isapprox(J[num_bus+1, num_bus+1], 1.0; atol=1e-4)       # dQ/dvm diagonal
             
             # PV bus - non-diagonal
-            @test isapprox(J[1, 2], -73.6728; atol = 1e-4)                  # dP/dva non-diagonal
-            @test isapprox(J[num_bus+1, 2], 13.8150; atol = 1e-4)           # dQ/dva non-diagonal
-            @test isapprox(J[1, num_bus+2], 0.0; atol = 1e-4)               # dP/dvm non-diagonal
-            @test isapprox(J[num_bus+1, num_bus+2], 0.0; atol = 1e-4)       # dQ/dvm non-diagonal
+            @test isapprox(J[1, 2], -73.6728; atol=1e-4)                  # dP/dva non-diagonal
+            @test isapprox(J[num_bus+1, 2], 13.8150; atol=1e-4)           # dQ/dva non-diagonal
+            @test isapprox(J[1, num_bus+2], 0.0; atol=1e-4)               # dP/dvm non-diagonal
+            @test isapprox(J[num_bus+1, num_bus+2], 0.0; atol=1e-4)       # dQ/dvm non-diagonal
             
             # PQ bus - diagonal
-            @test isapprox(J[3, 3], 24.5256; atol = 1e-4)                   # dP/dva diagonal
-            @test isapprox(J[num_bus+3, 3], -5.3917; atol = 1e-4)           # dQ/dva diagonal
-            @test isapprox(J[3, num_bus+3], 1.7671; atol = 1e-4)            # dP/dvm diagonal 
-            @test isapprox(J[num_bus+3, num_bus+3], 23.4586; atol = 1e-4)   # dQ/dvm diagonal
+            @test isapprox(J[3, 3], 24.5256; atol=1e-4)                   # dP/dva diagonal
+            @test isapprox(J[num_bus+3, 3], -5.3917; atol=1e-4)           # dQ/dva diagonal
+            @test isapprox(J[3, num_bus+3], 1.7671; atol=1e-4)            # dP/dvm diagonal 
+            @test isapprox(J[num_bus+3, num_bus+3], 23.4586; atol=1e-4)   # dQ/dvm diagonal
             
             # PQ bus - non-diagonal
-            @test isapprox(J[3, 9], -8.1751; atol = 1e-4)                  # dP/dva non-diagonal
-            @test isapprox(J[num_bus+3, 9], 2.2208; atol = 1e-4)           # dQ/dva non-diagonal
-            @test isapprox(J[3, num_bus+9], -2.1624; atol = 1e-4)          # dP/dvm non-diagonal
-            @test isapprox(J[num_bus+3, num_bus+9], -7.9603; atol = 1e-4)   # dQ/dvm non-diagonal
+            @test isapprox(J[3, 9], -8.1751; atol=1e-4)                  # dP/dva non-diagonal
+            @test isapprox(J[num_bus+3, 9], 2.2208; atol=1e-4)           # dQ/dva non-diagonal
+            @test isapprox(J[3, num_bus+9], -2.1624; atol=1e-4)          # dP/dvm non-diagonal
+            @test isapprox(J[num_bus+3, num_bus+9], -7.9603; atol=1e-4)  # dQ/dvm non-diagonal
         end
 
         @testset "30-bus-case-decoupled-matrices" begin
@@ -229,13 +251,12 @@ end
             H, L = calc_basic_decoupled_jacobian_matrices(data)
             J = calc_basic_jacobian_matrix(data)
             n = length(data["bus"])
-            @test isapprox(J[1:n, 1:n], H; atol = 1e-6)
-            @test isapprox(J[n+1:end, n+1:end], L; atol = 1e-6)
+            @test isapprox(J[1:n, 1:n], H; atol=1e-6)
+            @test isapprox(J[n+1:end, n+1:end], L; atol=1e-6)
         end
     end
 
     @testset "basic ac power flow" begin
-
         @testset "9-bus-case" begin     
             data = make_basic_network(PowerModels.parse_file("../test/data/matpower/case9.m"))
             solution = compute_ac_pf(data)["solution"]

--- a/test/data-basic.jl
+++ b/test/data-basic.jl
@@ -189,15 +189,49 @@ end
         end
     end
 
-    # @testset "basic jacobian matrix" begin
-    #     data = make_basic_network(PowerModels.parse_file("../test/data/matpower/case5_sw.m"))
-
-    #     J = calc_basic_jacobian_matrix(data)
-
-    #     @test size(J, 1) == 2*length(data["bus"])
-    #     @test size(J, 2) == 2*length(data["bus"])
-    #     @test isapprox(sum(J), 10.0933; atol=1e-4)
-    # end
+    @testset "test basic jacobian" begin
+        function test_size(data, J)
+            buses = 0; pv = 0; pq = 0;
+            for (_, bus) in data["bus"]
+                bus_type = bus["bus_type"]
+                if bus_type == 1
+                    pq += 1
+                    buses += 1
+                elseif bus_type == 2
+                    pv += 1
+                    buses += 1
+                elseif bus_type == 3
+                    buses += 1 
+                end
+            end
+            matrix_size = 2*(buses - 1) - pv
+            size(J) == (matrix_size, matrix_size)
+        end
+        
+        @testset "14-bus-case" begin
+            data = make_basic_network(PowerModels.parse_file("../test/data/matpower/case14.m"))
+            J = PowerModels.calc_basic_jacobian_matrix(data)
+    
+            @test test_size(data, J)
+            @test isapprox(J[1, 1], 32.7603; atol = 1e-4)
+            @test isapprox(J[1, 14], -1.2558, atol = 1e-4)
+            @test isapprox(J[14, 1], 2.2955, atol = 1e-4)
+            @test isapprox(J[14, 14], 39.4697, atol = 1e-4)
+            @test isapprox(sum(J), 63.1; atol = 1e-1)
+        end
+    
+        @testset "30-bus-case" begin
+            data = make_basic_network(PowerModels.parse_file("../test/data/matpower/case30.m"))
+            J = PowerModels.calc_basic_jacobian_matrix(data)
+    
+            @test test_size(data, J)
+            @test isapprox(J[1, 1], 32.7707; atol = 1e-4) 
+            @test isapprox(J[1, 31], -1.3548; atol = 1e-4)
+            @test isapprox(J[31, 1], 2.1783; atol = 1e-4)
+            @test isapprox(J[31, 31], 55.7408; atol = 1e-4)
+            @test isapprox(sum(J), 82.4; atol = 1e-1)
+        end
+    end
 
 end
 

--- a/test/data-basic.jl
+++ b/test/data-basic.jl
@@ -201,7 +201,7 @@ end
             
             @test size(J)[2] == num_bus * 2
             @test size(J)[1] == num_bus * 2
-            @test isapprox(LinearAlgebra.det(J), 1524.5588; atol=1e-4)
+            @test isapprox(sum(J), 1.0098308; atol=1e-6)
             
             # PQ bus - diagonal
             @test isapprox(J[1, 1], 225.5254; atol=1e-4)                  # dP/dva diagonal
@@ -218,7 +218,6 @@ end
             
             @test size(J)[1] == num_bus * 2
             @test size(J)[2] == num_bus * 2
-            @test isapprox(LinearAlgebra.det(J), 3.133520767308452e+57)
             @test isapprox(sum(J), -3.5289; atol=1e-4)
 
             # PV bus - diagonal

--- a/test/data-basic.jl
+++ b/test/data-basic.jl
@@ -189,7 +189,7 @@ end
         end
     end
 
-    @testset "test basic jacobian" begin       
+    @testset "test basic jacobian" begin  
         @testset "24-bus-case" begin
             data = make_basic_network(PowerModels.parse_file("../test/data/matpower/case24.m"))
             J = PowerModels.calc_basic_jacobian_matrix(data)
@@ -223,10 +223,8 @@ end
             @test isapprox(J[3, num_bus+9], -2.1624; atol = 1e-4)          # dP/dvm non-diagonal
             @test isapprox(J[num_bus+3, num_bus+9], -7.9603; atol = 1e-4)   # dQ/dvm non-diagonal
         end
-    end
 
-    @testset "basic decoupled matrices" begin
-        @testset "30-bus-case" begin
+        @testset "30-bus-case-decoupled-matrices" begin
             data = make_basic_network(PowerModels.parse_file("../test/data/matpower/case24.m"))
             H, L = calc_basic_decoupled_jacobian_matrices(data)
             J = calc_basic_jacobian_matrix(data)
@@ -236,12 +234,13 @@ end
         end
     end
 
-    @testset "basic decoupled ac power flow" begin
-        @testset "9-bus-case" begin
+    @testset "basic ac power flow" begin
+
+        @testset "9-bus-case" begin     
             data = make_basic_network(PowerModels.parse_file("../test/data/matpower/case9.m"))
             solution = compute_ac_pf(data)["solution"]
 
-            compute_basic_decoupled_ac_pf!(data)
+            compute_basic_ac_pf!(data)
             
             for (i, bus) in data["bus"]
                 @test isapprox(solution["bus"][i]["va"], bus["va"]; atol=1e-4)
@@ -253,14 +252,12 @@ end
                 @test isapprox(solution["gen"][i]["qg"], gen["qg"]; atol=1e-4)
             end
         end
-    end
 
-    @testset "basic ac power flow" begin
         @testset "9-bus-case" begin     
             data = make_basic_network(PowerModels.parse_file("../test/data/matpower/case9.m"))
             solution = compute_ac_pf(data)["solution"]
 
-            compute_basic_ac_pf!(data)
+            compute_basic_ac_pf!(data; decoupled=true)
             
             for (i, bus) in data["bus"]
                 @test isapprox(solution["bus"][i]["va"], bus["va"]; atol=1e-4)
@@ -305,10 +302,8 @@ end
             for (i, gen) in data["gen"]
                 @test isapprox(solution["gen"][i]["pg"], gen["pg"]; atol=1e-4)
                 @test isapprox(solution["gen"][i]["qg"], gen["qg"]; atol=1e-4)
-            end
-            =#
+            end =#
         end
-        
     end
 end
 

--- a/test/data-basic.jl
+++ b/test/data-basic.jl
@@ -225,8 +225,38 @@ end
         end
     end
 
+    @testset "basic decoupled matrices" begin
+        @testset "30-bus-case" begin
+            data = make_basic_network(PowerModels.parse_file("../test/data/matpower/case24.m"))
+            H, L = calc_basic_decoupled_jacobian_matrices(data)
+            J = calc_basic_jacobian_matrix(data)
+            n = length(data["bus"])
+            @test isapprox(J[1:n, 1:n], H; atol = 1e-6)
+            @test isapprox(J[n+1:end, n+1:end], L; atol = 1e-6)
+        end
+    end
+
+    @testset "basic decoupled ac power flow" begin
+        @testset "9-bus-case" begin
+            data = make_basic_network(PowerModels.parse_file("../test/data/matpower/case9.m"))
+            solution = compute_ac_pf(data)["solution"]
+
+            compute_basic_decoupled_ac_pf!(data)
+            
+            for (i, bus) in data["bus"]
+                @test isapprox(solution["bus"][i]["va"], bus["va"]; atol=1e-4)
+                @test isapprox(solution["bus"][i]["vm"], bus["vm"]; atol=1e-4)
+            end
+            
+            for (i, gen) in data["gen"]
+                @test isapprox(solution["gen"][i]["pg"], gen["pg"]; atol=1e-4)
+                @test isapprox(solution["gen"][i]["qg"], gen["qg"]; atol=1e-4)
+            end
+        end
+    end
+
     @testset "basic ac power flow" begin
-        @testset "5-bus-case" begin     
+        @testset "9-bus-case" begin     
             data = make_basic_network(PowerModels.parse_file("../test/data/matpower/case9.m"))
             solution = compute_ac_pf(data)["solution"]
 


### PR DESCRIPTION
#762

I modified the commented out version of the function that calculates the Jacobian matrix for basic networks. Also add a function to compute the sub-matrices dP/dva and dQ/dvm.

I move the from scratch AC power flow solver to `test/common.jl` because the Jacobian matrix is tested with it.