### PR TITLE
Improve performance of basic incidence matrix computation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@ PowerModels.jl Change Log
 =========================
 
 ### Staged
-- nothing
+- Improve performance of `calc_basic_incidence_matrix` (#946)
 
 ### v0.21.3
 - Fix no-buses bug in `calc_connected_components` (#933)

--- a/src/core/data_basic.jl
+++ b/src/core/data_basic.jl
@@ -242,29 +242,17 @@ function calc_basic_incidence_matrix(data::Dict{String,<:Any})
         Memento.warn(_LOGGER, "calc_basic_incidence_matrix requires basic network data and given data may be incompatible. make_basic_network can be used to transform data into the appropriate form.")
     end
 
-    N::Int = length(data["bus"])
-    E::Int = length(data["branch"])
-
-    I = Int[]
-    J = Int[]
-    V = Int[]
-    sizehint!(I, 2*E)
-    sizehint!(J, 2*E)
-    sizehint!(V, 2*E)
-
+    E, N = length(data["branch"])::Int, length(data["bus"])::Int
+    # I = [..., e, e, ...]
+    I = repeat(1:E; inner=2)
+    J = zeros(Int, 2 * E)
     for e in 1:E
         branch = data["branch"]["$e"]
-        i::Int = branch["f_bus"]
-        j::Int = branch["t_bus"]
-
-        push!(I, e)
-        push!(J, i)
-        push!(V, 1)
-
-        push!(I, e)
-        push!(J, j)
-        push!(V, -1)
+        J[2*e-1] = branch["f_bus"]::Int
+        J[2*e] = branch["t_bus"]::Int
     end
+    # V = [..., 1, -1, ...]
+    V = repeat([1, -1]; outer=E)
 
     return sparse(I, J, V, E, N)
 end

--- a/src/core/data_basic.jl
+++ b/src/core/data_basic.jl
@@ -253,7 +253,6 @@ function calc_basic_incidence_matrix(data::Dict{String,<:Any})
     end
     # V = [..., 1, -1, ...]
     V = repeat([1, -1]; outer=E)
-
     return sparse(I, J, V, E, N)
 end
 

--- a/src/core/data_basic.jl
+++ b/src/core/data_basic.jl
@@ -242,18 +242,31 @@ function calc_basic_incidence_matrix(data::Dict{String,<:Any})
         Memento.warn(_LOGGER, "calc_basic_incidence_matrix requires basic network data and given data may be incompatible. make_basic_network can be used to transform data into the appropriate form.")
     end
 
+    N::Int = length(data["bus"])
+    E::Int = length(data["branch"])
+
     I = Int[]
     J = Int[]
     V = Int[]
+    sizehint!(I, 2*E)
+    sizehint!(J, 2*E)
+    sizehint!(V, 2*E)
 
-    b = [branch for (i,branch) in data["branch"] if branch["br_status"] != 0]
-    branch_ordered = sort(b, by=(x) -> x["index"])
-    for (i,branch) in enumerate(branch_ordered)
-        push!(I, i); push!(J, branch["f_bus"]); push!(V,  1)
-        push!(I, i); push!(J, branch["t_bus"]); push!(V, -1)
+    for e in 1:E
+        branch = data["branch"]["$e"]
+        i::Int = branch["f_bus"]
+        j::Int = branch["t_bus"]
+
+        push!(I, e)
+        push!(J, i)
+        push!(V, 1)
+
+        push!(I, e)
+        push!(J, j)
+        push!(V, -1)
     end
 
-    return sparse(I,J,V)
+    return sparse(I, J, V, E, N)
 end
 
 """


### PR DESCRIPTION
A substantial amount of time is spent in this line
https://github.com/lanl-ansi/PowerModels.jl/blob/8824212b3d2f35f94f7dd72f37ff76e3419c478f/src/core/data_basic.jl#L250
mainly because the `sort` does two dictionary lookups every time is needs to compare two branches.

This is un-necessary for two reasons:
* basic network data has branches indexed from `1` to `E` (number of branches) and no disabled branches
* the subsequent call to `sparse` will re-sort any non-ordered indices if needed

Removing this step, plus some type annotations to help the compiler, result in a substantial performance improvement.
note that relative gains get better as system size increases.
___

Performance benchmark on the `9241_pegase` case from PGLib

Before
```jl
BenchmarkTools.Trial: 91 samples with 1 evaluation per sample.
 Range (min … max):  52.836 ms … 68.059 ms  ┊ GC (min … max): 0.00% … 19.06%
 Time  (median):     54.393 ms              ┊ GC (median):    0.00%
 Time  (mean ± σ):   55.223 ms ±  2.611 ms  ┊ GC (mean ± σ):  1.80% ±  3.92%

   ▁▁ ▂███▄▁▄                                                  
  ▅██████████▅▃▁▁▁▁▁▁▁▁▁▃▅▁▁▃▅▆▃▅▃▁▁▁▁▁▁▁▁▁▁▁▁▃▃▁▁▁▁▁▁▁▁▁▁▁▁▃ ▁
  52.8 ms         Histogram: frequency by time          65 ms <

 Memory estimate: 7.12 MiB, allocs estimate: 95887.
```
After
```jl
BenchmarkTools.Trial: 456 samples with 1 evaluation per sample.
 Range (min … max):  10.062 ms … 22.820 ms  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     10.464 ms              ┊ GC (median):    0.00%
 Time  (mean ± σ):   10.962 ms ±  1.485 ms  ┊ GC (mean ± σ):  2.49% ± 6.83%

  ▃▆█▅▃▂▆▂                                                     
  █████████▇▇▇▄▁▅▁▁▁▁▁▄▄▁▁▆▆▆▅▅▆▇▅▁▄▁▁▁▁▁▁▄▁▁▄▁▁▁▁▁▄▄▄▁▁▁▁▄▁▄ ▇
  10.1 ms      Histogram: log(frequency) by time        18 ms <

 Memory estimate: 2.84 MiB, allocs estimate: 32133.
```