### PR TITLE
Faster PTDF matrix computation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ PowerModels.jl Change Log
 
 ### Staged
 - Improved network data model documentation
+- Faster PTDF matrix computation (#849)
 
 ### v0.19.7
 - Improve linear algebra test robustness (#827)

--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ The primary developer is Carleton Coffrin (@ccoffrin) with support from the foll
 - Miles Lubin (@mlubin) MIT, Julia/JuMP advise
 - Yeesian Ng (@yeesian) MIT, Documenter.jl setup
 - Kaarthik Sundar (@kaarthiksundar) LANL, OBBT utility
+- Mathieu Tanneau (@mtanneau) Georgia Tech, PTDF matrix computation
 - Byron Tasseff (@tasseff) LANL, multi-infrastructure updates
 
 

--- a/src/core/admittance_matrix.jl
+++ b/src/core/admittance_matrix.jl
@@ -136,7 +136,18 @@ end
 Base.show(io::IO, x::AdmittanceMatrixInverse{<:Number}) = print(io, "AdmittanceMatrixInverse($(length(x.idx_to_bus)) buses, $(length(x.matrix)) entries)")
 
 
-"note, data should be a PowerModels network data model; only supports networks with exactly one refrence bus"
+"""
+    calc_susceptance_matrix_inv(data)
+
+Compute the inverse of the network's susceptance matrix.
+
+Note: `data`` should be a PowerModels network data model; only supports networks with exactly one refrence bus.
+
+While the susceptance matrix is sparse, its inverse it typically quite dense.
+This implementation first computes a sparse factorization, then recovers the (dense)
+    matrix inverse via backward substitution. This is more efficient
+    than directly computing a dense inverse with `LinearAlgebra.inv`.
+"""
 function calc_susceptance_matrix_inv(data::Dict{String,<:Any})
     #TODO check single connected component
     sm = calc_susceptance_matrix(data)

--- a/src/core/data_basic.jl
+++ b/src/core/data_basic.jl
@@ -338,18 +338,36 @@ function calc_basic_ptdf_matrix(data::Dict{String,<:Any})
     num_bus = length(data["bus"])
     num_branch = length(data["branch"])
 
-    b_inv = calc_susceptance_matrix_inv(data).matrix
-
-    ptdf = zeros(num_branch, num_bus)
-    for (i,branch) in data["branch"]
-        branch_idx = branch["index"]
-        bus_fr = branch["f_bus"]
-        bus_to = branch["t_bus"]
-        g,b = calc_branch_y(branch)
-        for n in 1:num_bus
-            ptdf[branch_idx, n] = b*(b_inv[bus_fr, n] - b_inv[bus_to, n])
-        end
+    if num_branch == 0 || num_bus == 0
+        # no branch and/or no bus --> return an empty matrix already
+        return zeros(Float64, num_branch, num_bus)
     end
+
+    S = calc_basic_susceptance_matrix(data)
+    B = calc_basic_branch_susceptance_matrix(data)
+    i0::Int = reference_bus(data)["index"]
+    if !(i0 > 0 && i0 <= num_bus)
+        Memento.error(_LOGGER, "invalid slack bus index in calc_basic_ptdf_matrix")
+    end
+
+    # Zero-out line and column of S corresponding to slack bus and set diagonal element to 1
+    # (otherwise S is not invertible)
+    S[:, i0]  .= 0.0
+    S[i0, :]  .= 0.0
+    S[i0, i0]  = 1.0
+
+    # `S` has the form A' * D * A, which is quasi-definite, so the LDLᵀ is well-defined
+    # (assuming the underlying grid has a single connected component)
+    F = LinearAlgebra.ldlt(Symmetric(S); check=false)
+    if !LinearAlgebra.issuccess(F)
+        Memento.error(_LOGGER, "Failed factorization in calc_basic_ptdf_matrix")
+    end
+
+    # Recover the (dense) inverse of the susceptance matrix...
+    M = F \ Matrix(1.0I, num_bus, num_bus)
+    M[i0, :] .= 0.0  # zero-out the row of the slack bus
+    # ... and the PTDF matrix
+    ptdf = B * M
 
     return ptdf
 end


### PR DESCRIPTION
The current code for computing PTDF matrices (`calc_basic_ptdf_matrix`) relies on a dense matrix inverse, plus some loops that can be optimized.

This PR uses a more efficient, sparse factorization together with linear algebra operations to speed up the computation.

Performance comparison on some medium-size PGLib networks:

| casefile | before (s) | after (s) | speedup |
|:-------|--:|--:|--:|
| 1354_pegase              |     0.584 |     0.056 |    10.41 |
| 1888_rte                 |     1.781 |     0.132 |    13.51 |
| 1951_rte                 |     2.205 |     0.225 |     9.78 |
| 2000_goc                 |     1.817 |     0.117 |    15.58 |
| 2312_goc                 |     2.450 |     0.205 |    11.97 |
| 2383wp_k                 |     2.483 |     0.242 |    10.27 |
| 2736sp_k                 |     3.088 |     0.291 |    10.63 |
| 2737sop_k                |     3.349 |     0.309 |    10.83 |
| 2742_goc                 |     4.303 |     0.325 |    13.24 |
| 2746wop_k                |     3.051 |     0.292 |    10.46 |
| 2746wp_k                 |     3.505 |     0.286 |    12.24 |
| 2848_rte                 |     3.628 |     0.318 |    11.40 |
| 2853_sdet                |     4.077 |     0.311 |    13.09 |
| 2868_rte                 |     3.732 |     0.304 |    12.29 |
| 2869_pegase              |     4.711 |     0.344 |    13.70 |
| 3012wp_k                 |     3.928 |     0.316 |    12.42 |
| 3022_goc                 |     4.858 |     0.525 |     9.26 |
| 3120sp_k                 |     4.096 |     0.371 |    11.03 |
| 3375wp_k                 |     5.250 |     0.453 |    11.59 |
| 3970_goc                 |     9.686 |     0.667 |    14.53 |
| 4020_goc                 |    10.059 |     0.770 |    13.06 |
| 4601_goc                 |    12.494 |     0.904 |    13.83 |
| 4619_goc                 |    14.324 |     1.052 |    13.61 |
| 4661_sdet                |    11.810 |     0.881 |    13.40 |
| 4837_goc                 |    14.117 |     1.032 |    13.68 |
| 4917_goc                 |    13.878 |     1.059 |    13.10 |
| 6468_rte                 |    25.386 |     2.005 |    12.66 |
| 6470_rte                 |    25.223 |     1.751 |    14.41 |
| 6495_rte                 |    26.308 |     2.035 |    12.93 |
| 6515_rte                 |    26.777 |     1.826 |    14.67 |

Those timings were obtained with `@time calc_basic_ptdf_matrix(data)`. It's not the most robust benchmark, but there's a clear speedup. Machine specs (via Julia's `versioninfo`):
```
Julia Version 1.8.1
Commit afb6c60d69a (2022-09-06 15:09 UTC)
Platform Info:
  OS: Linux (x86_64-linux-gnu)
  CPU: 16 × 12th Gen Intel(R) Core(TM) i7-1260P
  WORD_SIZE: 64
  LIBM: libopenlibm
  LLVM: libLLVM-13.0.1 (ORCJIT, goldmont)
  Threads: 1 on 16 virtual cores
```