### PR TITLE
More accurate message when deactivating isolated components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@ PowerModels.jl Change Log
 =========================
 
 ### Staged
-- nothing
+- Updated the logging message when components are deactivated (#943)
 
 ### v0.21.3
 - Fix no-buses bug in `calc_connected_components` (#933)

--- a/src/core/data.jl
+++ b/src/core/data.jl
@@ -2329,7 +2329,7 @@ function _deactivate_isolated_components!(data::Dict{String,<:Any})
         active_strg_count = sum(cc_active_strg)
 
         if (active_load_count == 0 && active_shunt_count == 0 && active_strg_count == 0) || active_gen_count == 0
-            Memento.info(_LOGGER, "deactivating connected component $(cc) due to isolation without generation, load or storage")
+            Memento.info(_LOGGER, "deactivating connected component $(cc) due to isolation without (a) generation or (b) load, storage, or shunts")
             for i in cc
                 buses[i]["bus_type"] = 4
             end


### PR DESCRIPTION
Was confused by this message so I updated it to more accurately reflect the logic.