### PR TITLE
Add license headers to all source files

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,3 +1,8 @@
+# Copyright (c) 2016: Los Alamos National Security, LLC
+#
+# Use of this source code is governed by a BSD-style license that can be found
+# in the LICENSE.md file.
+
 using Documenter, PowerModels
 
 makedocs(

--- a/src/PowerModels.jl
+++ b/src/PowerModels.jl
@@ -1,3 +1,8 @@
+# Copyright (c) 2016: Los Alamos National Security, LLC
+#
+# Use of this source code is governed by a BSD-style license that can be found
+# in the LICENSE.md file.
+
 module PowerModels
 
 import LinearAlgebra, SparseArrays

--- a/src/core/admittance_matrix.jl
+++ b/src/core/admittance_matrix.jl
@@ -1,3 +1,8 @@
+# Copyright (c) 2016: Los Alamos National Security, LLC
+#
+# Use of this source code is governed by a BSD-style license that can be found
+# in the LICENSE.md file.
+
 ###############################################################################
 # Data Structures and Functions for working with a network Admittance Matrix
 ###############################################################################

--- a/src/core/base.jl
+++ b/src/core/base.jl
@@ -1,3 +1,8 @@
+# Copyright (c) 2016: Los Alamos National Security, LLC
+#
+# Use of this source code is governed by a BSD-style license that can be found
+# in the LICENSE.md file.
+
 # stuff that is universal to all power models
 
 "root of the power formulation type hierarchy"

--- a/src/core/constraint.jl
+++ b/src/core/constraint.jl
@@ -1,3 +1,8 @@
+# Copyright (c) 2016: Los Alamos National Security, LLC
+#
+# Use of this source code is governed by a BSD-style license that can be found
+# in the LICENSE.md file.
+
 ###############################################################################
 # This file defines commonly used constraints for power flow models
 # These constraints generally assume that the model contains p and q values

--- a/src/core/constraint_template.jl
+++ b/src/core/constraint_template.jl
@@ -1,3 +1,8 @@
+# Copyright (c) 2016: Los Alamos National Security, LLC
+#
+# Use of this source code is governed by a BSD-style license that can be found
+# in the LICENSE.md file.
+
 #
 # Constraint Template Definitions
 #

--- a/src/core/data.jl
+++ b/src/core/data.jl
@@ -1,3 +1,8 @@
+# Copyright (c) 2016: Los Alamos National Security, LLC
+#
+# Use of this source code is governed by a BSD-style license that can be found
+# in the LICENSE.md file.
+
 # tools for working with a PowerModels data dict structure
 import LinearAlgebra: pinv
 

--- a/src/core/data_basic.jl
+++ b/src/core/data_basic.jl
@@ -1,3 +1,8 @@
+# Copyright (c) 2016: Los Alamos National Security, LLC
+#
+# Use of this source code is governed by a BSD-style license that can be found
+# in the LICENSE.md file.
+
 # tools for working with the "basic" versions of PowerModels data dict
 
 """

--- a/src/core/export.jl
+++ b/src/core/export.jl
@@ -1,3 +1,8 @@
+# Copyright (c) 2016: Los Alamos National Security, LLC
+#
+# Use of this source code is governed by a BSD-style license that can be found
+# in the LICENSE.md file.
+
 # PowerModels exports everything except internal symbols, which are defined as
 # those whose name starts with an underscore. If you don't want all of these
 # symbols in your environment, then use `import PowerModels` instead of

--- a/src/core/expression_template.jl
+++ b/src/core/expression_template.jl
@@ -1,3 +1,8 @@
+# Copyright (c) 2016: Los Alamos National Security, LLC
+#
+# Use of this source code is governed by a BSD-style license that can be found
+# in the LICENSE.md file.
+
 #
 # Expression Template Definitions
 #

--- a/src/core/objective.jl
+++ b/src/core/objective.jl
@@ -1,3 +1,8 @@
+# Copyright (c) 2016: Los Alamos National Security, LLC
+#
+# Use of this source code is governed by a BSD-style license that can be found
+# in the LICENSE.md file.
+
 ""
 function objective_min_fuel_and_flow_cost(pm::AbstractPowerModel; kwargs...)
     expression_pg_cost(pm; kwargs...)

--- a/src/core/ref.jl
+++ b/src/core/ref.jl
@@ -1,3 +1,8 @@
+# Copyright (c) 2016: Los Alamos National Security, LLC
+#
+# Use of this source code is governed by a BSD-style license that can be found
+# in the LICENSE.md file.
+
 # tools for working with a PowerModels ref dict structures
 
 

--- a/src/core/relaxation_scheme.jl
+++ b/src/core/relaxation_scheme.jl
@@ -1,3 +1,8 @@
+# Copyright (c) 2016: Los Alamos National Security, LLC
+#
+# Use of this source code is governed by a BSD-style license that can be found
+# in the LICENSE.md file.
+
 
 """
 A valid inequality for the product of two complex variables with magnitude and

--- a/src/core/solution.jl
+++ b/src/core/solution.jl
@@ -1,3 +1,8 @@
+# Copyright (c) 2016: Los Alamos National Security, LLC
+#
+# Use of this source code is governed by a BSD-style license that can be found
+# in the LICENSE.md file.
+
 function _IM.solution_preprocessor(pm::AbstractPowerModel, solution::Dict)
     per_unit = _IM.get_data(x -> x["per_unit"], pm.data, pm_it_name; apply_to_subnetworks = false)
     solution["it"][pm_it_name]["per_unit"] = per_unit

--- a/src/core/types.jl
+++ b/src/core/types.jl
@@ -1,3 +1,8 @@
+# Copyright (c) 2016: Los Alamos National Security, LLC
+#
+# Use of this source code is governed by a BSD-style license that can be found
+# in the LICENSE.md file.
+
 #================================================
     # exact non-convex models
     ACPPowerModel, ACRPowerModel, ACTPowerModel, IVRPowerModel

--- a/src/core/variable.jl
+++ b/src/core/variable.jl
@@ -1,3 +1,8 @@
+# Copyright (c) 2016: Los Alamos National Security, LLC
+#
+# Use of this source code is governed by a BSD-style license that can be found
+# in the LICENSE.md file.
+
 ################################################################################
 # This file defines common variables used in power flow models
 # This will hopefully make everything more compositional

--- a/src/form/acp.jl
+++ b/src/form/acp.jl
@@ -1,3 +1,8 @@
+# Copyright (c) 2016: Los Alamos National Security, LLC
+#
+# Use of this source code is governed by a BSD-style license that can be found
+# in the LICENSE.md file.
+
 ### polar form of the non-convex AC equations
 
 ""

--- a/src/form/acr.jl
+++ b/src/form/acr.jl
@@ -1,3 +1,8 @@
+# Copyright (c) 2016: Los Alamos National Security, LLC
+#
+# Use of this source code is governed by a BSD-style license that can be found
+# in the LICENSE.md file.
+
 ### rectangular form of the non-convex AC equations
 
 ""

--- a/src/form/act.jl
+++ b/src/form/act.jl
@@ -1,3 +1,8 @@
+# Copyright (c) 2016: Los Alamos National Security, LLC
+#
+# Use of this source code is governed by a BSD-style license that can be found
+# in the LICENSE.md file.
+
 ### w-theta form of the non-convex AC equations
 
 "`t[ref_bus] == 0`"

--- a/src/form/apo.jl
+++ b/src/form/apo.jl
@@ -1,3 +1,8 @@
+# Copyright (c) 2016: Los Alamos National Security, LLC
+#
+# Use of this source code is governed by a BSD-style license that can be found
+# in the LICENSE.md file.
+
 ### generic features that apply to all active-power-only (apo) approximations
 
 

--- a/src/form/bf.jl
+++ b/src/form/bf.jl
@@ -1,3 +1,8 @@
+# Copyright (c) 2016: Los Alamos National Security, LLC
+#
+# Use of this source code is governed by a BSD-style license that can be found
+# in the LICENSE.md file.
+
 # this file contains (balanced) convexified DistFlow formulation, in W space
 
 ""

--- a/src/form/dcp.jl
+++ b/src/form/dcp.jl
@@ -1,3 +1,8 @@
+# Copyright (c) 2016: Los Alamos National Security, LLC
+#
+# Use of this source code is governed by a BSD-style license that can be found
+# in the LICENSE.md file.
+
 ### simple active power only approximations (e.g. DC Power Flow)
 
 

--- a/src/form/iv.jl
+++ b/src/form/iv.jl
@@ -1,3 +1,8 @@
+# Copyright (c) 2016: Los Alamos National Security, LLC
+#
+# Use of this source code is governed by a BSD-style license that can be found
+# in the LICENSE.md file.
+
 # Kirchhoff's circuit laws as defined the current-voltage variable space.
 # Even though the branch model is linear, the feasible set is non-convex
 # in the context of constant-power loads or generators

--- a/src/form/lpac.jl
+++ b/src/form/lpac.jl
@@ -1,3 +1,8 @@
+# Copyright (c) 2016: Los Alamos National Security, LLC
+#
+# Use of this source code is governed by a BSD-style license that can be found
+# in the LICENSE.md file.
+
 ### the LPAC approximation
 
 ""

--- a/src/form/shared.jl
+++ b/src/form/shared.jl
@@ -1,3 +1,8 @@
+# Copyright (c) 2016: Los Alamos National Security, LLC
+#
+# Use of this source code is governed by a BSD-style license that can be found
+# in the LICENSE.md file.
+
 #
 # Shared Formulation Definitions
 #################################

--- a/src/form/wr.jl
+++ b/src/form/wr.jl
@@ -1,3 +1,8 @@
+# Copyright (c) 2016: Los Alamos National Security, LLC
+#
+# Use of this source code is governed by a BSD-style license that can be found
+# in the LICENSE.md file.
+
 ### quadratic relaxations in the rectangular W-space (e.g. SOC and QC relaxations)
 
 

--- a/src/form/wrm.jl
+++ b/src/form/wrm.jl
@@ -1,3 +1,8 @@
+# Copyright (c) 2016: Los Alamos National Security, LLC
+#
+# Use of this source code is governed by a BSD-style license that can be found
+# in the LICENSE.md file.
+
 ### sdp relaxations in the rectangular W-space
 import LinearAlgebra: Hermitian, cholesky, Symmetric, diag, I
 import SparseArrays: SparseMatrixCSC, sparse, spdiagm, findnz, spzeros, nonzeros

--- a/src/io/common.jl
+++ b/src/io/common.jl
@@ -1,3 +1,8 @@
+# Copyright (c) 2016: Los Alamos National Security, LLC
+#
+# Use of this source code is governed by a BSD-style license that can be found
+# in the LICENSE.md file.
+
 """
     parse_file(io::String; import_all=false, validate=true)
     parse_file(io::IO; import_all=false, validate=true, filetype="json")

--- a/src/io/json.jl
+++ b/src/io/json.jl
@@ -1,3 +1,8 @@
+# Copyright (c) 2016: Los Alamos National Security, LLC
+#
+# Use of this source code is governed by a BSD-style license that can be found
+# in the LICENSE.md file.
+
 # Parse PowerModels data from JSON exports of PowerModels data structures.
 
 function _jsonver2juliaver!(pm_data)

--- a/src/io/matpower.jl
+++ b/src/io/matpower.jl
@@ -1,3 +1,8 @@
+# Copyright (c) 2016: Los Alamos National Security, LLC
+#
+# Use of this source code is governed by a BSD-style license that can be found
+# in the LICENSE.md file.
+
 #########################################################################
 #                                                                       #
 # This file provides functions for interfacing with Matpower data files #

--- a/src/io/psse.jl
+++ b/src/io/psse.jl
@@ -1,3 +1,8 @@
+# Copyright (c) 2016: Los Alamos National Security, LLC
+#
+# Use of this source code is governed by a BSD-style license that can be found
+# in the LICENSE.md file.
+
 # Parse PSS(R)E data from PTI file into PowerModels data format
 
 

--- a/src/io/pti.jl
+++ b/src/io/pti.jl
@@ -1,3 +1,8 @@
+# Copyright (c) 2016: Los Alamos National Security, LLC
+#
+# Use of this source code is governed by a BSD-style license that can be found
+# in the LICENSE.md file.
+
 #####################################################################
 #                                                                   #
 # This file provides functions for interfacing with pti .raw files  #

--- a/src/prob/opb.jl
+++ b/src/prob/opb.jl
@@ -1,3 +1,8 @@
+# Copyright (c) 2016: Los Alamos National Security, LLC
+#
+# Use of this source code is governed by a BSD-style license that can be found
+# in the LICENSE.md file.
+
 ""
 function solve_nfa_opb(file, optimizer; kwargs...)
     return solve_opb(file, NFAPowerModel, optimizer; kwargs...)

--- a/src/prob/opf.jl
+++ b/src/prob/opf.jl
@@ -1,3 +1,8 @@
+# Copyright (c) 2016: Los Alamos National Security, LLC
+#
+# Use of this source code is governed by a BSD-style license that can be found
+# in the LICENSE.md file.
+
 ""
 function solve_ac_opf(file, optimizer; kwargs...)
     return solve_opf(file, ACPPowerModel, optimizer; kwargs...)

--- a/src/prob/opf_bf.jl
+++ b/src/prob/opf_bf.jl
@@ -1,3 +1,8 @@
+# Copyright (c) 2016: Los Alamos National Security, LLC
+#
+# Use of this source code is governed by a BSD-style license that can be found
+# in the LICENSE.md file.
+
 ""
 function solve_opf_bf(file, model_type::Type{T}, optimizer; kwargs...) where T <: AbstractBFModel
     return solve_model(file, model_type, optimizer, build_opf_bf; kwargs...)

--- a/src/prob/opf_iv.jl
+++ b/src/prob/opf_iv.jl
@@ -1,3 +1,8 @@
+# Copyright (c) 2016: Los Alamos National Security, LLC
+#
+# Use of this source code is governed by a BSD-style license that can be found
+# in the LICENSE.md file.
+
 ""
 function solve_opf_iv(file, model_type::Type, optimizer; kwargs...)
     return solve_model(file, model_type, optimizer, build_opf_iv; kwargs...)

--- a/src/prob/ots.jl
+++ b/src/prob/ots.jl
@@ -1,3 +1,8 @@
+# Copyright (c) 2016: Los Alamos National Security, LLC
+#
+# Use of this source code is governed by a BSD-style license that can be found
+# in the LICENSE.md file.
+
 #### General Assumptions of these OTS Models ####
 #
 # - if the branch status is 0 in the input, it is out of service and forced to 0 in OTS

--- a/src/prob/pf.jl
+++ b/src/prob/pf.jl
@@ -1,3 +1,8 @@
+# Copyright (c) 2016: Los Alamos National Security, LLC
+#
+# Use of this source code is governed by a BSD-style license that can be found
+# in the LICENSE.md file.
+
 "solves the AC Power Flow in polar coordinates using a JuMP model"
 function solve_ac_pf(file, optimizer; kwargs...)
     return solve_pf(file, ACPPowerModel, optimizer; kwargs...)

--- a/src/prob/pf_bf.jl
+++ b/src/prob/pf_bf.jl
@@ -1,3 +1,8 @@
+# Copyright (c) 2016: Los Alamos National Security, LLC
+#
+# Use of this source code is governed by a BSD-style license that can be found
+# in the LICENSE.md file.
+
 ""
 function solve_pf_bf(file, model_type::Type, optimizer; kwargs...)
     return solve_model(file, model_type, optimizer, build_pf_bf; kwargs...)

--- a/src/prob/pf_iv.jl
+++ b/src/prob/pf_iv.jl
@@ -1,3 +1,8 @@
+# Copyright (c) 2016: Los Alamos National Security, LLC
+#
+# Use of this source code is governed by a BSD-style license that can be found
+# in the LICENSE.md file.
+
 ""
 function solve_pf_iv(file, model_type::Type, optimizer; kwargs...)
     return solve_model(file, model_type, optimizer, build_pf_iv; kwargs...)

--- a/src/prob/test.jl
+++ b/src/prob/test.jl
@@ -1,3 +1,8 @@
+# Copyright (c) 2016: Los Alamos National Security, LLC
+#
+# Use of this source code is governed by a BSD-style license that can be found
+# in the LICENSE.md file.
+
 ######
 #
 # These are toy problem formulations used to test advanced features

--- a/src/prob/tnep.jl
+++ b/src/prob/tnep.jl
@@ -1,3 +1,8 @@
+# Copyright (c) 2016: Los Alamos National Security, LLC
+#
+# Use of this source code is governed by a BSD-style license that can be found
+# in the LICENSE.md file.
+
 #### General Assumptions of these TNEP Models ####
 #
 #

--- a/src/util/flow_limit_cuts.jl
+++ b/src/util/flow_limit_cuts.jl
@@ -1,3 +1,8 @@
+# Copyright (c) 2016: Los Alamos National Security, LLC
+#
+# Use of this source code is governed by a BSD-style license that can be found
+# in the LICENSE.md file.
+
 ### Solvers where line flow limit cuts are added iteratively ###
 
 """

--- a/src/util/obbt.jl
+++ b/src/util/obbt.jl
@@ -1,3 +1,8 @@
+# Copyright (c) 2016: Los Alamos National Security, LLC
+#
+# Use of this source code is governed by a BSD-style license that can be found
+# in the LICENSE.md file.
+
 ### Optimality-Based Bound Tightening for Optimal Power Flow Relaxations ###
 
 """

--- a/test/am.jl
+++ b/test/am.jl
@@ -1,3 +1,8 @@
+# Copyright (c) 2016: Los Alamos National Security, LLC
+#
+# Use of this source code is governed by a BSD-style license that can be found
+# in the LICENSE.md file.
+
 @testset "admittance matrix computation" begin
     @testset "5-bus case, no ref bus" begin
         data = PowerModels.parse_file("../test/data/matpower/case5.m")

--- a/test/common.jl
+++ b/test/common.jl
@@ -1,3 +1,8 @@
+# Copyright (c) 2016: Los Alamos National Security, LLC
+#
+# Use of this source code is governed by a BSD-style license that can be found
+# in the LICENSE.md file.
+
 
 function build_mn_data(base_data; replicates::Int=2)
     mp_data = PowerModels.parse_file(base_data)

--- a/test/data-basic.jl
+++ b/test/data-basic.jl
@@ -1,3 +1,8 @@
+# Copyright (c) 2016: Los Alamos National Security, LLC
+#
+# Use of this source code is governed by a BSD-style license that can be found
+# in the LICENSE.md file.
+
 # Tests of basic data transformation and utilities
 
 

--- a/test/data.jl
+++ b/test/data.jl
@@ -1,3 +1,8 @@
+# Copyright (c) 2016: Los Alamos National Security, LLC
+#
+# Use of this source code is governed by a BSD-style license that can be found
+# in the LICENSE.md file.
+
 # Tests of data checking and transformation code
 
 TESTLOG = Memento.getlogger(PowerModels)

--- a/test/docs.jl
+++ b/test/docs.jl
@@ -1,3 +1,8 @@
+# Copyright (c) 2016: Los Alamos National Security, LLC
+#
+# Use of this source code is governed by a BSD-style license that can be found
+# in the LICENSE.md file.
+
 
 @testset "code snippets from docs" begin
     @testset "DATA.md - The Network Data Dictionary" begin

--- a/test/io.jl
+++ b/test/io.jl
@@ -1,3 +1,8 @@
+# Copyright (c) 2016: Los Alamos National Security, LLC
+#
+# Use of this source code is governed by a BSD-style license that can be found
+# in the LICENSE.md file.
+
 
 @testset "export data to other file types" begin
 

--- a/test/matpower.jl
+++ b/test/matpower.jl
@@ -1,3 +1,8 @@
+# Copyright (c) 2016: Los Alamos National Security, LLC
+#
+# Use of this source code is governed by a BSD-style license that can be found
+# in the LICENSE.md file.
+
 @testset "test matpower parser" begin
     @testset "30-bus case file" begin
         result = solve_opf("../test/data/matpower/case30.m", ACPPowerModel, nlp_solver)

--- a/test/model.jl
+++ b/test/model.jl
@@ -1,3 +1,8 @@
+# Copyright (c) 2016: Los Alamos National Security, LLC
+#
+# Use of this source code is governed by a BSD-style license that can be found
+# in the LICENSE.md file.
+
 
 @testset "JuMP model building" begin
     @testset "run with user provided JuMP model" begin

--- a/test/modify.jl
+++ b/test/modify.jl
@@ -1,3 +1,8 @@
+# Copyright (c) 2016: Los Alamos National Security, LLC
+#
+# Use of this source code is governed by a BSD-style license that can be found
+# in the LICENSE.md file.
+
 
 
 @testset "data modification tests" begin

--- a/test/multinetwork.jl
+++ b/test/multinetwork.jl
@@ -1,3 +1,8 @@
+# Copyright (c) 2016: Los Alamos National Security, LLC
+#
+# Use of this source code is governed by a BSD-style license that can be found
+# in the LICENSE.md file.
+
 using JuMP
 PMs = PowerModels
 TESTLOG = Memento.getlogger(PowerModels)

--- a/test/opb.jl
+++ b/test/opb.jl
@@ -1,3 +1,8 @@
+# Copyright (c) 2016: Los Alamos National Security, LLC
+#
+# Use of this source code is governed by a BSD-style license that can be found
+# in the LICENSE.md file.
+
 
 
 @testset "test nfa opb" begin

--- a/test/opf-obj.jl
+++ b/test/opf-obj.jl
@@ -1,3 +1,8 @@
+# Copyright (c) 2016: Los Alamos National Security, LLC
+#
+# Use of this source code is governed by a BSD-style license that can be found
+# in the LICENSE.md file.
+
 ### Tests for OPF objective variants ###
 
 @testset "linear objective" begin

--- a/test/opf-ptdf.jl
+++ b/test/opf-ptdf.jl
@@ -1,3 +1,8 @@
+# Copyright (c) 2016: Los Alamos National Security, LLC
+#
+# Use of this source code is governed by a BSD-style license that can be found
+# in the LICENSE.md file.
+
 
 TESTLOG = Memento.getlogger(PowerModels)
 

--- a/test/opf-var.jl
+++ b/test/opf-var.jl
@@ -1,3 +1,8 @@
+# Copyright (c) 2016: Los Alamos National Security, LLC
+#
+# Use of this source code is governed by a BSD-style license that can be found
+# in the LICENSE.md file.
+
 ### Tests for OPF variants ###
 TESTLOG = Memento.getlogger(PowerModels)
 

--- a/test/opf.jl
+++ b/test/opf.jl
@@ -1,3 +1,8 @@
+# Copyright (c) 2016: Los Alamos National Security, LLC
+#
+# Use of this source code is governed by a BSD-style license that can be found
+# in the LICENSE.md file.
+
 
 
 @testset "test ac polar opf" begin

--- a/test/ots.jl
+++ b/test/ots.jl
@@ -1,3 +1,8 @@
+# Copyright (c) 2016: Los Alamos National Security, LLC
+#
+# Use of this source code is governed by a BSD-style license that can be found
+# in the LICENSE.md file.
+
 
 # used by OTS models
 function check_br_status(sol, active_lb::Real, active_ub::Real; tol=1e-6)

--- a/test/output.jl
+++ b/test/output.jl
@@ -1,3 +1,8 @@
+# Copyright (c) 2016: Los Alamos National Security, LLC
+#
+# Use of this source code is governed by a BSD-style license that can be found
+# in the LICENSE.md file.
+
 
 @testset "test output api" begin
     @testset "24-bus rts case" begin

--- a/test/pf-native.jl
+++ b/test/pf-native.jl
@@ -1,3 +1,8 @@
+# Copyright (c) 2016: Los Alamos National Security, LLC
+#
+# Use of this source code is governed by a BSD-style license that can be found
+# in the LICENSE.md file.
+
 @testset "test native dc pf solver" begin
     # degenerate due to no slack bus
     # @testset "3-bus case" begin

--- a/test/pf.jl
+++ b/test/pf.jl
@@ -1,3 +1,8 @@
+# Copyright (c) 2016: Los Alamos National Security, LLC
+#
+# Use of this source code is governed by a BSD-style license that can be found
+# in the LICENSE.md file.
+
 @testset "test ac polar pf" begin
     @testset "3-bus case" begin
         result = solve_ac_pf("../test/data/matpower/case3.m", nlp_solver)

--- a/test/psse.jl
+++ b/test/psse.jl
@@ -1,3 +1,8 @@
+# Copyright (c) 2016: Los Alamos National Security, LLC
+#
+# Use of this source code is governed by a BSD-style license that can be found
+# in the LICENSE.md file.
+
 # Tests for data conversion from PSS(R)E to PowerModels data structure
 
 TESTLOG = Memento.getlogger(PowerModels)

--- a/test/pti.jl
+++ b/test/pti.jl
@@ -1,3 +1,8 @@
+# Copyright (c) 2016: Los Alamos National Security, LLC
+#
+# Use of this source code is governed by a BSD-style license that can be found
+# in the LICENSE.md file.
+
 # Test cases for PTI RAW file parser
 
 TESTLOG = Memento.getlogger(PowerModels)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,3 +1,8 @@
+# Copyright (c) 2016: Los Alamos National Security, LLC
+#
+# Use of this source code is governed by a BSD-style license that can be found
+# in the LICENSE.md file.
+
 using PowerModels
 import InfrastructureModels
 import Memento

--- a/test/tnep.jl
+++ b/test/tnep.jl
@@ -1,3 +1,8 @@
+# Copyright (c) 2016: Los Alamos National Security, LLC
+#
+# Use of this source code is governed by a BSD-style license that can be found
+# in the LICENSE.md file.
+
 
 
 function check_tnep_status(sol)

--- a/test/util.jl
+++ b/test/util.jl
@@ -1,3 +1,8 @@
+# Copyright (c) 2016: Los Alamos National Security, LLC
+#
+# Use of this source code is governed by a BSD-style license that can be found
+# in the LICENSE.md file.
+
 
 @testset "obbt with trilinear convex hull relaxation" begin
     @testset "3-bus case" begin

--- a/test/warmstart.jl
+++ b/test/warmstart.jl
@@ -1,3 +1,8 @@
+# Copyright (c) 2016: Los Alamos National Security, LLC
+#
+# Use of this source code is governed by a BSD-style license that can be found
+# in the LICENSE.md file.
+
 ######
 #
 # These are toy workflows used to test advanced features


### PR DESCRIPTION
We semi-frequently get cases where people have liberally copy-pasted parts of JuMP-dev source code into new packages, and there has been at least one case with PowerModels (which I won't link to). Which is okay, of course, but this header still acts as a gentle reminder that there are some expectations in return.