### PR TITLE
Fast implementation of maximum cardinality search ordering algorithm.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,7 @@ repo = "https://github.com/lanl-ansi/PowerModels.jl"
 version = "0.21.3"
 
 [deps]
+CliqueTrees = "60701a23-6482-424a-84db-faee86b9b1f8"
 InfrastructureModels = "2030c09a-7f63-5d83-885d-db604e0e9cc0"
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 JuMP = "4076af6c-e467-56ae-b986-b466b2749572"
@@ -14,6 +15,7 @@ NLsolve = "2774e3e8-f4cf-5e23-947b-6d7e65073b56"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [compat]
+CliqueTrees = "0.4.0"
 HiGHS = "~1"
 InfrastructureModels = "~0.6, ~0.7"
 Ipopt = "~1"

--- a/Project.toml
+++ b/Project.toml
@@ -5,7 +5,6 @@ repo = "https://github.com/lanl-ansi/PowerModels.jl"
 version = "0.21.3"
 
 [deps]
-CliqueTrees = "60701a23-6482-424a-84db-faee86b9b1f8"
 InfrastructureModels = "2030c09a-7f63-5d83-885d-db604e0e9cc0"
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 JuMP = "4076af6c-e467-56ae-b986-b466b2749572"
@@ -15,7 +14,6 @@ NLsolve = "2774e3e8-f4cf-5e23-947b-6d7e65073b56"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [compat]
-CliqueTrees = "0.4.0"
 HiGHS = "~1"
 InfrastructureModels = "~0.6, ~0.7"
 Ipopt = "~1"

--- a/src/PowerModels.jl
+++ b/src/PowerModels.jl
@@ -1,5 +1,7 @@
 module PowerModels
 
+import CliqueTrees
+
 import LinearAlgebra, SparseArrays
 
 import JSON

--- a/src/PowerModels.jl
+++ b/src/PowerModels.jl
@@ -1,7 +1,5 @@
 module PowerModels
 
-import CliqueTrees
-
 import LinearAlgebra, SparseArrays
 
 import JSON
@@ -62,6 +60,7 @@ include("io/json.jl")
 
 include("form/iv.jl")
 
+include("form/cliquetrees/CliqueTrees.jl")
 include("form/acp.jl")
 include("form/acr.jl")
 include("form/act.jl")

--- a/src/form/cliquetrees/CliqueTrees.jl
+++ b/src/form/cliquetrees/CliqueTrees.jl
@@ -1,0 +1,16 @@
+module CliqueTrees
+
+using Base: oneto, @propagate_inbounds
+using SparseArrays
+
+const AbstractScalar{T} = AbstractArray{T,0}
+const Scalar{T} = Array{T,0}
+const MAX_ITEMS_PRINTED = 5
+
+export permutation, MCS
+
+include("./abstract_linked_lists.jl")
+include("./doubly_linked_lists.jl")
+include("./elimination_algorithms.jl")
+
+end

--- a/src/form/cliquetrees/LICENSE
+++ b/src/form/cliquetrees/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2023 AlgebraicJulia
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/src/form/cliquetrees/abstract_linked_lists.jl
+++ b/src/form/cliquetrees/abstract_linked_lists.jl
@@ -1,0 +1,40 @@
+abstract type AbstractLinkedList{I<:Integer} end
+
+function Base.show(io::IO, ::MIME"text/plain", list::L) where {L<:AbstractLinkedList}
+    println(io, "$L:")
+
+    for (i, v) in enumerate(take(list, MAX_ITEMS_PRINTED + 1))
+        if i <= MAX_ITEMS_PRINTED
+            println(io, " $v")
+        else
+            println(io, " ⋮")
+        end
+    end
+end
+
+function Base.empty!(list::AbstractLinkedList{I}) where {I}
+    list.head[] = zero(I)
+    return list
+end
+
+function Base.isempty(list::AbstractLinkedList)
+    return iszero(list.head[])
+end
+
+#######################
+# Iteration Interface #
+#######################
+
+function Base.iterate(list::AbstractLinkedList{I}, i::I=list.head[]) where {I}
+    if !iszero(i)
+        @inbounds (i, list.next[i])
+    end
+end
+
+function Base.IteratorSize(::Type{<:AbstractLinkedList})
+    return Base.SizeUnknown()
+end
+
+function Base.eltype(::Type{<:AbstractLinkedList{I}}) where {I}
+    return I
+end

