### PR TITLE
Improved parse_file speed for json files

### DIFF
--- a/src/io/common.jl
+++ b/src/io/common.jl
@@ -5,16 +5,14 @@ Parses a Matpower .m `file` or PTI (PSS(R)E-v33) .raw `file` into a
 PowerModels data structure. All fields from PTI files will be imported if
 `import_all` is true (Default: false).
 """
-function parse_file(file::String; import_all=false, validate=true)
-    pm_data = open(file) do io
-        pm_data = parse_file(io; import_all=import_all, validate=validate, filetype=split(lowercase(file), '.')[end])
-    end
-    return pm_data
-end
 
 
 "Parses the iostream from a file"
-function parse_file(io::IO; import_all=false, validate=true, filetype="json")
+function parse_file(io::Union{IO,String}; import_all=false, validate=true, filetype="json")
+    if io isa String
+        filetype = split(lowercase(io), '.')[end]
+    end
+
     if filetype == "m"
         pm_data = PowerModels.parse_matpower(io, validate=validate)
     elseif filetype == "raw"

--- a/src/io/json.jl
+++ b/src/io/json.jl
@@ -11,7 +11,7 @@ function parse_json(io::Union{IO,String}; kwargs...)::Dict{String,Any}
     if io isa IO
         pm_data = JSON.parse(io)
     else
-        pm_data = JSON.parsefile(io)
+        pm_data = JSON.parsefile(io;use_mmap=false)
     end
     _jsonver2juliaver!(pm_data)
 

--- a/src/io/json.jl
+++ b/src/io/json.jl
@@ -8,8 +8,11 @@ end
 
 "Parses json from iostream or string"
 function parse_json(io::Union{IO,String}; kwargs...)::Dict{String,Any}
-    pm_data = JSON.parse(io)
-
+    if io isa IO
+        pm_data = JSON.parse(io)
+    else
+        pm_data = JSON.parsefile(io)
+    end
     _jsonver2juliaver!(pm_data)
 
     if haskey(pm_data, "conductors")

--- a/test/io.jl
+++ b/test/io.jl
@@ -8,6 +8,10 @@
         PowerModels.export_file(file_tmp, source_data)
 
         destination_data = PowerModels.parse_file(file_tmp)
+        destination_data = open(file) do io
+            PowerModels.parse_file(io)
+        end
+        
         rm(file_tmp)
 
         @test true


### PR DESCRIPTION
`PowerModels.parse_file(filepath)` is not as fast as it could be for json files opened from the filesystem.

The reason for this is that 
```
pm_data = open(file) do io
     JSON.parse(io) 
end
```
is much slower than
```
 pm_data = JSON.parsefile(file)
```

---

For a random test file (~400 busses) that I have (but cannot share), the time speedup of this PR is around factor 8 (!).
Formerly:
`@btime PowerModels.parse_file("C:/Users/kuhrmann/CODE/test_file.json"; validate=false)`
>`19.742 ms (169472 allocations: 8.11 MiB)`

Now:
`@btime PowerModels.parse_file("C:/Users/kuhrmann/CODE/test_file.json"; validate=false)`
> `2.471 ms (70500 allocations: 3.70 MiB)`

Even when doing `validate=true` (the standard), the speedup is significant.
Formerly:
> `22.828 ms (232983 allocations: 9.91 MiB)`

Now:
>`5.834 ms (134011 allocations: 5.50 MiB)`

---

The edit removes `parse_json(file::String)` which just does `open()` and then forwards to `parse_json(io::IO)`.
It is not needed, as `parse_matpower`, `parse_psse` and `parse_json` allow filepaths themselves (also just doing `open()`).

---

Even if this may not be an overall bottleneck, I still think this speedup is worth it. For me this is especially an important use case, as I use Powermodels.parse_file to then do other julia things with the network model.

My julia skills are limited, so please edit the PR if needed!