### PR TITLE
Update Project [compat]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,10 @@ PowerModels.jl Change Log
 ### Staged
 - nothing
 
-### v0.20.0
+### v0.19.3
+
 - Add support for JuMP v0.23
-- Update minimum Julia requirement v1.6 (LTS)
 - Replace CBC with HiGHS in tests
-- Updates for SCS v0.9
 
 ### v0.19.2
 - Rename `run_*` methods to `solve_*` and add depreciation warnings (#649)

--- a/Project.toml
+++ b/Project.toml
@@ -14,15 +14,15 @@ NLsolve = "2774e3e8-f4cf-5e23-947b-6d7e65073b56"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [compat]
-HiGHS = "1"
+HiGHS = "~0.3, 1"
 InfrastructureModels = "~0.6, ~0.7"
-Ipopt = "1"
+Ipopt = "~0.8, ~0.9, ~1"
 JSON = "~0.18, ~0.19, ~0.20, ~0.21"
 JuMP = "~0.22, ~0.23"
 Juniper = "~0.8, ~0.9"
 Memento = "1"
 NLsolve = "4"
-SCS = "1"
+SCS = "~0.8, ~0.9, ~1"
 julia = "1"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -2,7 +2,7 @@ name = "PowerModels"
 uuid = "c36e90e8-916a-50a6-bd94-075b64ef4655"
 authors = ["Carleton Coffrin"]
 repo = "https://github.com/lanl-ansi/PowerModels.jl"
-version = "0.20.0"
+version = "0.19.3"
 
 [deps]
 InfrastructureModels = "2030c09a-7f63-5d83-885d-db604e0e9cc0"
@@ -14,16 +14,16 @@ NLsolve = "2774e3e8-f4cf-5e23-947b-6d7e65073b56"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [compat]
-HiGHS = ">= 0.3"
+HiGHS = "1"
 InfrastructureModels = "~0.6, ~0.7"
-Ipopt = ">= 0.8"
+Ipopt = "1"
 JSON = "~0.18, ~0.19, ~0.20, ~0.21"
-JuMP = "~0.23"
-Juniper = ">= 0.8"
-Memento = "~1.0, ~1.1, ~1.2, ~1.3"
-NLsolve = "4.0"
-SCS = ">= 0.9"
-julia = "1.6"
+JuMP = "~0.22, ~0.23"
+Juniper = "~0.8, ~0.9"
+Memento = "1"
+NLsolve = "4"
+SCS = "1"
+julia = "1"
 
 [extras]
 HiGHS = "87dc4568-4c63-4d18-b0c0-bb2238e4078b"


### PR DESCRIPTION
I think you can do this as a non-breaking release.

You _might_ have someone complain that the tests are broken on Julia 1.0, but PowerModels should work.

And we don't explicitly test JuMP v0.22, but you didn't change anything so there shouldn't be an issue. We also don't test earlier versions of InfrastructureModels or JSON, but there's no issue including older compats with them.