### PR TITLE
Remove empty docstrings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ PowerModels.jl Change Log
 - Fix `parse_file` to use `JSON.parsefile` (#958)
 - Fix spelling of `resolve_swithces!` and add deprecation for compatibility (#959)
 - Clean up package imports (#961)
+- Remove empty docstrings (#963)
 
 ### v0.21.3
 - Fix no-buses bug in `calc_connected_components` (#933)

--- a/src/core/base.jl
+++ b/src/core/base.jl
@@ -12,13 +12,11 @@ _IM.@def pm_fields begin
 end
 
 
-""
 function solve_model(file::String, model_type::Type, optimizer, build_method; kwargs...)
     data = PowerModels.parse_file(file)
     return solve_model(data, model_type, optimizer, build_method; kwargs...)
 end
 
-""
 function solve_model(data::Dict{String,<:Any}, model_type::Type, optimizer, build_method;
         ref_extensions=[], solution_processors=[], relax_integrality=false,
         multinetwork=false, kwargs...)
@@ -41,13 +39,11 @@ function solve_model(data::Dict{String,<:Any}, model_type::Type, optimizer, buil
 end
 
 
-""
 function instantiate_model(file::String, model_type::Type, build_method; kwargs...)
     data = PowerModels.parse_file(file)
     return instantiate_model(data, model_type, build_method; kwargs...)
 end
 
-""
 function instantiate_model(data::Dict{String,<:Any}, model_type::Type, build_method; kwargs...)
     return _IM.instantiate_model(data, model_type, build_method, ref_add_core!, _pm_global_keys, pm_it_sym; kwargs...)
 end

--- a/src/core/constraint.jl
+++ b/src/core/constraint.jl
@@ -159,7 +159,6 @@ function constraint_model_current(pm::AbstractPowerModel, n::Int)
 end
 
 
-""
 function constraint_switch_state_open(pm::AbstractPowerModel, n::Int, f_idx)
     psw = var(pm, n, :psw, f_idx)
     qsw = var(pm, n, :qsw, f_idx)
@@ -168,7 +167,6 @@ function constraint_switch_state_open(pm::AbstractPowerModel, n::Int, f_idx)
     JuMP.@constraint(pm.model, qsw == 0.0)
 end
 
-""
 function constraint_switch_thermal_limit(pm::AbstractPowerModel, n::Int, f_idx, rating)
     psw = var(pm, n, :psw, f_idx)
     qsw = var(pm, n, :qsw, f_idx)
@@ -176,7 +174,6 @@ function constraint_switch_thermal_limit(pm::AbstractPowerModel, n::Int, f_idx, 
     JuMP.@constraint(pm.model, psw^2 + qsw^2 <= rating^2)
 end
 
-""
 function constraint_switch_power_on_off(pm::AbstractPowerModel, n::Int, i, f_idx)
     psw = var(pm, n, :psw, f_idx)
     qsw = var(pm, n, :qsw, f_idx)
@@ -193,7 +190,6 @@ end
 
 
 
-""
 function constraint_storage_thermal_limit(pm::AbstractPowerModel, n::Int, i, rating)
     ps = var(pm, n, :ps, i)
     qs = var(pm, n, :qs, i)
@@ -201,7 +197,6 @@ function constraint_storage_thermal_limit(pm::AbstractPowerModel, n::Int, i, rat
     JuMP.@constraint(pm.model, ps^2 + qs^2 <= rating^2)
 end
 
-""
 function constraint_storage_state_initial(pm::AbstractPowerModel, n::Int, i::Int, energy, charge_eff, discharge_eff, time_elapsed)
     sc = var(pm, n, :sc, i)
     sd = var(pm, n, :sd, i)
@@ -210,7 +205,6 @@ function constraint_storage_state_initial(pm::AbstractPowerModel, n::Int, i::Int
     JuMP.@constraint(pm.model, se - energy == time_elapsed*(charge_eff*sc - sd/discharge_eff))
 end
 
-""
 function constraint_storage_state(pm::AbstractPowerModel, n_1::Int, n_2::Int, i::Int, charge_eff, discharge_eff, time_elapsed)
     sc_2 = var(pm, n_2, :sc, i)
     sd_2 = var(pm, n_2, :sd, i)
@@ -220,7 +214,6 @@ function constraint_storage_state(pm::AbstractPowerModel, n_1::Int, n_2::Int, i:
     JuMP.@constraint(pm.model, se_2 - se_1 == time_elapsed*(charge_eff*sc_2 - sd_2/discharge_eff))
 end
 
-""
 function constraint_storage_complementarity_nl(pm::AbstractPowerModel, n::Int, i)
     sc = var(pm, n, :sc, i)
     sd = var(pm, n, :sd, i)
@@ -228,7 +221,6 @@ function constraint_storage_complementarity_nl(pm::AbstractPowerModel, n::Int, i
     JuMP.@constraint(pm.model, sc*sd == 0.0)
 end
 
-""
 function constraint_storage_complementarity_mi(pm::AbstractPowerModel, n::Int, i, charge_ub, discharge_ub)
     sc = var(pm, n, :sc, i)
     sd = var(pm, n, :sd, i)
@@ -241,7 +233,6 @@ function constraint_storage_complementarity_mi(pm::AbstractPowerModel, n::Int, i
 end
 
 
-""
 function constraint_storage_on_off(pm::AbstractPowerModel, n::Int, i, pmin, pmax, qmin, qmax, charge_ub, discharge_ub)
     z_storage = var(pm, n, :z_storage, i)
     ps = var(pm, n, :ps, i)

--- a/src/core/constraint_template.jl
+++ b/src/core/constraint_template.jl
@@ -80,19 +80,16 @@ end
 
 ### Generator Constraints ###
 
-""
 function constraint_gen_setpoint_active(pm::AbstractPowerModel, i::Int; nw::Int=nw_id_default)
     gen = ref(pm, nw, :gen, i)
     constraint_gen_setpoint_active(pm, nw, gen["index"], gen["pg"])
 end
 
-""
 function constraint_gen_setpoint_reactive(pm::AbstractPowerModel, i::Int; nw::Int=nw_id_default)
     gen = ref(pm, nw, :gen, i)
     constraint_gen_setpoint_reactive(pm, nw, gen["index"], gen["qg"])
 end
 
-""
 function constraint_gen_power_on_off(pm::AbstractPowerModel, i::Int; nw::Int=nw_id_default)
     gen = ref(pm, nw, :gen, i)
 
@@ -115,12 +112,10 @@ end
 
 ### Bus - Setpoint Constraints ###
 
-""
 function constraint_theta_ref(pm::AbstractPowerModel, i::Int; nw::Int=nw_id_default)
     constraint_theta_ref(pm, nw, i)
 end
 
-""
 function constraint_voltage_magnitude_setpoint(pm::AbstractPowerModel, i::Int; nw::Int=nw_id_default)
     bus = ref(pm, nw, :bus, i)
     constraint_voltage_magnitude_setpoint(pm, nw, bus["index"], bus["vm"])
@@ -170,7 +165,6 @@ end
 
 ### Bus - KCL Constraints ###
 
-""
 function constraint_power_balance(pm::AbstractPowerModel, i::Int; nw::Int=nw_id_default)
     bus = ref(pm, nw, :bus, i)
     bus_arcs = ref(pm, nw, :bus_arcs, i)
@@ -210,7 +204,6 @@ function constraint_power_balance_ls(pm::AbstractPowerModel, i::Int; nw::Int=nw_
     constraint_power_balance_ls(pm, nw, i, bus_arcs, bus_arcs_dc, bus_arcs_sw, bus_gens, bus_storage, bus_pd, bus_qd, bus_gs, bus_bs)
 end
 
-""
 function constraint_ne_power_balance(pm::AbstractPowerModel, i::Int; nw::Int=nw_id_default)
     bus = ref(pm, nw, :bus, i)
     bus_arcs = ref(pm, nw, :bus_arcs, i)
@@ -231,7 +224,6 @@ function constraint_ne_power_balance(pm::AbstractPowerModel, i::Int; nw::Int=nw_
     constraint_ne_power_balance(pm, nw, i, bus_arcs, bus_arcs_dc, bus_arcs_sw, bus_arcs_ne, bus_gens, bus_storage, bus_pd, bus_qd, bus_gs, bus_bs)
 end
 
-""
 function constraint_current_balance(pm::AbstractPowerModel, i::Int; nw::Int=nw_id_default)
     if !haskey(con(pm, nw), :kcl_cr)
         con(pm, nw)[:kcl_cr] = Dict{Int,JuMP.ConstraintRef}()
@@ -259,7 +251,6 @@ end
 
 ### Branch - Ohm's Law Constraints ###
 
-""
 function constraint_ohms_yt_from(pm::AbstractPowerModel, i::Int; nw::Int=nw_id_default)
     branch = ref(pm, nw, :branch, i)
     f_bus = branch["f_bus"]
@@ -277,7 +268,6 @@ function constraint_ohms_yt_from(pm::AbstractPowerModel, i::Int; nw::Int=nw_id_d
 end
 
 
-""
 function constraint_ohms_yt_to(pm::AbstractPowerModel, i::Int; nw::Int=nw_id_default)
     branch = ref(pm, nw, :branch, i)
     f_bus = branch["f_bus"]
@@ -295,7 +285,6 @@ function constraint_ohms_yt_to(pm::AbstractPowerModel, i::Int; nw::Int=nw_id_def
 end
 
 
-""
 function constraint_ohms_y_from(pm::AbstractPowerModel, i::Int; nw::Int=nw_id_default)
     branch = ref(pm, nw, :branch, i)
     f_bus = branch["f_bus"]
@@ -313,7 +302,6 @@ function constraint_ohms_y_from(pm::AbstractPowerModel, i::Int; nw::Int=nw_id_de
 end
 
 
-""
 function constraint_ohms_y_to(pm::AbstractPowerModel, i::Int; nw::Int=nw_id_default)
     branch = ref(pm, nw, :branch, i)
     f_bus = branch["f_bus"]
@@ -331,7 +319,6 @@ function constraint_ohms_y_to(pm::AbstractPowerModel, i::Int; nw::Int=nw_id_defa
 end
 
 
-""
 function constraint_current_from(pm::AbstractIVRModel, i::Int; nw::Int=nw_id_default)
     branch = ref(pm, nw, :branch, i)
     f_bus = branch["f_bus"]
@@ -346,7 +333,6 @@ function constraint_current_from(pm::AbstractIVRModel, i::Int; nw::Int=nw_id_def
     constraint_current_from(pm, nw, f_bus, f_idx, g_fr, b_fr, tr, ti, tm)
 end
 
-""
 function constraint_current_to(pm::AbstractIVRModel, i::Int; nw::Int=nw_id_default)
     branch = ref(pm, nw, :branch, i)
     f_bus = branch["f_bus"]
@@ -366,7 +352,6 @@ end
 
 ### Branch - On/Off Ohm's Law Constraints ###
 
-""
 function constraint_ohms_yt_from_on_off(pm::AbstractPowerModel, i::Int; nw::Int=nw_id_default)
     branch = ref(pm, nw, :branch, i)
     f_bus = branch["f_bus"]
@@ -387,7 +372,6 @@ function constraint_ohms_yt_from_on_off(pm::AbstractPowerModel, i::Int; nw::Int=
 end
 
 
-""
 function constraint_ohms_yt_to_on_off(pm::AbstractPowerModel, i::Int; nw::Int=nw_id_default)
     branch = ref(pm, nw, :branch, i)
     f_bus = branch["f_bus"]
@@ -408,7 +392,6 @@ function constraint_ohms_yt_to_on_off(pm::AbstractPowerModel, i::Int; nw::Int=nw
 end
 
 
-""
 function constraint_ne_ohms_yt_from(pm::AbstractPowerModel, i::Int; nw::Int=nw_id_default)
     branch = ref(pm, nw, :ne_branch, i)
     f_bus = branch["f_bus"]
@@ -429,7 +412,6 @@ function constraint_ne_ohms_yt_from(pm::AbstractPowerModel, i::Int; nw::Int=nw_i
 end
 
 
-""
 function constraint_ne_ohms_yt_to(pm::AbstractPowerModel, i::Int; nw::Int=nw_id_default)
     branch = ref(pm, nw, :ne_branch, i)
     f_bus = branch["f_bus"]
@@ -449,7 +431,6 @@ function constraint_ne_ohms_yt_to(pm::AbstractPowerModel, i::Int; nw::Int=nw_id_
     constraint_ne_ohms_yt_to(pm, nw, i, f_bus, t_bus, f_idx, t_idx, g, b, g_to, b_to, tr, ti, tm, vad_min, vad_max)
 end
 
-""
 function constraint_ohms_y_oltc_pst_from(pm::AbstractPowerModel, i::Int; nw::Int=nw_id_default)
     branch = ref(pm, nw, :branch, i)
     f_bus = branch["f_bus"]
@@ -465,7 +446,6 @@ function constraint_ohms_y_oltc_pst_from(pm::AbstractPowerModel, i::Int; nw::Int
 end
 
 
-""
 function constraint_ohms_y_oltc_pst_to(pm::AbstractPowerModel, i::Int; nw::Int=nw_id_default)
     branch = ref(pm, nw, :branch, i)
     f_bus = branch["f_bus"]
@@ -482,7 +462,6 @@ end
 
 
 
-""
 function constraint_ohms_y_pst_from(pm::AbstractPowerModel, i::Int; nw::Int=nw_id_default)
     branch = ref(pm, nw, :branch, i)
     f_bus = branch["f_bus"]
@@ -499,7 +478,6 @@ function constraint_ohms_y_pst_from(pm::AbstractPowerModel, i::Int; nw::Int=nw_i
 end
 
 
-""
 function constraint_ohms_y_pst_to(pm::AbstractPowerModel, i::Int; nw::Int=nw_id_default)
     branch = ref(pm, nw, :branch, i)
     f_bus = branch["f_bus"]
@@ -517,7 +495,6 @@ end
 
 
 
-""
 function constraint_voltage_drop(pm::AbstractPowerModel, i::Int; nw::Int=nw_id_default)
     branch = ref(pm, nw, :branch, i)
     f_bus = branch["f_bus"]
@@ -535,7 +512,6 @@ end
 
 ### Branch - Current ###
 
-""
 function constraint_power_magnitude_sqr(pm::AbstractPowerModel, i::Int; nw::Int=nw_id_default)
     branch = ref(pm, nw, :branch, i)
     f_bus = branch["f_bus"]
@@ -548,7 +524,6 @@ function constraint_power_magnitude_sqr(pm::AbstractPowerModel, i::Int; nw::Int=
 end
 
 
-""
 function constraint_power_magnitude_sqr_on_off(pm::AbstractPowerModel, i::Int; nw::Int=nw_id_default)
     branch = ref(pm, nw, :branch, i)
     f_bus = branch["f_bus"]
@@ -561,7 +536,6 @@ function constraint_power_magnitude_sqr_on_off(pm::AbstractPowerModel, i::Int; n
 end
 
 
-""
 function constraint_power_magnitude_link(pm::AbstractPowerModel, i::Int; nw::Int=nw_id_default)
     branch = ref(pm, nw, :branch, i)
     f_bus = branch["f_bus"]
@@ -581,7 +555,6 @@ function constraint_power_magnitude_link(pm::AbstractPowerModel, i::Int; nw::Int
 end
 
 
-""
 function constraint_power_magnitude_link_on_off(pm::AbstractPowerModel, i::Int; nw::Int=nw_id_default)
     branch = ref(pm, nw, :branch, i)
     f_bus = branch["f_bus"]
@@ -622,7 +595,6 @@ function constraint_thermal_limit_from(pm::AbstractPowerModel, i::Int; nw::Int=n
 end
 
 
-""
 function constraint_thermal_limit_to(pm::AbstractPowerModel, i::Int; nw::Int=nw_id_default)
     branch = ref(pm, nw, :branch, i)
     f_bus = branch["f_bus"]
@@ -635,7 +607,6 @@ function constraint_thermal_limit_to(pm::AbstractPowerModel, i::Int; nw::Int=nw_
 end
 
 
-""
 function constraint_thermal_limit_from_on_off(pm::AbstractPowerModel, i::Int; nw::Int=nw_id_default)
     branch = ref(pm, nw, :branch, i)
     f_bus = branch["f_bus"]
@@ -650,7 +621,6 @@ function constraint_thermal_limit_from_on_off(pm::AbstractPowerModel, i::Int; nw
 end
 
 
-""
 function constraint_thermal_limit_to_on_off(pm::AbstractPowerModel, i::Int; nw::Int=nw_id_default)
     branch = ref(pm, nw, :branch, i)
     f_bus = branch["f_bus"]
@@ -665,7 +635,6 @@ function constraint_thermal_limit_to_on_off(pm::AbstractPowerModel, i::Int; nw::
 end
 
 
-""
 function constraint_ne_thermal_limit_from(pm::AbstractPowerModel, i::Int; nw::Int=nw_id_default)
     branch = ref(pm, nw, :ne_branch, i)
     f_bus = branch["f_bus"]
@@ -680,7 +649,6 @@ function constraint_ne_thermal_limit_from(pm::AbstractPowerModel, i::Int; nw::In
 end
 
 
-""
 function constraint_ne_thermal_limit_to(pm::AbstractPowerModel, i::Int; nw::Int=nw_id_default)
     branch = ref(pm, nw, :ne_branch, i)
     f_bus = branch["f_bus"]
@@ -697,7 +665,6 @@ end
 
 ### Branch - Current Limit Constraints ###
 
-""
 function constraint_current_limit_from(pm::AbstractPowerModel, i::Int; nw::Int=nw_id_default)
     branch = ref(pm, nw, :branch, i)
     f_bus = branch["f_bus"]
@@ -709,7 +676,6 @@ function constraint_current_limit_from(pm::AbstractPowerModel, i::Int; nw::Int=n
     end
 end
 
-""
 function constraint_current_limit_to(pm::AbstractPowerModel, i::Int; nw::Int=nw_id_default)
     branch = ref(pm, nw, :branch, i)
     f_bus = branch["f_bus"]
@@ -724,7 +690,6 @@ end
 
 ### Branch - Phase Angle Difference Constraints ###
 
-""
 function constraint_voltage_angle_difference(pm::AbstractPowerModel, i::Int; nw::Int=nw_id_default)
     branch = ref(pm, nw, :branch, i)
     f_bus = branch["f_bus"]
@@ -739,7 +704,6 @@ function constraint_voltage_angle_difference(pm::AbstractPowerModel, i::Int; nw:
 end
 
 
-""
 function constraint_voltage_angle_difference_on_off(pm::AbstractPowerModel, i::Int; nw::Int=nw_id_default)
     branch = ref(pm, nw, :branch, i)
     f_idx = (i, branch["f_bus"], branch["t_bus"])
@@ -751,7 +715,6 @@ function constraint_voltage_angle_difference_on_off(pm::AbstractPowerModel, i::I
 end
 
 
-""
 function constraint_ne_voltage_angle_difference(pm::AbstractPowerModel, i::Int; nw::Int=nw_id_default)
     branch = ref(pm, nw, :ne_branch, i)
     f_idx = (i, branch["f_bus"], branch["t_bus"])
@@ -765,7 +728,6 @@ end
 
 ### Branch - Loss Constraints ###
 
-""
 function constraint_power_losses_lb(pm::AbstractPowerModel, i::Int; nw::Int=nw_id_default)
     branch = ref(pm, nw, :branch, i)
     @assert branch["br_r"] >= 0
@@ -784,7 +746,6 @@ function constraint_power_losses_lb(pm::AbstractPowerModel, i::Int; nw::Int=nw_i
     constraint_power_losses_lb(pm, nw, f_bus, t_bus, f_idx, t_idx, g_fr, b_fr, g_to, b_to, tr)
 end
 
-""
 function constraint_power_losses(pm::AbstractPowerModel, i::Int; nw::Int=nw_id_default)
     branch = ref(pm, nw, :branch, i)
     f_bus = branch["f_bus"]
@@ -803,7 +764,6 @@ function constraint_power_losses(pm::AbstractPowerModel, i::Int; nw::Int=nw_id_d
     constraint_power_losses(pm::AbstractPowerModel, nw, i, f_bus, t_bus, f_idx, t_idx, r, x, g_sh_fr, g_sh_to, b_sh_fr, b_sh_to, tm)
 end
 
-""
 function constraint_voltage_magnitude_difference(pm::AbstractPowerModel, i::Int; nw::Int=nw_id_default)
     branch = ref(pm, nw, :branch, i)
     f_bus = branch["f_bus"]
@@ -863,25 +823,21 @@ end
 
 ### Storage Constraints ###
 
-""
 function constraint_storage_thermal_limit(pm::AbstractPowerModel, i::Int; nw::Int=nw_id_default)
     storage = ref(pm, nw, :storage, i)
     constraint_storage_thermal_limit(pm, nw, i, storage["thermal_rating"])
 end
 
-""
 function constraint_storage_current_limit(pm::AbstractPowerModel, i::Int; nw::Int=nw_id_default)
     storage = ref(pm, nw, :storage, i)
     constraint_storage_current_limit(pm, nw, i, storage["storage_bus"], storage["current_rating"])
 end
 
 
-""
 function constraint_storage_complementarity_nl(pm::AbstractPowerModel, i::Int; nw::Int=nw_id_default)
     constraint_storage_complementarity_nl(pm, nw, i)
 end
 
-""
 function constraint_storage_complementarity_mi(pm::AbstractPowerModel, i::Int; nw::Int=nw_id_default)
     storage = ref(pm, nw, :storage, i)
     charge_ub = storage["charge_rating"]
@@ -891,14 +847,12 @@ function constraint_storage_complementarity_mi(pm::AbstractPowerModel, i::Int; n
 end
 
 
-""
 function constraint_storage_losses(pm::AbstractPowerModel, i::Int; nw::Int=nw_id_default)
     storage = ref(pm, nw, :storage, i)
 
     constraint_storage_losses(pm, nw, i, storage["storage_bus"], storage["r"], storage["x"], storage["p_loss"], storage["q_loss"])
 end
 
-""
 function constraint_storage_state(pm::AbstractPowerModel, i::Int; nw::Int=nw_id_default)
     storage = ref(pm, nw, :storage, i)
 
@@ -912,7 +866,6 @@ function constraint_storage_state(pm::AbstractPowerModel, i::Int; nw::Int=nw_id_
     constraint_storage_state_initial(pm, nw, i, storage["energy"], storage["charge_efficiency"], storage["discharge_efficiency"], time_elapsed)
 end
 
-""
 function constraint_storage_state(pm::AbstractPowerModel, i::Int, nw_1::Int, nw_2::Int)
     storage = ref(pm, nw_2, :storage, i)
 
@@ -932,7 +885,6 @@ function constraint_storage_state(pm::AbstractPowerModel, i::Int, nw_1::Int, nw_
     end
 end
 
-""
 function constraint_storage_on_off(pm::AbstractPowerModel, i::Int; nw::Int=nw_id_default)
     storage = ref(pm, nw, :storage, i)
     charge_ub = storage["charge_rating"]
@@ -949,7 +901,6 @@ end
 
 ### DC LINES ###
 
-""
 function constraint_dcline_power_losses(pm::AbstractPowerModel, i::Int; nw::Int=nw_id_default)
     dcline = ref(pm, nw, :dcline, i)
     f_bus = dcline["f_bus"]
@@ -962,7 +913,6 @@ function constraint_dcline_power_losses(pm::AbstractPowerModel, i::Int; nw::Int=
     constraint_dcline_power_losses(pm, nw, f_bus, t_bus, f_idx, t_idx, loss0, loss1)
 end
 
-""
 function constraint_dcline_setpoint_active(pm::AbstractPowerModel, i::Int; nw::Int=nw_id_default)
     dcline = ref(pm, nw, :dcline, i)
     f_bus = dcline["f_bus"]
@@ -976,7 +926,6 @@ function constraint_dcline_setpoint_active(pm::AbstractPowerModel, i::Int; nw::I
 end
 
 
-""
 function constraint_dcline_power_fr_bounds(pm::AbstractPowerModel, i::Int; nw::Int=nw_id_default)
     dcline = ref(pm, nw, :dcline, i)
     f_bus = dcline["f_bus"]
@@ -991,7 +940,6 @@ function constraint_dcline_power_fr_bounds(pm::AbstractPowerModel, i::Int; nw::I
     constraint_dcline_power_fr_bounds(pm, nw, i, f_bus, f_idx, pmax, pmin, qmax, qmin)
 end
 
-""
 function constraint_dcline_power_to_bounds(pm::AbstractPowerModel, i::Int; nw::Int=nw_id_default)
     dcline = ref(pm, nw, :dcline, i)
     f_bus = dcline["f_bus"]

--- a/src/core/data.jl
+++ b/src/core/data.jl
@@ -12,7 +12,6 @@ function get_pm_data(data::Dict{String, <:Any})
 end
 
 
-""
 function calc_branch_t(branch::Dict{String,<:Any})
     tap_ratio = branch["tap"]
     angle_shift = branch["shift"]
@@ -24,7 +23,6 @@ function calc_branch_t(branch::Dict{String,<:Any})
 end
 
 
-""
 function calc_branch_y(branch::Dict{String,<:Any})
     y = LinearAlgebra.pinv(branch["br_r"] + im * branch["br_x"])
     g, b = real(y), imag(y)
@@ -32,7 +30,6 @@ function calc_branch_y(branch::Dict{String,<:Any})
 end
 
 
-""
 function calc_theta_delta_bounds(data::Dict{String,<:Any})
     bus_count = length(data["bus"])
     branches = [branch for branch in values(data["branch"])]
@@ -64,7 +61,6 @@ function calc_theta_delta_bounds(data::Dict{String,<:Any})
 end
 
 
-""
 function calc_max_cost_index(data::Dict{String,<:Any})
     if _IM.ismultinetwork(data)
         max_index = 0
@@ -79,7 +75,6 @@ function calc_max_cost_index(data::Dict{String,<:Any})
 end
 
 
-""
 function _calc_max_cost_index(data::Dict{String,<:Any})
     max_index = 0
 
@@ -230,7 +225,6 @@ function make_multinetwork(data::Dict{String, <:Any}; global_keys::Set{String}=S
 end
 
 
-""
 function _apply_func!(data::Dict{String,<:Any}, key::String, func)
     if haskey(data, key)
         data[key] = func.(data[key])
@@ -249,7 +243,6 @@ function make_per_unit!(data::Dict{String,<:Any})
 end
 
 
-""
 function _make_per_unit!(data::Dict{String,<:Any})
     mva_base = data["baseMVA"]
 
@@ -396,7 +389,6 @@ function make_mixed_units!(data::Dict{String,<:Any})
 end
 
 
-""
 function _make_mixed_units!(data::Dict{String,<:Any})
     mva_base = data["baseMVA"]
 
@@ -532,7 +524,6 @@ function _make_mixed_units!(data::Dict{String,<:Any})
 end
 
 
-""
 function _rescale_cost_model!(comp::Dict{String,<:Any}, scale::Real)
     if "model" in keys(comp) && "cost" in keys(comp)
         if comp["model"] == 1
@@ -1055,7 +1046,6 @@ function correct_thermal_limits!(data::Dict{String,<:Any})
     apply_pm!(_correct_thermal_limits!, data)
 end
 
-""
 function _correct_thermal_limits!(pm_data::Dict{String,<:Any})
     branches = [branch for branch in values(pm_data["branch"])]
 
@@ -1090,7 +1080,6 @@ function calc_thermal_limits!(data::Dict{String,<:Any})
 end
 
 
-""
 function _calc_thermal_limits!(pm_data::Dict{String,<:Any})
     mva_base = pm_data["baseMVA"]
 
@@ -1140,7 +1129,6 @@ function correct_current_limits!(data::Dict{String,<:Any})
     apply_pm!(_correct_current_limits!, data)
 end
 
-""
 function _correct_current_limits!(pm_data::Dict{String,<:Any})
     branches = [branch for branch in values(pm_data["branch"])]
 
@@ -1226,7 +1214,6 @@ function correct_branch_directions!(data::Dict{String,<:Any})
     apply_pm!(_correct_branch_directions!, data)
 end
 
-""
 function _correct_branch_directions!(pm_data::Dict{String,<:Any})
 
     orientations = Set()
@@ -1264,7 +1251,6 @@ function check_branch_loops(data::Dict{String,<:Any})
     apply_pm!(_check_branch_loops, data)
 end
 
-""
 function _check_branch_loops(pm_data::Dict{String, <:Any})
     for (i, branch) in pm_data["branch"]
         if branch["f_bus"] == branch["t_bus"]
@@ -1280,7 +1266,6 @@ function check_connectivity(data::Dict{String,<:Any})
 end
 
 
-""
 function _check_connectivity(data::Dict{String,<:Any})
     bus_ids = Set(bus["index"] for (i,bus) in data["bus"])
     @assert(length(bus_ids) == length(data["bus"])) # if this is not true something very bad is going on
@@ -1346,7 +1331,6 @@ function check_status(data::Dict{String,<:Any})
     apply_pm!(_check_status, data)
 end
 
-""
 function _check_status(data::Dict{String,<:Any})
     active_bus_ids = Set(bus["index"] for (i,bus) in data["bus"] if bus["bus_type"] != 4)
 
@@ -1420,7 +1404,6 @@ function check_reference_bus(data::Dict{String,<:Any})
     apply_pm!(_check_reference_bus, data)
 end
 
-""
 function _check_reference_bus(data::Dict{String,<:Any})
     ref_buses = Dict{String,Any}()
 
@@ -1450,7 +1433,6 @@ function correct_transformer_parameters!(data::Dict{String,<:Any})
 end
 
 
-""
 function _correct_transformer_parameters!(pm_data::Dict{String,<:Any})
 
     for (i, branch) in pm_data["branch"]
@@ -1478,7 +1460,6 @@ function check_storage_parameters(data::Dict{String,<:Any})
     apply_pm!(_check_storage_parameters, data)
 end
 
-""
 function _check_storage_parameters(data::Dict{String,<:Any})
     for (i, strg) in data["storage"]
         if strg["energy"] < 0.0
@@ -1538,7 +1519,6 @@ function check_switch_parameters(data::Dict{String,<:Any})
     apply_pm!(_check_switch_parameters, data)
 end
 
-""
 function _check_switch_parameters(data::Dict{String,<:Any})
     for (i, switch) in data["switch"]
         if switch["state"] <= 0.0 && (!isapprox(switch["psw"], 0.0) || !isapprox(switch["qsw"], 0.0))
@@ -1569,7 +1549,6 @@ function correct_bus_types!(data::Dict{String,<:Any})
     apply_pm!(_correct_bus_types!, data)
 end
 
-""
 function _correct_bus_types!(pm_data::Dict{String,<:Any})
     bus_gens = Dict(bus["index"] => [] for (i,bus) in pm_data["bus"])
 
@@ -1658,7 +1637,6 @@ function correct_dcline_limits!(data::Dict{String,<:Any})
     apply_pm!(_correct_dcline_limits!, data)
 end
 
-""
 function _correct_dcline_limits!(pm_data::Dict{String,<:Any})
     mva_base = pm_data["baseMVA"]
 
@@ -1700,7 +1678,6 @@ function check_voltage_setpoints(data::Dict{String,<:Any})
     apply_pm!(_check_voltage_setpoints, data)
 end
 
-""
 function _check_voltage_setpoints(data::Dict{String,<:Any})
 
     for (i,gen) in data["gen"]
@@ -1734,7 +1711,6 @@ function correct_cost_functions!(data::Dict{String,<:Any})
     apply_pm!(_correct_cost_functions!, data)
 end
 
-""
 function _correct_cost_functions!(pm_data::Dict{String,<:Any})
     for (i,gen) in pm_data["gen"]
         _correct_cost_function!(i, gen, "generator", "pmin", "pmax")
@@ -1746,7 +1722,6 @@ function _correct_cost_functions!(pm_data::Dict{String,<:Any})
 end
 
 
-""
 function _correct_cost_function!(id, comp, type_name, pmin_key, pmax_key)
 
     if "model" in keys(comp) && "cost" in keys(comp)
@@ -1859,7 +1834,6 @@ function simplify_cost_terms!(data::Dict{String,<:Any})
     apply_pm!(_simplify_cost_terms!, data)
 end
 
-""
 function _simplify_cost_terms!(pm_data::Dict{String,<:Any})
 
     if haskey(pm_data, "gen")
@@ -2022,7 +1996,6 @@ function propagate_topology_status!(data::Dict{String, <:Any})
 end
 
 
-""
 function _propagate_topology_status!(data::Dict{String,<:Any})
     buses = Dict(bus["bus_i"] => bus for (i,bus) in data["bus"])
 
@@ -2175,7 +2148,6 @@ function deactivate_isolated_components!(data::Dict{String, <:Any})
 end
 
 
-""
 function _deactivate_isolated_components!(data::Dict{String,<:Any})
     buses = Dict(bus["bus_i"] => bus for (i,bus) in data["bus"])
 
@@ -2369,7 +2341,6 @@ function select_largest_component!(data::Dict{String, <:Any})
     apply_pm!(_select_largest_component!, data)
 end
 
-""
 function _select_largest_component!(data::Dict{String,<:Any})
     ccs = calc_connected_components(data)
 
@@ -2400,7 +2371,6 @@ function correct_reference_buses!(data::Dict{String,<:Any})
     apply_pm!(_correct_reference_buses!, data)
 end
 
-""
 function _correct_reference_buses!(data::Dict{String,<:Any})
     bus_lookup = Dict(bus["bus_i"] => bus for (i,bus) in data["bus"])
     bus_gen = bus_gen_lookup(data["gen"], data["bus"])
@@ -2692,7 +2662,6 @@ end
 
 @deprecate resolve_swithces! resolve_switches!
 
-""
 function _resolve_switches!(data::Dict{String,<:Any})
     if length(data["switch"]) <= 0
         return

--- a/src/core/expression_template.jl
+++ b/src/core/expression_template.jl
@@ -64,7 +64,6 @@ end
 
 
 
-""
 function expression_branch_power_ohms_yt_from(pm::AbstractPowerModel, i::Int; nw::Int=nw_id_default)
     if !haskey(var(pm, nw), :p)
         var(pm, nw)[:p] = Dict{Tuple{Int,Int,Int},Any}()
@@ -89,7 +88,6 @@ function expression_branch_power_ohms_yt_from(pm::AbstractPowerModel, i::Int; nw
 end
 
 
-""
 function expression_branch_power_ohms_yt_to(pm::AbstractPowerModel, i::Int; nw::Int=nw_id_default)
     if !haskey(var(pm, nw), :p)
         var(pm, nw)[:p] = Dict{Tuple{Int,Int,Int},Any}()
@@ -115,7 +113,6 @@ end
 
 
 
-""
 function expression_branch_power_ohms_yt_from_ptdf(pm::AbstractPowerModel, i::Int; nw::Int=nw_id_default)
     if !haskey(var(pm, nw), :p)
         var(pm, nw)[:p] = Dict{Tuple{Int,Int,Int},Any}()
@@ -155,7 +152,6 @@ function expression_branch_power_ohms_yt_from_ptdf(pm::AbstractPowerModel, i::In
 end
 
 
-""
 function expression_branch_power_ohms_yt_to_ptdf(pm::AbstractPowerModel, i::Int; nw::Int=nw_id_default)
     if !haskey(var(pm, nw), :p)
         var(pm, nw)[:p] = Dict{Tuple{Int,Int,Int},Any}()

--- a/src/core/objective.jl
+++ b/src/core/objective.jl
@@ -12,7 +12,6 @@ function objective_min_fuel_and_flow_cost(pm::AbstractPowerModel; kwargs...)
 end
 
 
-""
 function objective_min_fuel_cost(pm::AbstractPowerModel; kwargs...)
     expression_pg_cost(pm; kwargs...)
 
@@ -306,14 +305,14 @@ function objective_max_loadability(pm::AbstractPowerModel)
     time_elapsed = Dict(n => get(ref(pm, n), :time_elapsed, 1) for n in nws)
 
     load_weight = Dict(n =>
-        Dict(i => get(load, "weight", 1.0) for (i,load) in ref(pm, n, :load)) 
+        Dict(i => get(load, "weight", 1.0) for (i,load) in ref(pm, n, :load))
     for n in nws)
 
     #println(load_weight)
 
     return JuMP.@objective(pm.model, Max,
-        sum( 
-            ( 
+        sum(
+            (
             time_elapsed[n]*(
                 sum(z_shunt[n][i] for (i,shunt) in ref(pm, n, :shunt)) +
                 sum(load_weight[n][i]*abs(load["pd"])*z_demand[n][i] for (i,load) in ref(pm, n, :load))

--- a/src/core/variable.jl
+++ b/src/core/variable.jl
@@ -161,7 +161,6 @@ function variable_branch_voltage_magnitude_to_sqr_on_off(pm::AbstractPowerModel;
     report && sol_component_value(pm, nw, :branch, :w_to, ids(pm, nw, :branch), w_to)
 end
 
-""
 function variable_buspair_cosine(pm::AbstractPowerModel; nw::Int=nw_id_default, bounded::Bool=true, report::Bool=true)
     cs = var(pm, nw)[:cs] = JuMP.@variable(pm.model,
         [bp in ids(pm, nw, :buspairs)], base_name="$(nw)_cs",
@@ -193,7 +192,6 @@ function variable_buspair_cosine(pm::AbstractPowerModel; nw::Int=nw_id_default, 
     report && sol_component_value_buspair(pm, nw, :buspairs, :cs, ids(pm, nw, :buspairs), cs)
 end
 
-""
 function variable_buspair_sine(pm::AbstractPowerModel; nw::Int=nw_id_default, bounded::Bool=true, report::Bool=true)
     si = var(pm, nw)[:si] = JuMP.@variable(pm.model,
         [bp in ids(pm, nw, :buspairs)], base_name="$(nw)_si",
@@ -210,7 +208,6 @@ function variable_buspair_sine(pm::AbstractPowerModel; nw::Int=nw_id_default, bo
     report && sol_component_value_buspair(pm, nw, :buspairs, :si, ids(pm, nw, :buspairs), si)
 end
 
-""
 function variable_buspair_voltage_product(pm::AbstractPowerModel; nw::Int=nw_id_default, bounded::Bool=true, report::Bool=true)
     wr = var(pm, nw)[:wr] = JuMP.@variable(pm.model,
         [bp in ids(pm, nw, :buspairs)], base_name="$(nw)_wr",
@@ -237,7 +234,6 @@ function variable_buspair_voltage_product(pm::AbstractPowerModel; nw::Int=nw_id_
     report && sol_component_value_buspair(pm, nw, :buspairs, :wi, ids(pm, nw, :buspairs), wi)
 end
 
-""
 function variable_branch_voltage_product_on_off(pm::AbstractPowerModel; nw::Int=nw_id_default, report::Bool=true)
     wr_min, wr_max, wi_min, wi_max = ref_calc_voltage_product_bounds(ref(pm, nw, :buspairs))
     bi_bp = Dict((i, (b["f_bus"], b["t_bus"])) for (i,b) in ref(pm, nw, :branch))
@@ -396,7 +392,6 @@ end
 
 
 
-""
 function variable_branch_power(pm::AbstractPowerModel; kwargs...)
     variable_branch_power_real(pm; kwargs...)
     variable_branch_power_imaginary(pm; kwargs...)
@@ -802,7 +797,6 @@ function variable_dcline_current_imaginary(pm::AbstractPowerModel; nw::Int=nw_id
 end
 
 
-""
 function variable_switch_indicator(pm::AbstractPowerModel; nw::Int=nw_id_default, relax::Bool=false, report::Bool=true)
     if !relax
         z_switch = var(pm, nw)[:z_switch] = JuMP.@variable(pm.model,
@@ -823,7 +817,6 @@ function variable_switch_indicator(pm::AbstractPowerModel; nw::Int=nw_id_default
 end
 
 
-""
 function variable_switch_power(pm::AbstractPowerModel; kwargs...)
     variable_switch_power_real(pm; kwargs...)
     variable_switch_power_imaginary(pm; kwargs...)
@@ -915,7 +908,6 @@ function variable_storage_power_mi(pm::AbstractPowerModel; kwargs...)
 end
 
 
-""
 function variable_storage_power_real(pm::AbstractPowerModel; nw::Int=nw_id_default, bounded::Bool=true, report::Bool=true)
     ps = var(pm, nw)[:ps] = JuMP.@variable(pm.model,
         [i in ids(pm, nw, :storage)], base_name="$(nw)_ps",
@@ -938,7 +930,6 @@ function variable_storage_power_real(pm::AbstractPowerModel; nw::Int=nw_id_defau
     report && sol_component_value(pm, nw, :storage, :ps, ids(pm, nw, :storage), ps)
 end
 
-""
 function variable_storage_power_imaginary(pm::AbstractPowerModel; nw::Int=nw_id_default, bounded::Bool=true, report::Bool=true)
     qs = var(pm, nw)[:qs] = JuMP.@variable(pm.model,
         [i in ids(pm, nw, :storage)], base_name="$(nw)_qs",
@@ -992,7 +983,6 @@ function variable_storage_current(pm::AbstractPowerModel; nw::Int=nw_id_default,
 end
 
 
-""
 function variable_storage_energy(pm::AbstractPowerModel; nw::Int=nw_id_default, bounded::Bool=true, report::Bool=true)
     se = var(pm, nw)[:se] = JuMP.@variable(pm.model,
         [i in ids(pm, nw, :storage)], base_name="$(nw)_se",
@@ -1009,7 +999,6 @@ function variable_storage_energy(pm::AbstractPowerModel; nw::Int=nw_id_default, 
     report && sol_component_value(pm, nw, :storage, :se, ids(pm, nw, :storage), se)
 end
 
-""
 function variable_storage_charge(pm::AbstractPowerModel; nw::Int=nw_id_default, bounded::Bool=true, report::Bool=true)
     sc = var(pm, nw)[:sc] = JuMP.@variable(pm.model,
         [i in ids(pm, nw, :storage)], base_name="$(nw)_sc",
@@ -1026,7 +1015,6 @@ function variable_storage_charge(pm::AbstractPowerModel; nw::Int=nw_id_default, 
     report && sol_component_value(pm, nw, :storage, :sc, ids(pm, nw, :storage), sc)
 end
 
-""
 function variable_storage_discharge(pm::AbstractPowerModel; nw::Int=nw_id_default, bounded::Bool=true, report::Bool=true)
     sd = var(pm, nw)[:sd] = JuMP.@variable(pm.model,
         [i in ids(pm, nw, :storage)], base_name="$(nw)_sd",
@@ -1043,7 +1031,6 @@ function variable_storage_discharge(pm::AbstractPowerModel; nw::Int=nw_id_defaul
     report && sol_component_value(pm, nw, :storage, :sd, ids(pm, nw, :storage), sd)
 end
 
-""
 function variable_storage_complementary_indicator(pm::AbstractPowerModel; nw::Int=nw_id_default, relax::Bool=false, report::Bool=true)
     if !relax
         sc_on = var(pm, nw)[:sc_on] = JuMP.@variable(pm.model,
@@ -1269,7 +1256,6 @@ function variable_ne_branch_indicator(pm::AbstractPowerModel; nw::Int=nw_id_defa
 end
 
 
-""
 function variable_load_power_factor(pm::AbstractPowerModel; nw::Int=nw_id_default, relax::Bool=false, report::Bool=true)
     if !relax
         z_demand = var(pm, nw)[:z_demand] = JuMP.@variable(pm.model,
@@ -1296,7 +1282,6 @@ function variable_load_power_factor(pm::AbstractPowerModel; nw::Int=nw_id_defaul
 end
 
 
-""
 function variable_shunt_admittance_factor(pm::AbstractPowerModel; nw::Int=nw_id_default, relax::Bool=false, report::Bool=true)
     if !relax
         z_shunt = var(pm, nw)[:z_shunt] = JuMP.@variable(pm.model,

--- a/src/form/acp.jl
+++ b/src/form/acp.jl
@@ -1,18 +1,15 @@
 ### polar form of the non-convex AC equations
 
-""
 function variable_bus_voltage(pm::AbstractACPModel; kwargs...)
     variable_bus_voltage_angle(pm; kwargs...)
     variable_bus_voltage_magnitude(pm; kwargs...)
 end
 
-""
 function sol_data_model!(pm::AbstractACPModel, solution::Dict)
     # nothing to do, this is in the data model space by default
 end
 
 
-""
 function variable_ne_branch_voltage(pm::AbstractACPModel; kwargs...)
 end
 
@@ -49,7 +46,6 @@ function constraint_current_limit_to(pm::AbstractACPModel, n::Int, t_idx, c_rati
 end
 
 
-""
 function constraint_power_balance(pm::AbstractACPModel, n::Int, i::Int, bus_arcs, bus_arcs_dc, bus_arcs_sw, bus_gens, bus_storage, bus_pd, bus_qd, bus_gs, bus_bs)
     vm   = var(pm, n, :vm, i)
     p    = get(var(pm, n),    :p, Dict()); _check_var_keys(p, bus_arcs, "active power", "branch")
@@ -92,7 +88,6 @@ function constraint_power_balance(pm::AbstractACPModel, n::Int, i::Int, bus_arcs
     end
 end
 
-""
 function constraint_power_balance_ls(pm::AbstractACPModel, n::Int, i::Int, bus_arcs, bus_arcs_dc, bus_arcs_sw, bus_gens, bus_storage, bus_pd, bus_qd, bus_gs, bus_bs)
     vm   = var(pm, n, :vm, i)
     p    = get(var(pm, n),    :p, Dict()); _check_var_keys(p, bus_arcs, "active power", "branch")
@@ -138,7 +133,6 @@ function constraint_power_balance_ls(pm::AbstractACPModel, n::Int, i::Int, bus_a
 end
 
 
-""
 function constraint_ne_power_balance(pm::AbstractACPModel, n::Int, i::Int, bus_arcs, bus_arcs_dc, bus_arcs_sw, bus_arcs_ne, bus_gens, bus_storage, bus_pd, bus_qd, bus_gs, bus_bs)
     vm   = var(pm, n, :vm, i)
     p    = get(var(pm, n),    :p, Dict()); _check_var_keys(p, bus_arcs, "active power", "branch")
@@ -180,7 +174,6 @@ end
 
 
 
-""
 function expression_branch_power_ohms_yt_from(pm::AbstractACPModel, n::Int, f_bus, t_bus, f_idx, t_idx, g, b, g_fr, b_fr, tr, ti, tm)
     vm_fr = var(pm, n, :vm, f_bus)
     vm_to = var(pm, n, :vm, t_bus)
@@ -191,7 +184,6 @@ function expression_branch_power_ohms_yt_from(pm::AbstractACPModel, n::Int, f_bu
     var(pm, n, :q)[f_idx] = JuMP.@expression(pm.model, -(b+b_fr)/tm^2*vm_fr^2 - (-b*tr-g*ti)/tm^2*(vm_fr*vm_to*cos(va_fr-va_to)) + (-g*tr+b*ti)/tm^2*(vm_fr*vm_to*sin(va_fr-va_to)) )
 end
 
-""
 function expression_branch_power_ohms_yt_to(pm::AbstractACPModel, n::Int, f_bus, t_bus, f_idx, t_idx, g, b, g_to, b_to, tr, ti, tm)
     vm_fr = var(pm, n, :vm, f_bus)
     vm_to = var(pm, n, :vm, t_bus)
@@ -284,7 +276,6 @@ function constraint_ohms_y_to(pm::AbstractACPModel, n::Int, f_bus, t_bus, f_idx,
 end
 
 
-""
 function constraint_switch_state_closed(pm::AbstractACPModel, n::Int, f_bus, t_bus)
     vm_fr = var(pm, n, :vm, f_bus)
     vm_to = var(pm, n, :vm, t_bus)
@@ -295,7 +286,6 @@ function constraint_switch_state_closed(pm::AbstractACPModel, n::Int, f_bus, t_b
     JuMP.@constraint(pm.model, va_fr == va_to)
 end
 
-""
 function constraint_switch_voltage_on_off(pm::AbstractACPModel, n::Int, i, f_bus, t_bus, vad_min, vad_max)
     vm_fr = var(pm, n, :vm, f_bus)
     vm_to = var(pm, n, :vm, t_bus)
@@ -307,7 +297,6 @@ function constraint_switch_voltage_on_off(pm::AbstractACPModel, n::Int, i, f_bus
     JuMP.@constraint(pm.model, z*va_fr == z*va_to)
 end
 
-""
 function variable_bus_voltage_on_off(pm::AbstractACPModel; kwargs...)
     variable_bus_voltage_angle(pm; kwargs...)
     variable_bus_voltage_magnitude(pm; kwargs...)
@@ -436,7 +425,6 @@ function constraint_ohms_y_oltc_pst_to(pm::AbstractACPModel, n::Int, f_bus, t_bu
 end
 
 
-""
 function constraint_ohms_y_pst_from(pm::AbstractACPModel, n::Int, f_bus, t_bus, f_idx, t_idx, g, b, g_fr, b_fr, tm)
     p_fr  = var(pm, n, :p, f_idx)
     q_fr  = var(pm, n,  :q, f_idx)
@@ -450,7 +438,6 @@ function constraint_ohms_y_pst_from(pm::AbstractACPModel, n::Int, f_bus, t_bus, 
     JuMP.@constraint(pm.model, q_fr == -(b+b_fr)/tm^2*vm_fr^2 - (-b)/tm*(vm_fr*vm_to*cos(va_fr-va_to-ta)) + (-g)/tm*(vm_fr*vm_to*sin(va_fr-va_to-ta)) )
 end
 
-""
 function constraint_ohms_y_pst_to(pm::AbstractACPModel, n::Int, f_bus, t_bus, f_idx, t_idx, g, b, g_to, b_to, tm)
     p_to  = var(pm, n,  :p, t_idx)
     q_to  = var(pm, n,  :q, t_idx)
@@ -509,7 +496,6 @@ function constraint_power_losses_lb(pm::AbstractACPModel, n::Int, f_bus, t_bus, 
 end
 
 
-""
 function constraint_storage_current_limit(pm::AbstractACPModel, n::Int, i, bus, rating)
     vm = var(pm, n, :vm, bus)
     ps = var(pm, n, :ps, i)
@@ -519,7 +505,6 @@ function constraint_storage_current_limit(pm::AbstractACPModel, n::Int, i, bus, 
 end
 
 
-""
 function constraint_storage_losses(pm::AbstractACPModel, n::Int, i, bus, r, x, p_loss, q_loss)
     vm = var(pm, n, :vm, bus)
     ps = var(pm, n, :ps, i)

--- a/src/form/acr.jl
+++ b/src/form/acr.jl
@@ -1,6 +1,5 @@
 ### rectangular form of the non-convex AC equations
 
-""
 function variable_bus_voltage(pm::AbstractACRModel; nw::Int=nw_id_default, bounded::Bool=true, kwargs...)
     variable_bus_voltage_real(pm; nw=nw, bounded=bounded, kwargs...)
     variable_bus_voltage_imaginary(pm; nw=nw, bounded=bounded, kwargs...)
@@ -90,7 +89,6 @@ function constraint_power_balance(pm::AbstractACRModel, n::Int, i::Int, bus_arcs
     end
 end
 
-""
 function constraint_power_balance_ls(pm::AbstractACRModel, n::Int, i::Int, bus_arcs, bus_arcs_dc, bus_arcs_sw, bus_gens, bus_storage, bus_pd, bus_qd, bus_gs, bus_bs)
     vr = var(pm, n, :vr, i)
     vi = var(pm, n, :vi, i)
@@ -137,7 +135,6 @@ end
 
 
 
-""
 function expression_branch_power_ohms_yt_from(pm::AbstractACRModel, n::Int, f_bus, t_bus, f_idx, t_idx, g, b, g_fr, b_fr, tr, ti, tm)
     vr_fr = var(pm, n, :vr, f_bus)
     vr_to = var(pm, n, :vr, t_bus)
@@ -149,7 +146,6 @@ function expression_branch_power_ohms_yt_from(pm::AbstractACRModel, n::Int, f_bu
 end
 
 
-""
 function expression_branch_power_ohms_yt_to(pm::AbstractACRModel, n::Int, f_bus, t_bus, f_idx, t_idx, g, b, g_to, b_to, tr, ti, tm)
     vr_fr = var(pm, n, :vr, f_bus)
     vr_to = var(pm, n, :vr, t_bus)
@@ -192,7 +188,6 @@ function constraint_ohms_yt_to(pm::AbstractACRModel, n::Int, f_bus, t_bus, f_idx
 end
 
 
-""
 function constraint_storage_losses(pm::AbstractACRModel, n::Int, i, bus, r, x, p_loss, q_loss)
     vr = var(pm, n, :vr, bus)
     vi = var(pm, n, :vi, bus)
@@ -245,13 +240,11 @@ function constraint_voltage_angle_difference(pm::AbstractACRModel, n::Int, f_idx
     JuMP.@constraint(pm.model, (vi_fr*vr_to - vr_fr*vi_to) >= tan(angmin)*(vr_fr*vr_to + vi_fr*vi_to))
 end
 
-""
 function sol_data_model!(pm::AbstractACRModel, solution::Dict)
     apply_pm!(_sol_data_model_acr!, solution)
 end
 
 
-""
 function _sol_data_model_acr!(solution::Dict)
     if haskey(solution, "bus")
         for (i, bus) in solution["bus"]

--- a/src/form/act.jl
+++ b/src/form/act.jl
@@ -5,7 +5,6 @@ function constraint_theta_ref(pm::AbstractACTModel, n::Int, i::Int)
     JuMP.@constraint(pm.model, var(pm, n, :va)[i] == 0)
 end
 
-""
 function variable_bus_voltage(pm::AbstractACTModel; kwargs...)
     variable_bus_voltage_angle(pm; kwargs...)
     variable_bus_voltage_magnitude_sqr(pm; kwargs...)
@@ -27,7 +26,6 @@ function constraint_model_voltage(pm::AbstractACTModel, n::Int)
 end
 
 
-""
 function constraint_power_balance_ls(pm::AbstractACTModel, n::Int, i::Int, bus_arcs, bus_arcs_dc, bus_arcs_sw, bus_gens, bus_storage, bus_pd, bus_qd, bus_gs, bus_bs)
     w    = var(pm, n, :w, i)
     p    = get(var(pm, n),    :p, Dict()); _check_var_keys(p, bus_arcs, "active power", "branch")

--- a/src/form/apo.jl
+++ b/src/form/apo.jl
@@ -55,7 +55,6 @@ end
 
 
 
-""
 function constraint_power_balance(pm::AbstractActivePowerModel, n::Int, i::Int, bus_arcs, bus_arcs_dc, bus_arcs_sw, bus_gens, bus_storage, bus_pd, bus_qd, bus_gs, bus_bs)
     p    = get(var(pm, n),    :p, Dict()); _check_var_keys(p, bus_arcs, "active power", "branch")
     pg   = get(var(pm, n),   :pg, Dict()); _check_var_keys(pg, bus_gens, "active power", "generator")
@@ -81,7 +80,6 @@ function constraint_power_balance(pm::AbstractActivePowerModel, n::Int, i::Int, 
     end
 end
 
-""
 function constraint_power_balance_ls(pm::AbstractActivePowerModel, n::Int, i::Int, bus_arcs, bus_arcs_dc, bus_arcs_sw, bus_gens, bus_storage, bus_pd, bus_qd, bus_gs, bus_bs)
     p    = get(var(pm, n),    :p, Dict()); _check_var_keys(p, bus_arcs, "active power", "branch")
     pg   = get(var(pm, n),   :pg, Dict()); _check_var_keys(pg, bus_gens, "active power", "generator")
@@ -109,7 +107,6 @@ function constraint_power_balance_ls(pm::AbstractActivePowerModel, n::Int, i::In
     end
 end
 
-""
 function constraint_ne_power_balance(pm::AbstractDCPModel, n::Int, i, bus_arcs, bus_arcs_dc, bus_arcs_sw, bus_arcs_ne, bus_gens, bus_storage, bus_pd, bus_qd, bus_gs, bus_bs)
     p    = get(var(pm, n),    :p, Dict()); _check_var_keys(p, bus_arcs, "active power", "branch")
     pg   = get(var(pm, n),   :pg, Dict()); _check_var_keys(pg, bus_gens, "active power", "generator")
@@ -137,7 +134,6 @@ function constraint_ne_power_balance(pm::AbstractDCPModel, n::Int, i, bus_arcs, 
 end
 
 
-""
 function expression_bus_power_injection(pm::AbstractActivePowerModel, n::Int, i::Int, bus_gens, bus_storage, bus_pd, bus_qd, bus_gs, bus_bs)
     pg   = get(var(pm, n),   :pg, Dict()); _check_var_keys(pg, bus_gens, "active power", "generator")
     ps   = get(var(pm, n),   :ps, Dict()); _check_var_keys(ps, bus_storage, "active power", "storage")
@@ -184,7 +180,6 @@ function constraint_thermal_limit_from(pm::AbstractActivePowerModel, n::Int, f_i
     end
 end
 
-""
 function constraint_thermal_limit_to(pm::AbstractActivePowerModel, n::Int, t_idx, rate_a)
     p_to = var(pm, n, :p, t_idx)
     if isa(p_to, JuMP.VariableRef) && JuMP.has_lower_bound(p_to)
@@ -203,7 +198,6 @@ function constraint_thermal_limit_to(pm::AbstractActivePowerModel, n::Int, t_idx
 end
 
 
-""
 function constraint_current_limit_from(pm::AbstractActivePowerModel, n::Int, f_idx, c_rating_a)
     p_fr = var(pm, n, :p, f_idx)
     if isa(p_fr, JuMP.VariableRef) && JuMP.has_lower_bound(p_fr)
@@ -216,7 +210,6 @@ function constraint_current_limit_from(pm::AbstractActivePowerModel, n::Int, f_i
     end
 end
 
-""
 function constraint_current_limit_to(pm::AbstractActivePowerModel, n::Int, t_idx, c_rating_a)
     p_to = var(pm, n, :p, t_idx)
     if isa(p_to, JuMP.VariableRef) && JuMP.has_lower_bound(p_to)
@@ -231,7 +224,6 @@ end
 
 
 
-""
 function constraint_thermal_limit_from_on_off(pm::AbstractActivePowerModel, n::Int, i, f_idx, rate_a)
     p_fr = var(pm, n, :p, f_idx)
     z = var(pm, n, :z_branch, i)
@@ -240,7 +232,6 @@ function constraint_thermal_limit_from_on_off(pm::AbstractActivePowerModel, n::I
     JuMP.@constraint(pm.model, p_fr >= -rate_a*z)
 end
 
-""
 function constraint_thermal_limit_to_on_off(pm::AbstractActivePowerModel, n::Int, i, t_idx, rate_a)
     p_to = var(pm, n, :p, t_idx)
     z = var(pm, n, :z_branch, i)
@@ -249,7 +240,6 @@ function constraint_thermal_limit_to_on_off(pm::AbstractActivePowerModel, n::Int
     JuMP.@constraint(pm.model, p_to >= -rate_a*z)
 end
 
-""
 function constraint_ne_thermal_limit_from(pm::AbstractActivePowerModel, n::Int, i, f_idx, rate_a)
     p_fr = var(pm, n, :p_ne, f_idx)
     z = var(pm, n, :branch_ne, i)
@@ -258,7 +248,6 @@ function constraint_ne_thermal_limit_from(pm::AbstractActivePowerModel, n::Int, 
     JuMP.@constraint(pm.model, p_fr >= -rate_a*z)
 end
 
-""
 function constraint_ne_thermal_limit_to(pm::AbstractActivePowerModel, n::Int, i, t_idx, rate_a)
     p_to = var(pm, n, :p_ne, t_idx)
     z = var(pm, n, :branch_ne, i)
@@ -269,7 +258,6 @@ end
 
 
 
-""
 function constraint_switch_thermal_limit(pm::AbstractActivePowerModel, n::Int, f_idx, rating)
     psw = var(pm, n, :psw, f_idx)
 
@@ -279,7 +267,6 @@ end
 
 
 
-""
 function constraint_storage_thermal_limit(pm::AbstractActivePowerModel, n::Int, i, rating)
     ps = var(pm, n, :ps, i)
 
@@ -287,7 +274,6 @@ function constraint_storage_thermal_limit(pm::AbstractActivePowerModel, n::Int, 
     JuMP.upper_bound(ps) >  rating && JuMP.set_upper_bound(ps,  rating)
 end
 
-""
 function constraint_storage_current_limit(pm::AbstractActivePowerModel, n::Int, i, bus, rating)
     ps = var(pm, n, :ps, i)
 
@@ -295,7 +281,6 @@ function constraint_storage_current_limit(pm::AbstractActivePowerModel, n::Int, 
     JuMP.upper_bound(ps) >  rating && JuMP.set_upper_bound(ps,  rating)
 end
 
-""
 function constraint_storage_losses(pm::AbstractActivePowerModel, n::Int, i, bus, r, x, p_loss, q_loss)
     ps = var(pm, n, :ps, i)
     sc = var(pm, n, :sc, i)

--- a/src/form/bf.jl
+++ b/src/form/bf.jl
@@ -1,6 +1,5 @@
 # this file contains (balanced) convexified DistFlow formulation, in W space
 
-""
 function variable_buspair_current_magnitude_sqr(pm::AbstractBFModel; nw::Int=nw_id_default, bounded::Bool=true, report::Bool=true)
     branch = ref(pm, nw, :branch)
 
@@ -28,12 +27,10 @@ function variable_buspair_current_magnitude_sqr(pm::AbstractBFModel; nw::Int=nw_
     report && sol_component_value(pm, nw, :branch, :ccm, ids(pm, nw, :branch), ccm)
 end
 
-""
 function variable_branch_current(pm::AbstractBFModel; kwargs...)
     variable_buspair_current_magnitude_sqr(pm; kwargs...)
 end
 
-""
 function variable_bus_voltage(pm::AbstractBFModel; kwargs...)
     variable_bus_voltage_magnitude_sqr(pm; kwargs...)
 end
@@ -180,12 +177,10 @@ function constraint_voltage_magnitude_difference(pm::AbstractBFAModel, n::Int, i
 end
 
 
-""
 function constraint_model_current(pm::AbstractBFAModel, n::Int)
 
 end
 
-""
 function variable_buspair_current_magnitude_sqr(pm::AbstractBFAModel; nw::Int=nw_id_default, bounded::Bool=true, report::Bool=true)
 
 end

--- a/src/form/dcp.jl
+++ b/src/form/dcp.jl
@@ -3,19 +3,16 @@
 
 ######## AbstractDCPForm Models (has va but assumes vm is 1.0) ########
 
-""
 function variable_bus_voltage(pm::AbstractDCPModel; kwargs...)
     variable_bus_voltage_angle(pm; kwargs...)
     variable_bus_voltage_magnitude(pm; kwargs...)
 end
 
-""
 function variable_bus_voltage_magnitude(pm::AbstractDCPModel; nw::Int=nw_id_default, bounded::Bool=true, report::Bool=true)
     report && sol_component_fixed(pm, nw, :bus, :vm, ids(pm, nw, :bus), 1.0)
 end
 
 
-""
 function sol_data_model!(pm::AbstractDCPModel, solution::Dict)
     # nothing to do, this is in the data model space by default
 end
@@ -55,7 +52,6 @@ function constraint_ohms_yt_from(pm::AbstractDCPModel, n::Int, f_bus, t_bus, f_i
     # omit reactive constraint
 end
 
-""
 function expression_branch_power_ohms_yt_from(pm::AbstractDCPModel, n::Int, f_bus, t_bus, f_idx, t_idx, g, b, g_fr, b_fr, tr, ti, tm)
     va_fr = var(pm, n, :va, f_bus)
     va_to = var(pm, n, :va, t_bus)
@@ -64,7 +60,6 @@ function expression_branch_power_ohms_yt_from(pm::AbstractDCPModel, n::Int, f_bu
     # omit reactive constraint
 end
 
-""
 function expression_branch_power_ohms_yt_to(pm::AbstractDCPModel, n::Int, f_bus, t_bus, f_idx, t_idx, g, b, g_fr, b_fr, tr, ti, tm)
     va_fr = var(pm, n, :va, f_bus)
     va_to = var(pm, n, :va, t_bus)
@@ -99,7 +94,6 @@ function constraint_ne_ohms_yt_from(pm::AbstractDCMPPModel, n::Int, i, f_bus, t_
 end
 
 
-""
 function expression_branch_power_ohms_yt_from(pm::AbstractDCMPPModel, n::Int, f_bus, t_bus, f_idx, t_idx, g, b, g_fr, b_fr, tr, ti, tm)
     va_fr = var(pm, n, :va, f_bus)
     va_to = var(pm, n, :va, t_bus)
@@ -111,7 +105,6 @@ function expression_branch_power_ohms_yt_from(pm::AbstractDCMPPModel, n::Int, f_
     # omit reactive constraint
 end
 
-""
 function expression_branch_power_ohms_yt_to(pm::AbstractDCMPPModel, n::Int, f_bus, t_bus, f_idx, t_idx, g, b, g_fr, b_fr, tr, ti, tm)
     va_fr = var(pm, n, :va, f_bus)
     va_to = var(pm, n, :va, t_bus)
@@ -123,7 +116,6 @@ function expression_branch_power_ohms_yt_to(pm::AbstractDCMPPModel, n::Int, f_bu
     # omit reactive constraint
 end
 
-""
 function constraint_ohms_yt_from(pm::AbstractDCMPPModel, n::Int, f_bus, t_bus, f_idx, t_idx, g, b, g_fr, b_fr, tr, ti, tm)
     p_fr  = var(pm, n,  :p, f_idx)
     va_fr = var(pm, n, :va, f_bus)
@@ -135,7 +127,6 @@ function constraint_ohms_yt_from(pm::AbstractDCMPPModel, n::Int, f_bus, t_bus, f
     JuMP.@constraint(pm.model, p_fr == (va_fr - va_to - ta)/(x*tm))
 end
 
-""
 function constraint_ohms_y_pst_from(pm::AbstractDCPModel, n::Int, f_bus, t_bus, f_idx, t_idx, g, b, g_fr, b_fr, tm)
     p_fr  = var(pm, n, :p, f_idx)
     va_fr = var(pm, n, :va, f_bus)
@@ -145,7 +136,6 @@ function constraint_ohms_y_pst_from(pm::AbstractDCPModel, n::Int, f_bus, t_bus, 
     JuMP.@constraint(pm.model, p_fr == -b*(va_fr - va_to - ta))
 end
 
-""
 function constraint_ohms_y_pst_to(pm::AbstractDCPModel, n::Int, f_bus, t_bus, f_idx, t_idx, g, b, g_to, b_to, tm)
     p_to  = var(pm, n, :p, t_idx)
     va_fr = var(pm, n, :va, f_bus)
@@ -157,7 +147,6 @@ end
 
 
 
-""
 function constraint_switch_state_closed(pm::AbstractDCPModel, n::Int, f_bus, t_bus)
     va_fr = var(pm, n, :va, f_bus)
     va_to = var(pm, n, :va, t_bus)
@@ -165,7 +154,6 @@ function constraint_switch_state_closed(pm::AbstractDCPModel, n::Int, f_bus, t_b
     JuMP.@constraint(pm.model, va_fr == va_to)
 end
 
-""
 function constraint_switch_voltage_on_off(pm::AbstractDCPModel, n::Int, i, f_bus, t_bus, vad_min, vad_max)
     va_fr = var(pm, n, :va, f_bus)
     va_to = var(pm, n, :va, t_bus)
@@ -176,7 +164,6 @@ function constraint_switch_voltage_on_off(pm::AbstractDCPModel, n::Int, i, f_bus
 end
 
 
-""
 function variable_bus_voltage_on_off(pm::AbstractDCPModel; kwargs...)
     variable_bus_voltage_angle(pm; kwargs...)
 end
@@ -227,7 +214,6 @@ function constraint_ne_voltage_angle_difference(pm::AbstractDCPModel, n::Int, f_
 end
 
 
-""
 function expression_bus_voltage(pm::AbstractPowerModel, n::Int, i, am::AdmittanceMatrix)
     ref_bus = collect(ids(pm, n, :ref_buses))[1]
     inj_factors = injection_factors_va(am, ref_bus, i)
@@ -236,7 +222,6 @@ function expression_bus_voltage(pm::AbstractPowerModel, n::Int, i, am::Admittanc
     var(pm, n, :va)[i] = JuMP.@expression(pm.model, sum(f*inj_p[j] for (j,f) in inj_factors))
 end
 
-""
 function expression_bus_voltage(pm::AbstractPowerModel, n::Int, i, am::AdmittanceMatrixInverse)
     inj_factors = injection_factors_va(am, i)
     inj_p = var(pm, n, :inj_p)
@@ -247,7 +232,6 @@ end
 
 ######## Lossless Models ########
 
-""
 function variable_branch_power_real(pm::AbstractAPLossLessModels; nw::Int=nw_id_default, bounded::Bool=true, report::Bool=true)
     p = var(pm, nw)[:p] = JuMP.@variable(pm.model,
         [(l,i,j) in ref(pm, nw, :arcs_from)], base_name="$(nw)_p",
@@ -283,7 +267,6 @@ function variable_branch_power_real(pm::AbstractAPLossLessModels; nw::Int=nw_id_
     report && sol_component_value_edge(pm, nw, :branch, :pf, :pt, ref(pm, nw, :arcs_from), ref(pm, nw, :arcs_to), p_expr)
 end
 
-""
 function variable_ne_branch_power_real(pm::AbstractAPLossLessModels; nw::Int=nw_id_default, bounded::Bool=true, report::Bool=true)
     p_ne = var(pm, nw)[:p_ne] = JuMP.@variable(pm.model,
         [(l,i,j) in ref(pm, nw, :ne_arcs_from)], base_name="$(nw)_p_ne",
@@ -306,7 +289,6 @@ function variable_ne_branch_power_real(pm::AbstractAPLossLessModels; nw::Int=nw_
     report && sol_component_value_edge(pm, nw, :ne_branch, :pf, :pt, ref(pm, nw, :ne_arcs_from), ref(pm, nw, :ne_arcs_to), p_ne_expr)
 end
 
-""
 function constraint_network_power_balance(pm::AbstractAPLossLessModels, n::Int, i, comp_gen_ids, comp_pd, comp_qd, comp_gs, comp_bs, comp_branch_g, comp_branch_b)
     pg = var(pm, n, :pg)
 
@@ -351,7 +333,6 @@ end
 function constraint_ne_ohms_yt_to(pm::AbstractAPLossLessModels, n::Int, i, f_bus, t_bus, f_idx, t_idx, g, b, g_to, b_to, tr, ti, tm, vad_min, vad_max)
 end
 
-""
 function constraint_storage_on_off(pm::AbstractAPLossLessModels, n::Int, i, pmin, pmax, qmin, qmax, charge_ub, discharge_ub)
     z_storage = var(pm, n, :z_storage, i)
     ps = var(pm, n, :ps, i)
@@ -364,7 +345,6 @@ function constraint_storage_on_off(pm::AbstractAPLossLessModels, n::Int, i, pmin
     JuMP.@constraint(pm.model, sd <= z_storage*discharge_ub)
 end
 
-""
 function constraint_storage_losses(pm::AbstractAPLossLessModels, n::Int, i, bus, r, x, p_loss, q_loss)
     ps = var(pm, n, :ps, i)
     sc = var(pm, n, :sc, i)
@@ -413,7 +393,6 @@ function constraint_ohms_yt_to(pm::AbstractDCPLLModel, n::Int, f_bus, t_bus, f_i
     JuMP.@constraint(pm.model, p_fr + p_to >= r*(p_fr^2))
 end
 
-""
 function constraint_ohms_yt_to_on_off(pm::AbstractDCPLLModel, n::Int, i, f_bus, t_bus, f_idx, t_idx, g, b, g_to, b_to, tr, ti, tm, vad_min, vad_max)
     p_fr  = var(pm, n,  :p, f_idx)
     p_to  = var(pm, n,  :p, t_idx)
@@ -427,7 +406,6 @@ function constraint_ohms_yt_to_on_off(pm::AbstractDCPLLModel, n::Int, i, f_bus, 
     JuMP.@constraint(pm.model, p_fr + p_to >= 0)
 end
 
-""
 function constraint_ne_ohms_yt_to(pm::AbstractDCPLLModel, n::Int, i, f_bus, t_bus, f_idx, t_idx, g, b, g_to, b_to, tr, ti, tm, vad_min, vad_max)
     p_fr = var(pm, n, :p_ne, f_idx)
     p_to = var(pm, n, :p_ne, t_idx)

--- a/src/form/iv.jl
+++ b/src/form/iv.jl
@@ -2,7 +2,6 @@
 # Even though the branch model is linear, the feasible set is non-convex
 # in the context of constant-power loads or generators
 
-""
 function variable_branch_current(pm::AbstractIVRModel; nw::Int=nw_id_default, bounded::Bool=true, report::Bool=true, kwargs...)
     variable_branch_current_real(pm, nw=nw, bounded=bounded, report=report; kwargs...)
     variable_branch_current_imaginary(pm, nw=nw, bounded=bounded, report=report; kwargs...)
@@ -36,7 +35,6 @@ function variable_branch_current(pm::AbstractIVRModel; nw::Int=nw_id_default, bo
     variable_branch_series_current_imaginary(pm, nw=nw, bounded=bounded, report=report; kwargs...)
 end
 
-""
 function variable_gen_current(pm::AbstractIVRModel; nw::Int=nw_id_default, bounded::Bool=true, report::Bool=true, kwargs...)
     variable_gen_current_real(pm, nw=nw, bounded=bounded, report=report; kwargs...)
     variable_gen_current_imaginary(pm, nw=nw, bounded=bounded, report=report; kwargs...)
@@ -66,7 +64,6 @@ function variable_gen_current(pm::AbstractIVRModel; nw::Int=nw_id_default, bound
     end
 end
 
-""
 function variable_dcline_current(pm::AbstractIVRModel; nw::Int=nw_id_default, bounded::Bool=true, report::Bool=true, kwargs...)
     variable_dcline_current_real(pm, nw=nw, bounded=bounded, report=report; kwargs...)
     variable_dcline_current_imaginary(pm, nw=nw, bounded=bounded, report=report; kwargs...)
@@ -197,7 +194,7 @@ function constraint_current_balance(pm::AbstractIVRModel, n::Int, i, bus_arcs, b
         - (sum(pd for pd in values(bus_pd))*vr + sum(qd for qd in values(bus_qd))*vi)/(vr^2 + vi^2)
         - sum(gs for gs in values(bus_gs))*vr + sum(bs for bs in values(bus_bs))*vi
     )
-    JuMP.@constraint(pm.model, 
+    JuMP.@constraint(pm.model,
         sum(ci[a] for a in bus_arcs)
         + sum(cidc[d] for d in bus_arcs_dc)
         ==

--- a/src/form/lpac.jl
+++ b/src/form/lpac.jl
@@ -1,13 +1,11 @@
 ### the LPAC approximation
 
-""
 function variable_bus_voltage(pm::AbstractLPACModel; kwargs...)
     variable_bus_voltage_angle(pm; kwargs...)
     variable_bus_voltage_magnitude(pm; kwargs...)
     variable_buspair_cosine(pm; kwargs...)
 end
 
-""
 function variable_bus_voltage_magnitude(pm::AbstractLPACModel; nw::Int=nw_id_default, bounded::Bool=true, report::Bool=true)
     phi = var(pm, nw)[:phi] = JuMP.@variable(pm.model,
         [i in ids(pm, nw, :bus)], base_name="$(nw)_phi",
@@ -25,13 +23,11 @@ function variable_bus_voltage_magnitude(pm::AbstractLPACModel; nw::Int=nw_id_def
 end
 
 
-""
 function sol_data_model!(pm::AbstractLPACModel, solution::Dict)
     apply_pm!(_sol_data_model_lpac!, solution)
 end
 
 
-""
 function _sol_data_model_lpac!(solution::Dict)
     if haskey(solution, "bus")
         for (i, bus) in solution["bus"]
@@ -44,7 +40,6 @@ function _sol_data_model_lpac!(solution::Dict)
 end
 
 
-""
 function constraint_model_voltage(pm::AbstractLPACModel, n::Int)
     _check_missing_keys(var(pm, n), [:va,:cs], typeof(pm))
 
@@ -59,7 +54,6 @@ function constraint_model_voltage(pm::AbstractLPACModel, n::Int)
 end
 
 
-""
 function constraint_power_balance(pm::AbstractLPACModel, n::Int, i::Int, bus_arcs, bus_arcs_dc, bus_arcs_sw, bus_gens, bus_storage, bus_pd, bus_qd, bus_gs, bus_bs)
     phi  = var(pm, n, :phi, i)
     p    = get(var(pm, n),    :p, Dict()); _check_var_keys(p, bus_arcs, "active power", "branch")
@@ -102,7 +96,6 @@ function constraint_power_balance(pm::AbstractLPACModel, n::Int, i::Int, bus_arc
 end
 
 
-""
 function constraint_ohms_yt_from(pm::AbstractLPACCModel, n::Int, f_bus, t_bus, f_idx, t_idx, g, b, g_fr, b_fr, tr, ti, tm)
     p_fr   = var(pm, n, :p, f_idx)
     q_fr   = var(pm, n, :q, f_idx)
@@ -116,7 +109,6 @@ function constraint_ohms_yt_from(pm::AbstractLPACCModel, n::Int, f_bus, t_bus, f
     JuMP.@constraint(pm.model, q_fr == -(b+b_fr)/tm^2*(1.0 + 2*phi_fr) - (-b*tr-g*ti)/tm^2*(cs + phi_fr + phi_to) + (-g*tr+b*ti)/tm^2*(va_fr-va_to) )
 end
 
-""
 function constraint_ohms_yt_to(pm::AbstractLPACCModel, n::Int, f_bus, t_bus, f_idx, t_idx, g, b, g_to, b_to, tr, ti, tm)
     p_to   = var(pm, n, :p, t_idx)
     q_to   = var(pm, n, :q, t_idx)
@@ -155,7 +147,6 @@ function constraint_voltage_angle_difference_on_off(pm::AbstractLPACCModel, n::I
     JuMP.@constraint(pm.model, va_fr - va_to >= angmin*z + vad_min*(1-z))
 end
 
-""
 function variable_ne_branch_voltage(pm::AbstractLPACCModel; kwargs...)
     variable_ne_branch_voltage_magnitude_fr(pm; kwargs...)
     variable_ne_branch_voltage_magnitude_to(pm; kwargs...)
@@ -163,7 +154,6 @@ function variable_ne_branch_voltage(pm::AbstractLPACCModel; kwargs...)
     variable_ne_branch_cosine(pm; kwargs...)
 end
 
-""
 function variable_ne_branch_voltage_magnitude_fr(pm::AbstractLPACModel; nw::Int=nw_id_default, bounded::Bool=true, report::Bool=true)
     buses = ref(pm, nw, :bus)
     branches = ref(pm, nw, :ne_branch)
@@ -178,7 +168,6 @@ function variable_ne_branch_voltage_magnitude_fr(pm::AbstractLPACModel; nw::Int=
     report && sol_component_value(pm, nw, :ne_branch, :phi_fr, ids(pm, nw, :ne_branch), phi_fr_ne)
 end
 
-""
 function variable_ne_branch_voltage_magnitude_to(pm::AbstractLPACModel; nw::Int=nw_id_default, bounded::Bool=true, report::Bool=true)
     buses = ref(pm, nw, :bus)
     branches = ref(pm, nw, :ne_branch)
@@ -194,7 +183,6 @@ function variable_ne_branch_voltage_magnitude_to(pm::AbstractLPACModel; nw::Int=
     report && sol_component_value(pm, nw, :ne_branch, :phi_to, ids(pm, nw, :ne_branch), phi_to_ne)
 end
 
-""
 function variable_ne_branch_cosine(pm::AbstractLPACCModel; nw::Int=nw_id_default, report::Bool=true)
     cos_min = Dict((l, -Inf) for l in ids(pm, nw, :ne_branch))
     cos_max = Dict((l,  Inf) for l in ids(pm, nw, :ne_branch))
@@ -226,7 +214,6 @@ function variable_ne_branch_cosine(pm::AbstractLPACCModel; nw::Int=nw_id_default
     report && sol_component_value(pm, nw, :ne_branch, :cs, ids(pm, nw, :ne_branch), cs_ne)
 end
 
-""
 function variable_ne_branch_voltage_product_angle(pm::AbstractLPACCModel; nw::Int=nw_id_default, bounded::Bool=true, report::Bool=true)
     bi_bp = Dict((i, (b["f_bus"], b["t_bus"])) for (i,b) in ref(pm, nw, :ne_branch))
      buspair = ref(pm, nw, :ne_buspairs)
@@ -240,7 +227,6 @@ function variable_ne_branch_voltage_product_angle(pm::AbstractLPACCModel; nw::In
     report && sol_component_value(pm, nw, :ne_branch, :td, ids(pm, nw, :ne_branch), td_ne)
 end
 
-""
 function constraint_model_voltage_on_off(pm::AbstractLPACCModel, n::Int)
     phi  = var(pm, n, :phi)
     t = var(pm, n, :va)
@@ -273,7 +259,6 @@ function constraint_model_voltage_on_off(pm::AbstractLPACCModel, n::Int)
     end
 end
 
-""
 function constraint_ne_model_voltage(pm::AbstractLPACCModel, n::Int)
     phi  = var(pm, n, :phi)
     t = var(pm, n, :va)
@@ -306,7 +291,6 @@ function constraint_ne_model_voltage(pm::AbstractLPACCModel, n::Int)
     end
 end
 
-""
 function constraint_ne_power_balance(pm::AbstractLPACCModel, n::Int, i::Int, bus_arcs, bus_arcs_dc, bus_arcs_sw, bus_arcs_ne, bus_gens, bus_storage, bus_pd, bus_qd, bus_gs, bus_bs)
     phi  = var(pm, n, :phi, i)
     p    = get(var(pm, n),    :p, Dict()); _check_var_keys(p, bus_arcs, "active power", "branch")
@@ -350,7 +334,6 @@ function constraint_ne_power_balance(pm::AbstractLPACCModel, n::Int, i::Int, bus
     end
 end
 
-""
 function constraint_ne_ohms_yt_from(pm::AbstractLPACCModel, n::Int, i, f_bus, t_bus, f_idx, t_idx, g, b, g_fr, b_fr, tr, ti, tm, vad_min, vad_max)
     p_fr = var(pm, n,    :p_ne, f_idx)
     q_fr = var(pm, n,    :q_ne, f_idx)
@@ -363,7 +346,6 @@ function constraint_ne_ohms_yt_from(pm::AbstractLPACCModel, n::Int, i, f_bus, t_
     JuMP.@constraint(pm.model, q_fr == -(b+b_fr)/tm^2*(z + 2*phi_fr) - (-b*tr-g*ti)/tm^2*(cs + phi_fr + phi_to) + (-g*tr+b*ti)/tm^2*(td))
 end
 
-""
 function constraint_ne_ohms_yt_to(pm::AbstractLPACCModel, n::Int, i, f_bus, t_bus, f_idx, t_idx, g, b, g_to, b_to, tr, ti, tm, vad_min, vad_max)
     p_to = var(pm, n,    :p_ne, t_idx)
     q_to = var(pm, n,    :q_ne, t_idx)
@@ -389,7 +371,6 @@ function variable_bus_voltage_on_off(pm::AbstractLPACCModel; kwargs...)
 end
 
 
-""
 function variable_branch_voltage_magnitude_fr_on_off(pm::AbstractLPACCModel; nw::Int=nw_id_default, report::Bool=true)
     buses = ref(pm, nw, :bus)
     branches = ref(pm, nw, :branch)
@@ -404,7 +385,6 @@ function variable_branch_voltage_magnitude_fr_on_off(pm::AbstractLPACCModel; nw:
     report && sol_component_value(pm, nw, :branch, :phi_fr, ids(pm, nw, :branch), phi_fr)
 end
 
-""
 function variable_branch_voltage_magnitude_to_on_off(pm::AbstractLPACCModel; nw::Int=nw_id_default, report::Bool=true)
     buses = ref(pm, nw, :bus)
     branches = ref(pm, nw, :branch)

--- a/src/form/shared.jl
+++ b/src/form/shared.jl
@@ -11,7 +11,6 @@
 #
 
 
-""
 function variable_shunt_admittance_factor(pm::AbstractWConvexModels; nw::Int=nw_id_default, relax::Bool=false, report::Bool=true)
     if !relax
         z_shunt = var(pm, nw)[:z_shunt] = JuMP.@variable(pm.model,
@@ -93,7 +92,6 @@ function variable_bus_voltage_magnitude_only(pm::AbstractWModels; kwargs...)
     variable_bus_voltage_magnitude_sqr(pm; kwargs...)
 end
 
-""
 function constraint_voltage_magnitude_setpoint(pm::AbstractWModels, n::Int, i, vm)
     w = var(pm, n, :w, i)
 
@@ -105,13 +103,11 @@ function constraint_theta_ref(pm::AbstractWModels, n::Int, ref_bus::Int)
 end
 
 
-""
 function sol_data_model!(pm::AbstractWModels, solution::Dict)
     apply_pm!(_sol_data_model_w!, solution)
 end
 
 
-""
 function _sol_data_model_w!(solution::Dict)
     if haskey(solution, "bus")
         for (i, bus) in solution["bus"]
@@ -124,7 +120,6 @@ function _sol_data_model_w!(solution::Dict)
 end
 
 
-""
 function constraint_power_balance(pm::AbstractWModels, n::Int, i, bus_arcs, bus_arcs_dc, bus_arcs_sw, bus_gens, bus_storage, bus_pd, bus_qd, bus_gs, bus_bs)
     w    = var(pm, n, :w, i)
     p    = get(var(pm, n),    :p, Dict()); _check_var_keys(p, bus_arcs, "active power", "branch")
@@ -167,7 +162,6 @@ function constraint_power_balance(pm::AbstractWModels, n::Int, i, bus_arcs, bus_
 end
 
 
-""
 function constraint_power_balance_ls(pm::AbstractWConvexModels, n::Int, i::Int, bus_arcs, bus_arcs_dc, bus_arcs_sw, bus_gens, bus_storage, bus_pd, bus_qd, bus_gs, bus_bs)
     w    = var(pm, n, :w, i)
     p    = get(var(pm, n),    :p, Dict()); _check_var_keys(p, bus_arcs, "active power", "branch")
@@ -217,7 +211,6 @@ function constraint_power_balance_ls(pm::AbstractWConvexModels, n::Int, i::Int, 
 end
 
 
-""
 function constraint_ne_power_balance(pm::AbstractWModels, n::Int, i::Int, bus_arcs, bus_arcs_dc, bus_arcs_sw, bus_arcs_ne, bus_gens, bus_storage, bus_pd, bus_qd, bus_gs, bus_bs)
     w    = var(pm, n, :w, i)
     p    = get(var(pm, n),    :p, Dict()); _check_var_keys(p, bus_arcs, "active power", "branch")
@@ -264,7 +257,6 @@ function constraint_ne_power_balance(pm::AbstractWModels, n::Int, i::Int, bus_ar
 end
 
 
-""
 function expression_branch_power_ohms_yt_from(pm::AbstractWRModels, n::Int, f_bus, t_bus, f_idx, t_idx, g, b, g_fr, b_fr, tr, ti, tm)
     w_fr = var(pm, n, :w, f_bus)
     wr   = var(pm, n, :wr, (f_bus, t_bus))
@@ -275,7 +267,6 @@ function expression_branch_power_ohms_yt_from(pm::AbstractWRModels, n::Int, f_bu
 end
 
 
-""
 function expression_branch_power_ohms_yt_to(pm::AbstractWRModels, n::Int, f_bus, t_bus, f_idx, t_idx, g, b, g_to, b_to, tr, ti, tm)
     w_to = var(pm, n, :w, t_bus)
     wr   = var(pm, n, :wr, (f_bus, t_bus))
@@ -316,7 +307,6 @@ function constraint_ohms_yt_to(pm::AbstractWRModels, n::Int, f_bus, t_bus, f_idx
 end
 
 
-""
 function constraint_voltage_angle_difference(pm::AbstractWModels, n::Int, f_idx, angmin, angmax)
     i, f_bus, t_bus = f_idx
 
@@ -332,7 +322,6 @@ function constraint_voltage_angle_difference(pm::AbstractWModels, n::Int, f_idx,
 end
 
 
-""
 function constraint_network_power_balance(pm::AbstractWModels, n::Int, i, comp_gen_ids, comp_pd, comp_qd, comp_gs, comp_bs, comp_branch_g, comp_branch_b)
     for (i,(i,j,r,x,tm,g_fr,g_to)) in comp_branch_g
         @assert(r >= 0 && x >= 0) # requirement for the relaxation property
@@ -347,7 +336,6 @@ function constraint_network_power_balance(pm::AbstractWModels, n::Int, i, comp_g
 end
 
 
-""
 function constraint_switch_state_closed(pm::AbstractWModels, n::Int, f_bus, t_bus)
     w_fr = var(pm, n, :w, f_bus)
     w_to = var(pm, n, :w, t_bus)
@@ -355,7 +343,6 @@ function constraint_switch_state_closed(pm::AbstractWModels, n::Int, f_bus, t_bu
     JuMP.@constraint(pm.model, w_fr == w_to)
 end
 
-""
 function constraint_switch_voltage_on_off(pm::AbstractWModels, n::Int, i, f_bus, t_bus, vad_min, vad_max)
     w_fr = var(pm, n, :w, f_bus)
     w_to = var(pm, n, :w, t_bus)
@@ -374,7 +361,6 @@ function constraint_switch_voltage_on_off(pm::AbstractWModels, n::Int, i, f_bus,
 end
 
 
-""
 function constraint_current_limit_from(pm::AbstractWModels, n::Int, f_idx, c_rating_a)
     l,i,j = f_idx
 
@@ -385,7 +371,6 @@ function constraint_current_limit_from(pm::AbstractWModels, n::Int, f_idx, c_rat
     JuMP.@constraint(pm.model, p_fr^2 + q_fr^2 <= w_fr*c_rating_a^2)
 end
 
-""
 function constraint_current_limit_to(pm::AbstractWModels, n::Int, t_idx, c_rating_a)
     l,j,i = t_idx
 
@@ -397,7 +382,6 @@ function constraint_current_limit_to(pm::AbstractWModels, n::Int, t_idx, c_ratin
 end
 
 
-""
 function constraint_storage_losses(pm::AbstractWConvexModels, n::Int, i, bus, r, x, p_loss, q_loss)
     w = var(pm, n, :w, bus)
     ccms = var(pm, n, :ccms, i)

--- a/src/form/wr.jl
+++ b/src/form/wr.jl
@@ -1,19 +1,16 @@
 ### quadratic relaxations in the rectangular W-space (e.g. SOC and QC relaxations)
 
 
-""
 function variable_bus_voltage(pm::AbstractWRModel; kwargs...)
     variable_bus_voltage_magnitude_sqr(pm; kwargs...)
     variable_buspair_voltage_product(pm; kwargs...)
 end
 
-""
 function variable_bus_voltage(pm::AbstractWRConicModel; kwargs...)
     variable_bus_voltage_magnitude_sqr(pm; kwargs...)
     variable_buspair_voltage_product(pm; kwargs...)
 end
 
-""
 function constraint_model_voltage(pm::AbstractWRModel, n::Int)
     _check_missing_keys(var(pm, n), [:w,:wr,:wi], typeof(pm))
 
@@ -26,7 +23,6 @@ function constraint_model_voltage(pm::AbstractWRModel, n::Int)
     end
 end
 
-""
 function constraint_model_voltage(pm::AbstractWRConicModel, n::Int)
     _check_missing_keys(var(pm, n), [:w,:wr,:wi], typeof(pm))
 
@@ -77,7 +73,6 @@ function constraint_ne_ohms_yt_to(pm::AbstractWRModel, n::Int, i, f_bus, t_bus, 
     JuMP.@constraint(pm.model, q_to == -(b+b_to)*w_to - (-b*tr+g*ti)/tm^2*wr + (-g*tr-b*ti)/tm^2*-wi )
 end
 
-""
 function variable_bus_voltage_on_off(pm::AbstractWRModel; kwargs...)
     variable_bus_voltage_magnitude_sqr(pm; kwargs...)
 
@@ -86,7 +81,6 @@ function variable_bus_voltage_on_off(pm::AbstractWRModel; kwargs...)
     variable_branch_voltage_product_on_off(pm; kwargs...)
 end
 
-""
 function constraint_model_voltage_on_off(pm::AbstractWRModel, n::Int)
     w  = var(pm, n, :w)
     wr = var(pm, n, :wr)
@@ -107,7 +101,6 @@ function constraint_model_voltage_on_off(pm::AbstractWRModel, n::Int)
     end
 end
 
-""
 function constraint_ne_model_voltage(pm::AbstractWRModel, n::Int)
     buses = ref(pm, n, :bus)
     branches = ref(pm, n, :ne_branch)
@@ -142,7 +135,6 @@ function constraint_ne_model_voltage(pm::AbstractWRModel, n::Int)
 end
 
 
-""
 function constraint_voltage_magnitude_from_on_off(pm::AbstractWRModel, n::Int)
     buses = ref(pm, n, :bus)
     branches = ref(pm, n, :branch)
@@ -156,7 +148,6 @@ function constraint_voltage_magnitude_from_on_off(pm::AbstractWRModel, n::Int)
     end
 end
 
-""
 function constraint_voltage_magnitude_to_on_off(pm::AbstractWRModel, n::Int)
     buses = ref(pm, n, :bus)
     branches = ref(pm, n, :branch)
@@ -171,7 +162,6 @@ function constraint_voltage_magnitude_to_on_off(pm::AbstractWRModel, n::Int)
 end
 
 
-""
 function constraint_voltage_magnitude_sqr_from_on_off(pm::AbstractWRModel, n::Int)
     buses = ref(pm, n, :bus)
     branches = ref(pm, n, :branch)
@@ -185,7 +175,6 @@ function constraint_voltage_magnitude_sqr_from_on_off(pm::AbstractWRModel, n::In
     end
 end
 
-""
 function constraint_voltage_magnitude_sqr_to_on_off(pm::AbstractWRModel, n::Int)
     buses = ref(pm, n, :bus)
     branches = ref(pm, n, :branch)
@@ -199,7 +188,6 @@ function constraint_voltage_magnitude_sqr_to_on_off(pm::AbstractWRModel, n::Int)
     end
 end
 
-""
 function constraint_voltage_product_on_off(pm::AbstractWRModel, n::Int)
     wr_min, wr_max, wi_min, wi_max = ref_calc_voltage_product_bounds(ref(pm, n, :buspairs))
 
@@ -275,14 +263,12 @@ function constraint_ne_voltage_angle_difference(pm::AbstractWRModel, n::Int, f_i
     JuMP.@constraint(pm.model, wi >= tan(angmin)*wr)
 end
 
-""
 function variable_ne_branch_voltage(pm::AbstractWRModel; kwargs...)
     variable_ne_branch_voltage_magnitude_fr_sqr(pm; kwargs...)
     variable_ne_branch_voltage_magnitude_to_sqr(pm; kwargs...)
     variable_ne_branch_voltage_product(pm; kwargs...)
 end
 
-""
 function variable_ne_branch_voltage_magnitude_fr_sqr(pm::AbstractWRModel; nw::Int=nw_id_default, report::Bool=true)
     buses = ref(pm, nw, :bus)
     branches = ref(pm, nw, :ne_branch)
@@ -297,7 +283,6 @@ function variable_ne_branch_voltage_magnitude_fr_sqr(pm::AbstractWRModel; nw::In
     report && sol_component_value(pm, nw, :ne_branch, :w_fr, ids(pm, nw, :ne_branch), w_fr_ne)
 end
 
-""
 function variable_ne_branch_voltage_magnitude_to_sqr(pm::AbstractWRModel; nw::Int=nw_id_default, report::Bool=true)
     buses = ref(pm, nw, :bus)
     branches = ref(pm, nw, :ne_branch)
@@ -312,7 +297,6 @@ function variable_ne_branch_voltage_magnitude_to_sqr(pm::AbstractWRModel; nw::In
     report && sol_component_value(pm, nw, :ne_branch, :w_to, ids(pm, nw, :ne_branch), w_to_ne)
 end
 
-""
 function variable_ne_branch_voltage_product(pm::AbstractWRModel; nw::Int=nw_id_default, report::Bool=true)
     wr_min, wr_max, wi_min, wi_max = ref_calc_voltage_product_bounds(ref(pm, nw, :ne_buspairs))
     bi_bp = Dict((i, (b["f_bus"], b["t_bus"])) for (i,b) in ref(pm, nw, :ne_branch))
@@ -375,7 +359,6 @@ function variable_buspair_voltage_product_magnitude(pm::AbstractPowerModel; nw::
 end
 
 
-""
 function variable_buspair_current_magnitude_sqr(pm::AbstractPowerModel; nw::Int=nw_id_default, bounded::Bool=true, report::Bool=true)
     ccm = var(pm, nw)[:ccm] = JuMP.@variable(pm.model,
         [bp in ids(pm, nw, :buspairs)], base_name="$(nw)_ccm",
@@ -399,7 +382,6 @@ function variable_buspair_current_magnitude_sqr(pm::AbstractPowerModel; nw::Int=
     report && sol_component_value_buspair(pm, nw, :buspairs, :ccm, ids(pm, nw, :buspairs), ccm)
 end
 
-""
 function variable_bus_voltage(pm::AbstractQCWRModel; kwargs...)
     variable_bus_voltage_angle(pm; kwargs...)
     variable_bus_voltage_magnitude(pm; kwargs...)
@@ -414,7 +396,6 @@ function variable_bus_voltage(pm::AbstractQCWRModel; kwargs...)
     variable_buspair_current_magnitude_sqr(pm; kwargs...)
 end
 
-""
 function constraint_model_voltage(pm::AbstractQCWRModel, n::Int)
     _check_missing_keys(var(pm, n), [:vm,:va,:td,:si,:cs,:vv,:w,:wr,:wi], typeof(pm))
 
@@ -491,7 +472,6 @@ function constraint_theta_ref(pm::AbstractQCWRModel, n::Int, i::Int)
     JuMP.@constraint(pm.model, var(pm, n, :va)[i] == 0)
 end
 
-""
 function constraint_voltage_angle_difference(pm::AbstractQCWRModel, n::Int, f_idx, angmin, angmax)
     i, f_bus, t_bus = f_idx
 
@@ -517,7 +497,6 @@ function constraint_voltage_angle_difference(pm::AbstractQCWRModel, n::Int, f_id
 end
 
 
-""
 function variable_bus_voltage_on_off(pm::AbstractQCWRModel; kwargs...)
     variable_bus_voltage_angle(pm; kwargs...)
     variable_bus_voltage_magnitude(pm; kwargs...)
@@ -537,12 +516,10 @@ function variable_bus_voltage_on_off(pm::AbstractQCWRModel; kwargs...)
     variable_branch_current_magnitude_sqr_on_off(pm; kwargs...) # includes 0, but needs new indexes
 end
 
-""
 function variable_ne_branch_voltage(pm::AbstractQCWRModel; kwargs...)
     Memento.error(_LOGGER, "variable_ne_branch_voltage is not yet supported for QC formulations, open an issue if you would like this feature.")
 end
 
-""
 function variable_branch_voltage_product_angle_on_off(pm::AbstractPowerModel; nw::Int=nw_id_default, report::Bool=true)
     td = var(pm, nw)[:td] = JuMP.@variable(pm.model,
         [l in ids(pm, nw, :branch)], base_name="$(nw)_td",
@@ -554,7 +531,6 @@ function variable_branch_voltage_product_angle_on_off(pm::AbstractPowerModel; nw
     report && sol_component_value(pm, nw, :branch, :td, ids(pm, nw, :branch), td)
 end
 
-""
 function variable_buspair_voltage_product_magnitude_on_off(pm::AbstractPowerModel; nw::Int=nw_id_default, report::Bool=true)
     branches = ref(pm, nw, :branch)
     buses = ref(pm, nw, :bus)
@@ -573,7 +549,6 @@ function variable_buspair_voltage_product_magnitude_on_off(pm::AbstractPowerMode
 end
 
 
-""
 function variable_branch_cosine_on_off(pm::AbstractPowerModel; nw::Int=nw_id_default, report::Bool=true)
     cos_min = Dict((l, -Inf) for l in ids(pm, nw, :branch))
     cos_max = Dict((l,  Inf) for l in ids(pm, nw, :branch))
@@ -605,7 +580,6 @@ function variable_branch_cosine_on_off(pm::AbstractPowerModel; nw::Int=nw_id_def
     report && sol_component_value(pm, nw, :branch, :cs, ids(pm, nw, :branch), cs)
 end
 
-""
 function variable_branch_sine_on_off(pm::AbstractPowerModel; nw::Int=nw_id_default, report::Bool=true)
     si = var(pm, nw)[:si] = JuMP.@variable(pm.model,
         [l in ids(pm, nw, :branch)], base_name="$(nw)_si",
@@ -618,7 +592,6 @@ function variable_branch_sine_on_off(pm::AbstractPowerModel; nw::Int=nw_id_defau
 end
 
 
-""
 function variable_branch_current_magnitude_sqr_on_off(pm::AbstractPowerModel; nw::Int=nw_id_default, report::Bool=true)
     ccm_min = Dict((l, 0) for l in ids(pm, nw, :branch))
 
@@ -640,7 +613,6 @@ function variable_branch_current_magnitude_sqr_on_off(pm::AbstractPowerModel; nw
 end
 
 
-""
 function constraint_model_voltage_on_off(pm::AbstractQCWRModel, n::Int)
     v = var(pm, n, :vm)
     t = var(pm, n, :va)
@@ -741,7 +713,6 @@ end
 
 
 
-""
 function variable_buspair_voltage_product_magnitude(pm::AbstractQCLSModel; nw::Int=nw_id_default, report::Bool=true)
     # do nothing - no lifted variables required for voltage variable product
 end
@@ -766,7 +737,6 @@ function variable_buspair_voltage_product_magnitude_multipliers(pm::AbstractQCLS
     end
 end
 
-""
 function variable_bus_voltage(pm::AbstractQCLSModel; kwargs...)
     variable_bus_voltage_angle(pm; kwargs...)
     variable_bus_voltage_magnitude(pm; kwargs...)
@@ -783,7 +753,6 @@ function variable_bus_voltage(pm::AbstractQCLSModel; kwargs...)
 end
 
 
-""
 function constraint_model_voltage(pm::AbstractQCLSModel, n::Int)
     _check_missing_keys(var(pm, n), [:vm,:va,:td,:si,:cs,:w,:wr,:wi,:lambda_wr,:lambda_wi], typeof(pm))
 

--- a/src/form/wrm.jl
+++ b/src/form/wrm.jl
@@ -1,6 +1,5 @@
 ### sdp relaxations in the rectangular W-space
 
-""
 function constraint_current_limit_from(pm::AbstractWRMModel, n::Int, f_idx, c_rating_a)
     l,i,j = f_idx
 
@@ -11,7 +10,6 @@ function constraint_current_limit_from(pm::AbstractWRMModel, n::Int, f_idx, c_ra
     JuMP.@constraint(pm.model, [w_fr*c_rating_a^2+1, 2*p_fr, 2*q_fr, w_fr*c_rating_a^2-1] in JuMP.SecondOrderCone())
 end
 
-""
 function constraint_current_limit_to(pm::AbstractWRMModel, n::Int, t_idx, c_rating_a)
     l,j,i = t_idx
 
@@ -25,7 +23,6 @@ end
 
 
 
-""
 function constraint_model_voltage(pm::AbstractWRMModel, n::Int)
     _check_missing_keys(var(pm, n), [:WR,:WI], typeof(pm))
 
@@ -36,7 +33,6 @@ function constraint_model_voltage(pm::AbstractWRMModel, n::Int)
 end
 
 
-""
 function variable_bus_voltage(pm::AbstractWRMModel; nw::Int=nw_id_default, bounded::Bool=true, report::Bool=true)
     wr_min, wr_max, wi_min, wi_max = ref_calc_voltage_product_bounds(ref(pm, nw, :buspairs))
     bus_ids = ids(pm, nw, :bus)

--- a/src/io/matpower.jl
+++ b/src/io/matpower.jl
@@ -123,7 +123,6 @@ const _mp_switch_columns = [
 ]
 
 
-""
 function _parse_matpower_string(data_string::String)
     matlab_data, func_name, colnames = _IM.parse_matlab_string(data_string, extended=true)
 
@@ -299,7 +298,6 @@ function _parse_matpower_string(data_string::String)
 end
 
 
-""
 function _mp_cost_data(cost_row)
     ncost = _IM.check_type(Int, cost_row[4])
     model = _IM.check_type(Int, cost_row[1])
@@ -687,7 +685,6 @@ function _get_default(dict, key, default=0.0)
 end
 
 
-""
 function _check_keys(data, keys)
     for key in keys
         if haskey(data, key)
@@ -839,7 +836,7 @@ function export_matpower(io::IO, data::Dict{String,Any})
         if idx != gen["index"]
             Memento.warn(_LOGGER, "The index of the generator does not match the matpower assigned index. Any data that uses generator indexes for reference is corrupted.");
         end
-        println(io, 
+        println(io,
             "\t", gen["gen_bus"],
             "\t", _get_default(gen, "pg"),
             "\t", _get_default(gen, "qg"),
@@ -945,7 +942,7 @@ function export_matpower(io::IO, data::Dict{String,Any})
     println(io, "];")
     println(io)
 
-    if length(dclines) > 0 
+    if length(dclines) > 0
         # print the dcline data
         println(io, "%% dcline data")
         println(io, "%    f_bus    t_bus    status    Pf    Pt    Qf    Qt    Vf    Vt    Pmin    Pmax    QminF    QmaxF    QminT    QmaxT    loss0    loss1")

--- a/src/prob/opb.jl
+++ b/src/prob/opb.jl
@@ -8,7 +8,6 @@ function solve_opb(file, model_type::Type, optimizer; kwargs...)
     return solve_model(file, model_type, optimizer, build_opb; ref_extensions=[ref_add_connected_components!], kwargs...)
 end
 
-""
 function build_opb(pm::AbstractPowerModel)
     variable_bus_voltage_magnitude_only(pm)
     variable_gen_power(pm)
@@ -21,13 +20,11 @@ function build_opb(pm::AbstractPowerModel)
 end
 
 
-""
 function ref_add_connected_components!(ref::Dict{Symbol,<:Any}, data::Dict{String,<:Any})
     apply_pm!(_ref_add_connected_components!, ref, data)
 end
 
 
-""
 function _ref_add_connected_components!(ref::Dict{Symbol,<:Any}, data::Dict{String,<:Any})
     component_sets = PowerModels.calc_connected_components(data)
     ref[:components] = Dict(i => c for (i,c) in enumerate(sort(collect(component_sets); by = length)))

--- a/src/prob/opf.jl
+++ b/src/prob/opf.jl
@@ -3,17 +3,14 @@ function solve_ac_opf(file, optimizer; kwargs...)
     return solve_opf(file, ACPPowerModel, optimizer; kwargs...)
 end
 
-""
 function solve_dc_opf(file, optimizer; kwargs...)
     return solve_opf(file, DCPPowerModel, optimizer; kwargs...)
 end
 
-""
 function solve_opf(file, model_type::Type, optimizer; kwargs...)
     return solve_model(file, model_type, optimizer, build_opf; kwargs...)
 end
 
-""
 function build_opf(pm::AbstractPowerModel)
     variable_bus_voltage(pm)
     variable_gen_power(pm)
@@ -54,7 +51,6 @@ function solve_mn_opf(file, model_type::Type, optimizer; kwargs...)
     return solve_model(file, model_type, optimizer, build_mn_opf; multinetwork=true, kwargs...)
 end
 
-""
 function build_mn_opf(pm::AbstractPowerModel)
     for (n, network) in nws(pm)
         variable_bus_voltage(pm, nw=n)
@@ -96,7 +92,6 @@ function solve_mn_opf_strg(file, model_type::Type, optimizer; kwargs...)
     return solve_model(file, model_type, optimizer, build_mn_opf_strg; multinetwork=true, kwargs...)
 end
 
-""
 function build_mn_opf_strg(pm::AbstractPowerModel)
     for (n, network) in nws(pm)
         variable_bus_voltage(pm, nw=n)
@@ -170,12 +165,10 @@ function solve_opf_ptdf(file, model_type::Type, optimizer; full_inverse=false, k
     end
 end
 
-""
 function build_opf_ptdf(pm::AbstractPowerModel)
     Memento.error(_LOGGER, "build_opf_ptdf is only valid for DCPPowerModels")
 end
 
-""
 function build_opf_ptdf(pm::DCPPowerModel)
     variable_gen_power(pm)
 
@@ -212,26 +205,22 @@ function build_opf_ptdf(pm::DCPPowerModel)
 end
 
 
-""
 function ref_add_sm!(ref::Dict{Symbol, <:Any}, data::Dict{String, <:Any})
     apply_pm!(_ref_add_sm!, ref, data)
 end
 
 
-""
 function _ref_add_sm!(ref::Dict{Symbol, <:Any}, data::Dict{String, <:Any})
     reference_bus(data) # throws an error if an incorrect number of reference buses are defined
     ref[:sm] = calc_susceptance_matrix(data)
 end
 
 
-""
 function ref_add_sm_inv!(ref::Dict{Symbol, <:Any}, data::Dict{String, <:Any})
     apply_pm!(_ref_add_sm_inv!, ref, data)
 end
 
 
-""
 function _ref_add_sm_inv!(ref::Dict{Symbol, <:Any}, data::Dict{String, <:Any})
     ref[:sm] = calc_susceptance_matrix_inv(data)
 end

--- a/src/prob/opf_bf.jl
+++ b/src/prob/opf_bf.jl
@@ -3,12 +3,10 @@ function solve_opf_bf(file, model_type::Type{T}, optimizer; kwargs...) where T <
     return solve_model(file, model_type, optimizer, build_opf_bf; kwargs...)
 end
 
-""
 function solve_mn_opf_bf_strg(file, model_type::Type{T}, optimizer; kwargs...) where T <: AbstractBFModel
     return solve_model(file, model_type, optimizer, build_mn_opf_bf_strg; multinetwork=true, kwargs...)
 end
 
-""
 function build_opf_bf(pm::AbstractPowerModel)
     variable_bus_voltage(pm)
     variable_gen_power(pm)

--- a/src/prob/opf_iv.jl
+++ b/src/prob/opf_iv.jl
@@ -3,7 +3,6 @@ function solve_opf_iv(file, model_type::Type, optimizer; kwargs...)
     return solve_model(file, model_type, optimizer, build_opf_iv; kwargs...)
 end
 
-""
 function build_opf_iv(pm::AbstractPowerModel)
     variable_bus_voltage(pm)
     variable_branch_current(pm)

--- a/src/prob/ots.jl
+++ b/src/prob/ots.jl
@@ -4,12 +4,10 @@
 # - the network will be maintained as one connected component (i.e. at least n-1 edges)
 #
 
-""
 function solve_ots(file, model_type::Type, optimizer; kwargs...)
     return solve_model(file, model_type, optimizer, build_ots; ref_extensions=[ref_add_on_off_va_bounds!], kwargs...)
 end
 
-""
 function build_ots(pm::AbstractPowerModel)
     variable_branch_indicator(pm)
     variable_bus_voltage_on_off(pm)
@@ -45,13 +43,11 @@ function build_ots(pm::AbstractPowerModel)
 end
 
 
-""
 function ref_add_on_off_va_bounds!(ref::Dict{Symbol,<:Any}, data::Dict{String,<:Any})
     apply_pm!(_ref_add_on_off_va_bounds!, ref, data)
 end
 
 
-""
 function _ref_add_on_off_va_bounds!(ref::Dict{Symbol,<:Any}, data::Dict{String,<:Any})
     off_angmin, off_angmax = calc_theta_delta_bounds(data)
     ref[:off_angmin], ref[:off_angmax] = off_angmin, off_angmax

--- a/src/prob/pf_bf.jl
+++ b/src/prob/pf_bf.jl
@@ -3,7 +3,6 @@ function solve_pf_bf(file, model_type::Type, optimizer; kwargs...)
     return solve_model(file, model_type, optimizer, build_pf_bf; kwargs...)
 end
 
-""
 function build_pf_bf(pm::AbstractPowerModel)
     variable_bus_voltage(pm, bounded = false)
     variable_gen_power(pm, bounded = false)

--- a/src/prob/pf_iv.jl
+++ b/src/prob/pf_iv.jl
@@ -3,7 +3,6 @@ function solve_pf_iv(file, model_type::Type, optimizer; kwargs...)
     return solve_model(file, model_type, optimizer, build_pf_iv; kwargs...)
 end
 
-""
 function build_pf_iv(pm::AbstractPowerModel)
     variable_bus_voltage(pm, bounded = false)
     variable_branch_current(pm, bounded = false)

--- a/src/prob/test.jl
+++ b/src/prob/test.jl
@@ -11,7 +11,6 @@ function _solve_opf_cl(file, model_type::Type, optimizer; kwargs...)
     return solve_model(file, model_type, optimizer, _build_opf_cl; kwargs...)
 end
 
-""
 function _build_opf_cl(pm::AbstractPowerModel)
     variable_bus_voltage(pm)
     variable_gen_power(pm)
@@ -51,7 +50,6 @@ function _solve_opf_sw(file, model_constructor, optimizer; kwargs...)
     return solve_model(file, model_constructor, optimizer, _build_opf_sw; kwargs...)
 end
 
-""
 function _build_opf_sw(pm::AbstractPowerModel)
     variable_bus_voltage(pm)
     variable_gen_power(pm)
@@ -97,7 +95,6 @@ function _solve_oswpf(file, model_constructor, optimizer; kwargs...)
     return solve_model(file, model_constructor, optimizer, _build_oswpf; ref_extensions=[ref_add_on_off_va_bounds!], kwargs...)
 end
 
-""
 function _build_oswpf(pm::AbstractPowerModel)
     variable_bus_voltage(pm)
     variable_gen_power(pm)
@@ -146,7 +143,6 @@ function _solve_oswpf_nb(file, model_constructor, optimizer; kwargs...)
     return solve_model(file, model_constructor, optimizer, _build_oswpf_nb; ref_extensions=[ref_add_on_off_va_bounds!], kwargs...)
 end
 
-""
 function _build_oswpf_nb(pm::AbstractPowerModel)
     variable_bus_voltage_on_off(pm)
     variable_gen_power(pm)
@@ -268,7 +264,6 @@ function _solve_ucopf(file, model_type::Type, solver; kwargs...)
     return solve_model(file, model_type, solver, _build_ucopf; kwargs...)
 end
 
-""
 function _build_ucopf(pm::AbstractPowerModel)
     variable_bus_voltage(pm)
 
@@ -324,12 +319,10 @@ function _build_ucopf(pm::AbstractPowerModel)
 end
 
 
-""
 function _solve_mn_opb(file, model_type::Type, optimizer; kwargs...)
     return solve_model(file, model_type, optimizer, _build_mn_opb; ref_extensions=[ref_add_connected_components!], multinetwork=true, kwargs...)
 end
 
-""
 function _build_mn_opb(pm::AbstractPowerModel)
     for (n, network) in nws(pm)
         variable_gen_power(pm, nw=n)
@@ -343,12 +336,10 @@ function _build_mn_opb(pm::AbstractPowerModel)
 end
 
 
-""
 function _solve_mn_pf(file, model_type::Type, optimizer; kwargs...)
     return solve_model(file, model_type, optimizer, _build_mn_pf; multinetwork=true, kwargs...)
 end
 
-""
 function _build_mn_pf(pm::AbstractPowerModel)
     for (n, network) in nws(pm)
         variable_bus_voltage(pm, nw=n, bounded = false)
@@ -404,7 +395,6 @@ function _solve_opf_strg(file, model_type::Type, optimizer; kwargs...)
     return solve_model(file, model_type, optimizer, _build_opf_strg; kwargs...)
 end
 
-""
 function _build_opf_strg(pm::AbstractPowerModel)
     variable_bus_voltage(pm)
     variable_gen_power(pm)
@@ -452,7 +442,6 @@ function _solve_opf_strg_mi(file, model_type::Type, optimizer; kwargs...)
     return solve_model(file, model_type, optimizer, _build_opf_strg_mi; kwargs...)
 end
 
-""
 function _build_opf_strg_mi(pm::AbstractPowerModel)
     variable_bus_voltage(pm)
     variable_gen_power(pm)
@@ -500,7 +489,6 @@ function _solve_opf_pst(file, model_type::Type, optimizer; kwargs...)
     return solve_model(file, model_type, optimizer, _build_opf_pst; kwargs...)
 end
 
-""
 function _build_opf_pst(pm::AbstractPowerModel)
     variable_bus_voltage(pm)
     variable_gen_power(pm)
@@ -542,7 +530,6 @@ function _solve_opf_oltc_pst(file, model_type::Type, optimizer; kwargs...)
     return solve_model(file, model_type, optimizer, _build_opf_oltc_pst; kwargs...)
 end
 
-""
 function _build_opf_oltc_pst(pm::AbstractPowerModel)
     variable_bus_voltage(pm)
     variable_gen_power(pm)

--- a/src/prob/tnep.jl
+++ b/src/prob/tnep.jl
@@ -2,7 +2,6 @@
 #
 #
 
-""
 function solve_tnep(file, model_type::Type, optimizer; kwargs...)
     return solve_model(file, model_type, optimizer, build_tnep; ref_extensions=[ref_add_on_off_va_bounds!,ref_add_ne_branch!], kwargs...)
 end
@@ -67,13 +66,11 @@ function objective_tnep_cost(pm::AbstractPowerModel)
 end
 
 
-""
 function ref_add_ne_branch!(ref::Dict{Symbol,<:Any}, data::Dict{String,<:Any})
     apply_pm!(_ref_add_ne_branch!, ref, data)
 end
 
 
-""
 function _ref_add_ne_branch!(ref::Dict{Symbol,<:Any}, data::Dict{String,<:Any})
     if !haskey(ref, :ne_branch)
         error(_LOGGER, "required ne_branch data not found")

--- a/test/common.jl
+++ b/test/common.jl
@@ -44,33 +44,28 @@ function all_shunts_on(result; atol=1e-5)
     return !haskey(result["solution"], "shunt") ||all(isapprox(shunt["status"], 1.0, atol=atol) for (i,shunt) in result["solution"]["shunt"])
 end
 
-""
 function load_status(result, nw_id, load_id)
     return result["solution"]["nw"][nw_id]["load"][load_id]["status"]
 end
 
-""
 function load_status(result, load_id)
     return result["solution"]["load"][load_id]["status"]
 end
 
-""
 function shunt_status(result, nw_id, shunt_id)
     return result["solution"]["nw"][nw_id]["shunt"][shunt_id]["status"]
 end
 
-""
 function shunt_status(result, shunt_id)
     return result["solution"]["shunt"][shunt_id]["status"]
 end
 
-""
 function active_power_served(result)
     return sum([load["pd"] for (i,load) in result["solution"]["load"]])
 end
 
 """
-An AC Power Flow Solver from scratch. 
+An AC Power Flow Solver from scratch.
 """
 function compute_basic_ac_pf!(data::Dict{String, Any})
     if !get(data, "basic_network", false)
@@ -115,7 +110,7 @@ function compute_basic_ac_pf!(data::Dict{String, Any})
             bus_type = data["bus"]["$(i)"]["bus_type"]
             if bus_type == 1
                 data["bus"]["$(i)"]["va"] = data["bus"]["$(i)"]["va"] + x[i]
-                data["bus"]["$(i)"]["vm"] = data["bus"]["$(i)"]["vm"] + x[i+bus_num] * data["bus"]["$(i)"]["vm"] 
+                data["bus"]["$(i)"]["vm"] = data["bus"]["$(i)"]["vm"] + x[i+bus_num] * data["bus"]["$(i)"]["vm"]
             end
             if bus_type == 2
                 data["bus"]["$(i)"]["va"] = data["bus"]["$(i)"]["va"] + x[i]


### PR DESCRIPTION
These are actually less helpful than nothing.

Before

```julia
help?> build_mn_opf
search: build_mn_opf build_mn_opf_strg build_mn_opf_bf_strg



```

Now

```Julia
help?> build_mn_opf
search: build_mn_opf build_mn_opf_strg build_mn_opf_bf_strg

  No documentation found.

  PowerModels.build_mn_opf is a Function.

  # 1 method for generic function "build_mn_opf" from PowerModels:
   [1] build_mn_opf(pm::AbstractPowerModel)
       @ ~/.julia/dev/PowerModels/src/prob/opf.jl:54
```