--- a/src/form/cliquetrees/doubly_linked_lists.jl
+++ b/src/form/cliquetrees/doubly_linked_lists.jl
@@ -1,0 +1,91 @@
+# A doubly linked list of distinct natural numbers.
+struct DoublyLinkedList{
+    I,Init<:AbstractScalar{I},Prev<:AbstractVector{I},Next<:AbstractVector{I}
+} <: AbstractLinkedList{I}
+    head::Init
+    prev::Prev
+    next::Next
+end
+
+function DoublyLinkedList{I}(n::Integer) where {I}
+    head = fill(zero(I))
+    prev = Vector{I}(undef, n)
+    next = Vector{I}(undef, n)
+    return DoublyLinkedList(head, prev, next)
+end
+
+function DoublyLinkedList{I}(vector::AbstractVector) where {I}
+    list = DoublyLinkedList{I}(length(vector))
+    return prepend!(list, vector)
+end
+
+function DoublyLinkedList(vector::AbstractVector{I}) where {I}
+    return DoublyLinkedList{I}(vector)
+end
+
+@propagate_inbounds function Base.pushfirst!(list::DoublyLinkedList, i::Integer)
+    @boundscheck checkbounds(list.prev, i)
+    @boundscheck checkbounds(list.next, i)
+
+    @inbounds begin
+        n = list.next[i] = list.head[]
+        list.head[] = i
+        list.prev[i] = 0
+
+        if !iszero(n)
+            list.prev[n] = i
+        end
+    end
+
+    return list
+end
+
+@propagate_inbounds function Base.popfirst!(list::DoublyLinkedList)
+    i = list.head[]
+    @boundscheck checkbounds(list.next, i)
+
+    @inbounds begin
+        n = list.head[] = list.next[i]
+
+        if !iszero(n)
+            list.prev[n] = 0
+        end
+    end
+
+    return i
+end
+
+@propagate_inbounds function Base.delete!(list::DoublyLinkedList, i::Integer)
+    @boundscheck checkbounds(list.prev, i)
+    @boundscheck checkbounds(list.next, i)
+
+    @inbounds begin
+        p = list.prev[i]
+        n = list.next[i]
+
+        if !iszero(p)
+            list.next[p] = n
+        else
+            list.head[] = n
+        end
+
+        if !iszero(n)
+            list.prev[n] = p
+        end
+    end
+
+    return list
+end
+
+function Base.prepend!(list::DoublyLinkedList, vector::AbstractVector)
+    @views list.next[vector[begin:(end - 1)]] = vector[(begin + 1):end]
+    @views list.prev[vector[(begin + 1):end]] = vector[begin:(end - 1)]
+
+    if !isempty(vector)
+        list.next[vector[end]] = list.head[]
+        list.prev[vector[begin]] = 0
+        list.head[] = vector[begin]
+    end
+
+    return list
+end

--- a/src/form/cliquetrees/elimination_algorithms.jl
+++ b/src/form/cliquetrees/elimination_algorithms.jl
@@ -1,0 +1,96 @@
+"""
+    EliminationAlgorithm
+
+A graph elimination algorithm. The options are
+
+| type             | name                                         | time     | space    |
+|:---------------- |:-------------------------------------------- |:-------- |:-------- |
+| [`MCS`](@ref)    | maximum cardinality search                   | O(m + n) | O(n)     |
+"""
+abstract type EliminationAlgorithm end
+
+"""
+    MCS <: EliminationAlgorithm
+
+    MCS()
+
+The maximum cardinality search algorithm.
+
+### Reference
+
+Tarjan, Robert E., and Mihalis Yannakakis. "Simple linear-time algorithms to test chordality of graphs, test acyclicity of hypergraphs, and selectively reduce acyclic hypergraphs." *SIAM Journal on Computing* 13.3 (1984): 566-579.
+"""
+struct MCS <: EliminationAlgorithm end
+
+function permutation(matrix, alg::MCS)
+    index, card = mcs(matrix)
+    return invperm(index), index
+end
+
+"""
+    mcs(matrix[, clique::AbstractVector])
+
+Perform a maximum cardinality search, optionally specifying a clique to be ordered last.
+Returns the inverse permutation.
+"""
+function mcs(matrix::SparseMatrixCSC{<:Any, V}) where V
+    mcs(matrix, oneto(zero(V)))
+end
+
+# Simple Linear-Time Algorithms to Test Chordality of BipartiteGraphs, Test Acyclicity of Hypergraphs, and Selectively Reduce Acyclic Hypergraphs
+# Tarjan and Yannakakis
+# Maximum Cardinality Search
+#
+# Construct a fill-reducing permutation of a graph.
+# The complexity is O(m + n), where m = |E| and n = |V|.
+function mcs(matrix::SparseMatrixCSC{<:Any, V}, clique::AbstractVector) where {V}
+    n = convert(V, size(matrix, 2))
+
+    # construct disjoint sets data structure
+    head = zeros(V, n + one(V))
+    prev = Vector{V}(undef, n + one(V))
+    next = Vector{V}(undef, n + one(V))
+
+    function set(i)
+        @inbounds DoublyLinkedList(view(head, i), prev, next)
+    end
+
+    # run algorithm
+    alpha = Vector{V}(undef, n)
+    card = ones(V, n)
+    prepend!(set(one(V)), oneto(n))
+
+    j = one(V)
+    k = convert(V, lastindex(clique))
+
+    @inbounds for i in reverse(oneto(n))
+        v = zero(V)
+
+        if k in eachindex(clique)
+            v = convert(V, clique[k])
+            k -= one(V)
+            delete!(set(j), v)
+        else
+            v = popfirst!(set(j))
+        end
+
+        alpha[v] = i
+        card[v] = one(V) - card[v]
+
+        for w in @view rowvals(matrix)[nzrange(matrix, v)]
+            if card[w] >= one(V)
+                delete!(set(card[w]), w)
+                card[w] += one(V)
+                pushfirst!(set(card[w]), w)
+            end
+        end
+
+        j += one(V)
+
+        while j >= one(V) && isempty(set(j))
+            j -= one(V)
+        end
+    end
+
+    return alpha, card
+end

