### PR TITLE
No deepcopy when renumbering components

### DIFF
--- a/src/core/data_basic.jl
+++ b/src/core/data_basic.jl
@@ -110,7 +110,7 @@ function make_basic_network(data::Dict{String,<:Any})
     # re-number non-bus component ids
     for comp_key in keys(pm_component_status)
         if comp_key != "bus"
-            data[comp_key] = _renumber_components(data[comp_key])
+            data[comp_key] = _renumber_components!(data[comp_key])
         end
     end
 
@@ -148,17 +148,18 @@ end
 given a component dict returns a new dict where components have been renumbered
 from 1-to-n ordered by the increasing values of the orginal component id.
 """
-function _renumber_components(comp_dict::Dict{String,<:Any})
-    renumbered_dict = Dict{String,Any}()
+function _renumber_components!(comp_dict::Dict{String,<:Any})
+    comp_ordered = sort([(comp["index"], comp) for (i, comp) in comp_dict], by=(x) -> x[1])
 
-    comp_ordered = sort([comp for (i,comp) in comp_dict], by=(x) -> x["index"])
-
-    for (i,comp) in enumerate(comp_ordered)
-        comp["index"] = i
-        renumbered_dict["$i"] = comp
+    # Delete existing keys
+    empty!(comp_dict)
+    # Update component indices and re-build the dict keys
+    for (i_new, (i_old, comp)) in enumerate(comp_ordered)
+        comp["index"] = i_new
+        comp_dict["$(i_new)"] = comp
     end
 
-    return renumbered_dict
+    return comp_dict
 end
 
 

--- a/src/core/data_basic.jl
+++ b/src/core/data_basic.jl
@@ -154,7 +154,6 @@ function _renumber_components(comp_dict::Dict{String,<:Any})
     comp_ordered = sort([comp for (i,comp) in comp_dict], by=(x) -> x["index"])
 
     for (i,comp) in enumerate(comp_ordered)
-        comp = deepcopy(comp)
         comp["index"] = i
         renumbered_dict["$i"] = comp
     end

--- a/test/data-basic.jl
+++ b/test/data-basic.jl
@@ -35,6 +35,28 @@
         @test isapprox(result["objective"], 16551.7; atol=1e0)
     end
 
+    @testset "Re-number components in-place" begin
+        data = make_basic_network(PowerModels.parse_file("../test/data/matpower/case7_tplgy.m"))
+
+        # Scramble indices before renumbering
+        v = [data["gen"]["$i"] for i in 1:3]
+        data["gen"]["1"]["index"] = 2
+        data["gen"]["2"]["index"] = 3
+        data["gen"]["3"]["index"] = 1
+
+        d = PowerModels._renumber_components!(data["gen"])
+        @test length(data["gen"]) == 3
+        # Check index consistency
+        @test data["gen"]["1"]["index"] == 1
+        @test data["gen"]["2"]["index"] == 2
+        @test data["gen"]["3"]["index"] == 3
+        # Check that modifications were done in-place
+        @test d === data["gen"]
+        @test data["gen"]["1"] === v[3]
+        @test data["gen"]["2"] === v[1]
+        @test data["gen"]["3"] === v[2]
+    end
+
 end
 
 

--- a/test/data-basic.jl
+++ b/test/data-basic.jl
@@ -36,7 +36,7 @@
     end
 
     @testset "Re-number components in-place" begin
-        data = make_basic_network(PowerModels.parse_file("../test/data/matpower/case7_tplgy.m"))
+        data = PowerModels.parse_file("../test/data/matpower/case7_tplgy.m")
 
         # Scramble indices before renumbering
         v = [data["gen"]["$i"] for i in 1:3]


### PR DESCRIPTION
Motivated by #913. 

This PR removes an internal `deepcopy` while re-indexing components in `_renumber_components`, thus reducing time and memory allocations.

| Case | #buses | old time (s) | in-place time (s) | old memory (MiB) | in-place memory (MiB) |
|:--|--:|--:|--:|--:|--:|
| `1354_pegase` | 1354 | 0.21 | 0.15 | 29.4 | 20.0 |
| `2869_pegase` | 2869 | 0.60 | 0.2 | 66.7 | 45.7 |
| `9241_pegase` | 9241 | 2.50 | 1.91 | 208.3 | 136.5 |
| `13659_pegase` | 13659 | 5.44 | 4.63 | 313.0 | 215.6 |

and corresponding profile of `make_basic_network(data)` where `data = pglib("9241_pegase")`

![prof_no_internal_deepcopy](https://github.com/lanl-ansi/PowerModels.jl/assets/9593025/7ec7e457-53f0-4cf3-8294-f95c286fae11)
