### PR TITLE
Add dependabot workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "monthly"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,3 +1,4 @@
+# For details, see:
 # https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
 version: 2
 updates:


### PR DESCRIPTION
CI is currently failing because of a depreacted action `cache@v2`, see, e.g., log of https://github.com/lanl-ansi/PowerModels.jl/actions/runs/13634709010/job/38110480556

![image](https://github.com/user-attachments/assets/d0cfea33-864f-4f4f-b56a-d62960813b17)

Dependabot will automatically check for most recent actions and open PRs to update old/depreacted actions.



