### PR TITLE
Add DC alias for constraint_ohms_y_oltc_pst

### DIFF
--- a/src/form/dcp.jl
+++ b/src/form/dcp.jl
@@ -155,7 +155,15 @@ function constraint_ohms_y_pst_to(pm::AbstractDCPModel, n::Int, f_bus, t_bus, f_
     JuMP.@constraint(pm.model, p_to == -b*(va_to - va_fr + ta))
 end
 
+""" Alias for constraint_ohms_y_pst_from"""
+function constraint_ohms_y_oltc_pst_from(pm::AbstractDCPModel, i::Int; nw::Int=nw_id_default)
+    constraint_ohms_y_pst_from(pm, i; nw=nw)
+end
 
+""" Alias for constraint_ohms_y_pst_to"""
+function constraint_ohms_y_oltc_pst_to(pm::AbstractDCPModel, i::Int; nw::Int=nw_id_default)
+    constraint_ohms_y_pst_to(pm, i; nw=nw)
+end
 
 ""
 function constraint_switch_state_closed(pm::AbstractDCPModel, n::Int, f_bus, t_bus)


### PR DESCRIPTION
Dear @ccoffrin,

Thank you for integrating the constraint_ohms_y_pst constraints into the master. I added alias functions for the DCP formulations of `constraint_ohms_y_oltc_pst_to` and `constraint_ohms_y_oltc_pst_from` functions which refer to the newly added `constraint_ohms_y_pst_to` and `constraint_ohms_y_pst_from` in dcp.jl. 
In this way, it suffices to call constraint_ohms_y_oltc_pst from constraint_template.jl for both AC and DC formulations. The DC formulation obviously lacks the possibility to change the voltages by adjusting the OLTC (tm). But this should be clear if the DC models are used.

Best regards,
Martin