### PR TITLE
PTI Parser Quote Counter Fix

### DIFF
--- a/src/io/pti.jl
+++ b/src/io/pti.jl
@@ -607,7 +607,7 @@ Comments, typically indicated at the end of a line with a `'/'` character,
 are also extracted separately, and `Array{Array{String}, String}` is returned.
 """
 function _get_line_elements(line::AbstractString)
-    if count(i->(i=="'"), line) % 2 == 1
+    if count(i->(i=='\''), line) % 2 == 1
         throw(Memento.error(_LOGGER, "There are an uneven number of single-quotes in \"{line}\", the line cannot be parsed."))
     end
 


### PR DESCRIPTION
Found a small bug that prevents the current PTI parser from throwing an error at mismatched quotations.

The "'" represents a string, while the count function expects to compare i with a character. This means that the current code always counted 0 quotes in each line. This small fix should correct the error handling in this case.