--- a/src/form/wrm.jl
+++ b/src/form/wrm.jl
@@ -379,21 +379,7 @@ Maximum cardinality search for graph adjacency matrix A.
 Returns a perfect elimination ordering for chordal graphs.
 """
 function _mcs(A)
-    n = size(A, 1)
-    w = zeros(Int, n)
-    peo = zeros(Int, n)
-    unnumbered = collect(1:n)
-
-    for i = n:-1:1
-        z = unnumbered[argmax(w[unnumbered])]
-        filter!(x -> x != z, unnumbered)
-        peo[i] = z
-
-        Nz = findall(x->x!=0, A[:, z])
-        for y in intersect(Nz, unnumbered)
-            w[y] += 1
-        end
-    end
+    peo, _ = CliqueTrees.permutation(A, CliqueTrees.MCS())
     return peo
 end
 

--- a/src/form/wrm.jl
+++ b/src/form/wrm.jl
@@ -1,4 +1,5 @@
 ### sdp relaxations in the rectangular W-space
+import .CliqueTrees
 import LinearAlgebra: Hermitian, cholesky, Symmetric, diag, I
 import SparseArrays: SparseMatrixCSC, sparse, spdiagm, findnz, spzeros, nonzeros
 


### PR DESCRIPTION
I have a library [CliqueTrees.jl](https://github.com/AlgebraicJulia/CliqueTrees.jl/tree/main) with a fast implementation of the maximum cardinality algorithm. Here are some benchmarks.

```julia
using BenchmarkTools, MatrixMarket, PowerModels, SuiteSparseMatrixCollection

ssmc = ssmc_db()
name = "bcsstk17"
matrix = mmread(joinpath(fetch_ssmc(ssmc[ssmc.name .== name, :], format="MM")[1], "$(name).mtx"))
```

**current implementation**

```julia
julia> @benchmark PowerModels._mcs($matrix)
BenchmarkTools.Trial: 7 samples with 1 evaluation per sample.
 Range (min … max):  778.347 ms … 849.834 ms  ┊ GC (min … max): 4.17% … 6.36%
 Time  (median):     801.612 ms               ┊ GC (median):    5.25%
 Time  (mean ± σ):   803.112 ms ±  23.522 ms  ┊ GC (mean ± σ):  5.17% ± 0.72%

  █   █       █      █ █     █                                █  
  █▁▁▁█▁▁▁▁▁▁▁█▁▁▁▁▁▁█▁█▁▁▁▁▁█▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁█ ▁
  778 ms           Histogram: frequency by time          850 ms <

 Memory estimate: 1.50 GiB, allocs estimate: 238040.
 ```
 
 **new implementation**
 
```julia
julia> @benchmark PowerModels._mcs($matrix)
BenchmarkTools.Trial: 4301 samples with 1 evaluation per sample.
 Range (min … max):  1.083 ms …   5.601 ms  ┊ GC (min … max): 0.00% … 75.50%
 Time  (median):     1.128 ms               ┊ GC (median):    0.00%
 Time  (mean ± σ):   1.160 ms ± 153.791 μs  ┊ GC (mean ± σ):  2.05% ±  6.05%

  ▆▇▆█▇▅▅▄▃▃▂▂      ▁▁▁▁                                      ▂
  ████████████████▇▇█████▇█▇▆▇▅▆▇▅▄▅▇▃▆▃▃▃▃▆▃▁▁▃▅▅▃▄▃▄▁▃▃▅▁▁▃ █
  1.08 ms      Histogram: log(frequency) by time      1.78 ms <

 Memory estimate: 514.88 KiB, allocs estimate: 18.
```

The new implementation is linear time, and the current one is quadratic (cubic?), so the difference will get worse with larger matrices. You can take a look at the new implementation [here](https://github.com/AlgebraicJulia/CliqueTrees.jl/blob/b7b64bcc3afb60b5aadfa0cc1ba8b0b145b3443b/src/elimination_algorithms.jl#L522).