### PR TITLE
Add in-place conversion to basic data format

### DIFF
--- a/src/core/data_basic.jl
+++ b/src/core/data_basic.jl
@@ -17,6 +17,30 @@ users requiring any of the features listed above for their analysis should use
 the non-basic PowerModels routines.
 """
 function make_basic_network(data::Dict{String,<:Any})
+    # These initial checks are redundant with the checks in make_basic_network!
+    # We keep them here so they run _before_ we create a deepcopy of the data
+    # The checks are fast so this redundancy has little performance impact
+    if _IM.ismultiinfrastructure(data)
+        Memento.error(_LOGGER, "make_basic_network does not support multiinfrastructure data")
+    end
+    
+    if _IM.ismultinetwork(data)
+        Memento.error(_LOGGER, "make_basic_network does not support multinetwork data")
+    end
+
+    data = deepcopy(data)
+
+    make_basic_network!(data)
+
+    return data
+end
+
+"""
+given a powermodels data dict, modifies it in-place to conform to basic network model requirements.
+
+See [`make_basic_network`](@ref) for more information.
+"""
+function make_basic_network!(data::Dict{String,<:Any})
     if _IM.ismultiinfrastructure(data)
         Memento.error(_LOGGER, "make_basic_network does not support multiinfrastructure data")
     end
@@ -24,9 +48,6 @@ function make_basic_network(data::Dict{String,<:Any})
     if _IM.ismultinetwork(data)
         Memento.error(_LOGGER, "make_basic_network does not support multinetwork data")
     end
-
-    # make a copy of data so that modifications do not change the input data
-    data = deepcopy(data)
 
     # TODO transform PWL costs into linear costs
     for (i,gen) in data["gen"]


### PR DESCRIPTION
Motivated by #913 

This PR introduces an in-place `make_basic_data!`, which has the same functionality but does not create a `deepcopy`.
The goal is to avoid the (time and memory) cost of deepcopy-ing the initial data dictionary when the user does not want to keep it.

A typical use-case would be workflows that look like `data = make_basic_network(parse_file(...))`.
This call with load the raw data dictionary with `parse_file`, then deep-copy it, convert the copy to basic format, and discard the original raw data.

Timings of `make_basic_network` after the changes: times are improved, and memory consumption is reduced.
Note: those are just the ouptut of `@time`; I did run `GC.gc()` before to reduce garbage collection, but it's not a full-fledge `@benchmark`

| Case | #buses | old time (s) | in-place time (s) | old memory (MiB) | in-place memory (MiB) |
|:--|--:|--:|--:|--:|--:|
| `1354_pegase` | 1354 | 0.21 | 0.13 | 29.4 | 20.4 |
| `2869_pegase` | 2869 | 0.60 | 0.40 | 66.7 | 48.2 |
| `9241_pegase` | 9241 | 2.50 | 1.87 | 208.3 | 145.9 |
| `13659_pegase` | 13659 | 5.44 | 4.67 | 313.0 | 227.4 |

and corresponding profile of `make_basic_network!(data)` where `data = pglib("9241_pegase")`:
![prof_inplace](https://github.com/lanl-ansi/PowerModels.jl/assets/9593025/07e9f85b-4c10-46ab-83cd-1f96a3359ce9)

Note that the above profile does not include the improvements in #914. The main (and expected) outcome is that the time spent deep-copying at the beginning is gone.