### PR TITLE
Added check for positive resistances and reactances

### DIFF
--- a/src/core/data_basic.jl
+++ b/src/core/data_basic.jl
@@ -76,6 +76,17 @@ function make_basic_network!(data::Dict{String,<:Any})
         end
     end
 
+    # check whether all resistances and conductances are > 0
+    for (i,branch) in data["branch"]
+        if branch["br_r"] < 0
+            Memento.warn(_LOGGER, "resistance on branch $(i) is $(branch["br_r"]) < 0.")
+        end
+        if branch["br_x"] < 0
+            Memento.warn(_LOGGER, "reactance on branch $(i) is $(branch["br_x"]) < 0.")
+        end
+    end
+
+
     # ensure single connected component
     select_largest_component!(data)
 


### PR DESCRIPTION
Thank you so much for this great package! I use it a lot, its my absolute favorite tool to do power system computations. 

I've added a check for positive resistances and reactances in make_basic_network. Currently it issues a warning if they are not positive, but maybe it should even be an error. I found cases with negative resistances in the pglib repo, cf. https://github.com/power-grid-lib/pglib-opf/issues/45

