### PR TITLE
Fixed dictionary call syntax error in psse export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@ PowerModels.jl Change Log
 =========================
 
 ### Staged
-- nothing
+- Fix dictionary call syntax error in psse export (#941)
 
 ### v0.21.3
 - Fix no-buses bug in `calc_connected_components` (#933)

--- a/src/io/pti.jl
+++ b/src/io/pti.jl
@@ -1542,7 +1542,7 @@ function _pm2psse_2w_tran(pm_br::Dict{String, Any}, owner::Int, sbase::Real, sou
     if haskey(pm_br, "source_id")
         ckt = source == "pti" ? "\'$(pm_br["source_id"][5])\'" : "\'$(pm_br["source_id"][end])\'"
     else
-        ckt = _default_transformer("CKT")
+        ckt = _default_transformer["CKT"]
     end
     sub_data["CKT"] = ckt
     sub_data["CW"] = _default_transformer["CW"]


### PR DESCRIPTION
There is a very simple syntax error in the pm2psse transformer export function.
(A dict was being accessed with brackets instead of square brackets).

I did not find this issue, but a former colleague didn't pull request/ issue tracker it (so I don't really know the impact of the bug, just that my former colleague found it and fixed it locally).

If this is too small of a fix for a pull request, you are welcome to add it to a different commit/pr.
