### PR TITLE
Make SDP Solution Reporting Consistent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@ PowerModels.jl Change Log
 =========================
 
 ### Staged
-- nothing
+- Fix SDP solution reporting consistency (#833)
 
 ### v0.19.6
 - Add specialized version of `sol_component_fixed` for PowerModels (#821)

--- a/src/form/wrm.jl
+++ b/src/form/wrm.jl
@@ -104,6 +104,8 @@ function variable_bus_voltage(pm::AbstractWRMModel; nw::Int=nw_id_default, bound
         var(pm, nw, :wr)[(i,j)] = WR[w_fr_index, w_to_index]
         var(pm, nw, :wi)[(i,j)] = WI[w_fr_index, w_to_index]
     end
+    report && sol_component_value_buspair(pm, nw, :buspairs, :wr, ids(pm, nw, :buspairs), var(pm, nw)[:wr])
+    report && sol_component_value_buspair(pm, nw, :buspairs, :wi, ids(pm, nw, :buspairs), var(pm, nw)[:wi])
 end
 
 
@@ -225,6 +227,10 @@ function variable_bus_voltage(pm::AbstractSparseSDPWRMModel; nw::Int=nw_id_defau
             end
         end
     end
+
+    report && sol_component_value(pm, nw, :bus, :w, ids(pm, nw, :bus), var(pm, nw)[:w])
+    report && sol_component_value_buspair(pm, nw, :buspairs, :wr, ids(pm, nw, :buspairs), var(pm, nw)[:wr])
+    report && sol_component_value_buspair(pm, nw, :buspairs, :wi, ids(pm, nw, :buspairs), var(pm, nw)[:wi])
 end
 
 

--- a/test/opf.jl
+++ b/test/opf.jl
@@ -911,9 +911,9 @@ end
 
         @test haskey(result["solution"],"WR")
         @test haskey(result["solution"],"WI")
-        @test isapprox(result["solution"]["bus"]["1"]["w"], 1.210, atol = 1e-2)
+        @test isapprox(result["solution"]["bus"]["1"]["w"], 1.179, atol = 1e-2)
         @test isapprox(result["solution"]["branch"]["1"]["wr"], 0.941, atol = 1e-2)
-        @test isapprox(result["solution"]["branch"]["1"]["wi"], 0.285, atol = 1e-2)
+        @test isapprox(result["solution"]["branch"]["1"]["wi"], 0.269, atol = 1e-2)
     end
     @testset "5-bus asymmetric case" begin
         result = run_opf("../test/data/matpower/case5_asym.m", SDPWRMPowerModel, sdp_solver)
@@ -974,9 +974,9 @@ end
 
         @test haskey(result["solution"]["w_group"]["1"],"WR")
         @test haskey(result["solution"]["w_group"]["1"],"WI")
-        @test isapprox(result["solution"]["bus"]["1"]["w"], 1.210, atol = 1e-2)
+        @test isapprox(result["solution"]["bus"]["1"]["w"], 1.179, atol = 1e-2)
         @test isapprox(result["solution"]["branch"]["1"]["wr"], 0.941, atol = 1e-2)
-        @test isapprox(result["solution"]["branch"]["1"]["wi"], 0.285, atol = 1e-2)
+        @test isapprox(result["solution"]["branch"]["1"]["wi"], 0.269, atol = 1e-2)
     end
     @testset "5-bus with asymmetric line charge" begin
         result = run_opf("../test/data/pti/case5_alc.raw", SparseSDPWRMPowerModel, sdp_solver)

--- a/test/opf.jl
+++ b/test/opf.jl
@@ -908,6 +908,12 @@ end
         @test result["termination_status"] == OPTIMAL
         @test isapprox(result["objective"], 5818.00; atol = 1e1)
         #@test isapprox(result["objective"], 5852.51; atol = 1e1)
+
+        @test haskey(result["solution"],"WR")
+        @test haskey(result["solution"],"WI")
+        @test isapprox(result["solution"]["bus"]["1"]["w"], 1.210, atol = 1e-2)
+        @test isapprox(result["solution"]["branch"]["1"]["wr"], 0.941, atol = 1e-2)
+        @test isapprox(result["solution"]["branch"]["1"]["wi"], 0.285, atol = 1e-2)
     end
     @testset "5-bus asymmetric case" begin
         result = run_opf("../test/data/matpower/case5_asym.m", SDPWRMPowerModel, sdp_solver)
@@ -965,6 +971,12 @@ end
         #@test isapprox(result["objective"], 5851.23; atol = 1e1)
         @test isapprox(result["objective"], 5818.00; atol = 1e1)
         #@test isapprox(result["objective"], 5852.51; atol = 1e1)
+
+        @test haskey(result["solution"]["w_group"]["1"],"WR")
+        @test haskey(result["solution"]["w_group"]["1"],"WI")
+        @test isapprox(result["solution"]["bus"]["1"]["w"], 1.210, atol = 1e-2)
+        @test isapprox(result["solution"]["branch"]["1"]["wr"], 0.941, atol = 1e-2)
+        @test isapprox(result["solution"]["branch"]["1"]["wi"], 0.285, atol = 1e-2)
     end
     @testset "5-bus with asymmetric line charge" begin
         result = run_opf("../test/data/pti/case5_alc.raw", SparseSDPWRMPowerModel, sdp_solver)


### PR DESCRIPTION
Add `w` values to buses and `wr,wi` to branches in all model variants.

Producing a consistent `W` matrix in all cases could be quite time consuming and memory intensive defeating the objective of the sparse solver.  Reporting these minimal values provides a user friendly solution.

Closes #833