### PR TITLE
Fix doc build and change warnings into errors

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -24,4 +24,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }}
-        run: julia --project=docs/ docs/make.jl
+        run: julia --color=yes --project=docs/ docs/make.jl

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ PowerModels.jl Change Log
 - Fix spelling of `resolve_swithces!` and add deprecation for compatibility (#959)
 - Clean up package imports (#961)
 - Refactor `test/runtests.jl` (#962)
-- Remove empty docstrings (#963)
+- Remove empty docstrings (#963) (#966)
 
 ### v0.21.3
 - Fix no-buses bug in `calc_connected_components` (#933)

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,6 +1,6 @@
 [deps]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+PowerModels = "c36e90e8-916a-50a6-bd94-075b64ef4655"
 
 [compat]
 Documenter = "1"
-

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,5 +1,5 @@
 import Documenter
-import PowerModels
+using PowerModels
 
 Documenter.makedocs(
     sitename = "PowerModels",

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,11 +1,16 @@
-using Documenter, PowerModels
+import Documenter
+import PowerModels
 
-makedocs(
-    warnonly = Documenter.except(:linkcheck),
-    modules = [PowerModels],
-    format = Documenter.HTML(analytics = "UA-367975-10", mathengine = Documenter.MathJax()),
+Documenter.makedocs(
     sitename = "PowerModels",
     authors = "Carleton Coffrin, Russell Bent, and contributors.",
+    format = Documenter.HTML(analytics = "UA-367975-10", mathengine = Documenter.MathJax()),
+    modules = [PowerModels],
+    # There are a large number of exported functions in PowerModels.jl that have
+    # docstrings, but which are not explicitly included in the docs.
+    #
+    # When this is fixed, we should change to `checkdocs = :exports,`
+    checkdocs = :none,
     pages = [
         "Home" => "index.md",
         "Manual" => [
@@ -40,6 +45,6 @@ makedocs(
     ]
 )
 
-deploydocs(
+Documenter.deploydocs(
     repo = "github.com/lanl-ansi/PowerModels.jl.git",
 )

--- a/docs/src/constraints.md
+++ b/docs/src/constraints.md
@@ -85,9 +85,10 @@ constraint_ne_thermal_limit_to
 ### Current Limit Constraints
 
 ```@docs
-constraint_current_limit
 constraint_current_to
 constraint_current_from
+constraint_current_limit_to
+constraint_current_limit_from
 ```
 
 ### Phase Angle Difference Constraints

--- a/docs/src/math-model.md
+++ b/docs/src/math-model.md
@@ -78,7 +78,7 @@ Note that for clarity of this presentation some model variants that PowerModels 
 - Eq. $\eqref{eq_power_from}$ - [`constraint_ohms_yt_from`](@ref)
 - Eq. $\eqref{eq_power_to}$ - [`constraint_ohms_yt_to`](@ref)
 - Eq. $\eqref{eq_thermal_limit}$ - [`constraint_thermal_limit_from`](@ref) and [`constraint_thermal_limit_to`](@ref)
-- Eq. $\eqref{eq_current_limit}$ - [`constraint_current_limit`](@ref)
+- Eq. $\eqref{eq_current_limit}$ - [`constraint_current_limit_from`](@ref) and  [`constraint_current_limit_to`](@ref)
 - Eq. $\eqref{eq_angle_difference}$ - [`constraint_voltage_angle_difference`](@ref)
 
 
@@ -116,7 +116,7 @@ A complete mathematical formulation for a Branch Flow Model is conceived as:
 \end{align}
 ```
 
-Note that constraints $\eqref{eq_line_losses} - \eqref{eq_ohms_bfm}$ replace $\eqref{eq_power_from} - \eqref{eq_power_to}$ but the remainder of the problem formulation is identical. Furthermore, the problems have the same feasible set.  
+Note that constraints $\eqref{eq_line_losses} - \eqref{eq_ohms_bfm}$ replace $\eqref{eq_power_from} - \eqref{eq_power_to}$ but the remainder of the problem formulation is identical. Furthermore, the problems have the same feasible set.
 
 ### Mapping to PowerModels Functions
 - Eq. $\eqref{var_branch_current}$ - [`variable_branch_current`](@ref)

--- a/src/core/constraint.jl
+++ b/src/core/constraint.jl
@@ -197,6 +197,9 @@ function constraint_storage_thermal_limit(pm::AbstractPowerModel, n::Int, i, rat
     JuMP.@constraint(pm.model, ps^2 + qs^2 <= rating^2)
 end
 
+"""
+    constraint_storage_state_initial(pm::AbstractPowerModel, n::Int, i::Int, energy, charge_eff, discharge_eff, time_elapsed)
+"""
 function constraint_storage_state_initial(pm::AbstractPowerModel, n::Int, i::Int, energy, charge_eff, discharge_eff, time_elapsed)
     sc = var(pm, n, :sc, i)
     sd = var(pm, n, :sd, i)

--- a/src/core/constraint_template.jl
+++ b/src/core/constraint_template.jl
@@ -165,6 +165,9 @@ end
 
 ### Bus - KCL Constraints ###
 
+"""
+    constraint_power_balance(pm::AbstractPowerModel, i::Int; nw::Int=nw_id_default)
+"""
 function constraint_power_balance(pm::AbstractPowerModel, i::Int; nw::Int=nw_id_default)
     bus = ref(pm, nw, :bus, i)
     bus_arcs = ref(pm, nw, :bus_arcs, i)
@@ -184,7 +187,11 @@ function constraint_power_balance(pm::AbstractPowerModel, i::Int; nw::Int=nw_id_
     constraint_power_balance(pm, nw, i, bus_arcs, bus_arcs_dc, bus_arcs_sw, bus_gens, bus_storage, bus_pd, bus_qd, bus_gs, bus_bs)
 end
 
-"nodal power balance with constant power factor load and shunt shedding"
+"""
+    constraint_power_balance_ls(pm::AbstractPowerModel, i::Int; nw::Int=nw_id_default)
+
+Nodal power balance with constant power factor load and shunt shedding.
+"""
 function constraint_power_balance_ls(pm::AbstractPowerModel, i::Int; nw::Int=nw_id_default)
     bus = ref(pm, nw, :bus, i)
     bus_arcs = ref(pm, nw, :bus_arcs, i)
@@ -204,6 +211,9 @@ function constraint_power_balance_ls(pm::AbstractPowerModel, i::Int; nw::Int=nw_
     constraint_power_balance_ls(pm, nw, i, bus_arcs, bus_arcs_dc, bus_arcs_sw, bus_gens, bus_storage, bus_pd, bus_qd, bus_gs, bus_bs)
 end
 
+"""
+    constraint_ne_power_balance(pm::AbstractPowerModel, i::Int; nw::Int=nw_id_default)
+"""
 function constraint_ne_power_balance(pm::AbstractPowerModel, i::Int; nw::Int=nw_id_default)
     bus = ref(pm, nw, :bus, i)
     bus_arcs = ref(pm, nw, :bus_arcs, i)
@@ -665,6 +675,9 @@ end
 
 ### Branch - Current Limit Constraints ###
 
+"""
+    constraint_current_limit_from(pm::AbstractPowerModel, i::Int; nw::Int=nw_id_default)
+"""
 function constraint_current_limit_from(pm::AbstractPowerModel, i::Int; nw::Int=nw_id_default)
     branch = ref(pm, nw, :branch, i)
     f_bus = branch["f_bus"]
@@ -676,6 +689,9 @@ function constraint_current_limit_from(pm::AbstractPowerModel, i::Int; nw::Int=n
     end
 end
 
+"""
+    constraint_current_limit_to(pm::AbstractPowerModel, i::Int; nw::Int=nw_id_default)
+"""
 function constraint_current_limit_to(pm::AbstractPowerModel, i::Int; nw::Int=nw_id_default)
     branch = ref(pm, nw, :branch, i)
     f_bus = branch["f_bus"]
@@ -823,21 +839,32 @@ end
 
 ### Storage Constraints ###
 
+"""
+    constraint_storage_thermal_limit(pm::AbstractPowerModel, i::Int; nw::Int=nw_id_default)
+"""
 function constraint_storage_thermal_limit(pm::AbstractPowerModel, i::Int; nw::Int=nw_id_default)
     storage = ref(pm, nw, :storage, i)
     constraint_storage_thermal_limit(pm, nw, i, storage["thermal_rating"])
 end
 
+"""
+    constraint_storage_current_limit(pm::AbstractPowerModel, i::Int; nw::Int=nw_id_default)
+"""
 function constraint_storage_current_limit(pm::AbstractPowerModel, i::Int; nw::Int=nw_id_default)
     storage = ref(pm, nw, :storage, i)
     constraint_storage_current_limit(pm, nw, i, storage["storage_bus"], storage["current_rating"])
 end
 
-
+"""
+    constraint_storage_complementarity_nl(pm::AbstractPowerModel, i::Int; nw::Int=nw_id_default)
+"""
 function constraint_storage_complementarity_nl(pm::AbstractPowerModel, i::Int; nw::Int=nw_id_default)
     constraint_storage_complementarity_nl(pm, nw, i)
 end
 
+"""
+    constraint_storage_complementarity_mi(pm::AbstractPowerModel, i::Int; nw::Int=nw_id_default)
+"""
 function constraint_storage_complementarity_mi(pm::AbstractPowerModel, i::Int; nw::Int=nw_id_default)
     storage = ref(pm, nw, :storage, i)
     charge_ub = storage["charge_rating"]
@@ -853,6 +880,9 @@ function constraint_storage_losses(pm::AbstractPowerModel, i::Int; nw::Int=nw_id
     constraint_storage_losses(pm, nw, i, storage["storage_bus"], storage["r"], storage["x"], storage["p_loss"], storage["q_loss"])
 end
 
+"""
+    constraint_storage_state(pm::AbstractPowerModel, i::Int; nw::Int=nw_id_default)
+"""
 function constraint_storage_state(pm::AbstractPowerModel, i::Int; nw::Int=nw_id_default)
     storage = ref(pm, nw, :storage, i)
 

--- a/src/core/objective.jl
+++ b/src/core/objective.jl
@@ -12,6 +12,9 @@ function objective_min_fuel_and_flow_cost(pm::AbstractPowerModel; kwargs...)
 end
 
 
+"""
+    objective_min_fuel_cost(pm::AbstractPowerModel; kwargs...)
+"""
 function objective_min_fuel_cost(pm::AbstractPowerModel; kwargs...)
     expression_pg_cost(pm; kwargs...)
 

--- a/src/core/variable.jl
+++ b/src/core/variable.jl
@@ -392,6 +392,9 @@ end
 
 
 
+"""
+    variable_branch_power(pm::AbstractPowerModel; kwargs...)
+"""
 function variable_branch_power(pm::AbstractPowerModel; kwargs...)
     variable_branch_power_real(pm; kwargs...)
     variable_branch_power_imaginary(pm; kwargs...)
@@ -796,7 +799,9 @@ function variable_dcline_current_imaginary(pm::AbstractPowerModel; nw::Int=nw_id
     report && sol_component_value_edge(pm, nw, :dcline, :cidc_fr, :cidc_to, ref(pm, nw, :arcs_from_dc), ref(pm, nw, :arcs_to_dc), cidc)
 end
 
-
+"""
+    variable_switch_indicator(pm::AbstractPowerModel; nw::Int=nw_id_default, relax::Bool=false, report::Bool=true)
+"""
 function variable_switch_indicator(pm::AbstractPowerModel; nw::Int=nw_id_default, relax::Bool=false, report::Bool=true)
     if !relax
         z_switch = var(pm, nw)[:z_switch] = JuMP.@variable(pm.model,
@@ -816,7 +821,9 @@ function variable_switch_indicator(pm::AbstractPowerModel; nw::Int=nw_id_default
     report && sol_component_value(pm, nw, :switch, :status, ids(pm, nw, :switch), z_switch)
 end
 
-
+"""
+    variable_switch_power(pm::AbstractPowerModel; kwargs...)
+"""
 function variable_switch_power(pm::AbstractPowerModel; kwargs...)
     variable_switch_power_real(pm; kwargs...)
     variable_switch_power_imaginary(pm; kwargs...)
@@ -983,6 +990,9 @@ function variable_storage_current(pm::AbstractPowerModel; nw::Int=nw_id_default,
 end
 
 
+"""
+    variable_storage_energy(pm::AbstractPowerModel; nw::Int=nw_id_default, bounded::Bool=true, report::Bool=true)
+"""
 function variable_storage_energy(pm::AbstractPowerModel; nw::Int=nw_id_default, bounded::Bool=true, report::Bool=true)
     se = var(pm, nw)[:se] = JuMP.@variable(pm.model,
         [i in ids(pm, nw, :storage)], base_name="$(nw)_se",
@@ -999,6 +1009,9 @@ function variable_storage_energy(pm::AbstractPowerModel; nw::Int=nw_id_default, 
     report && sol_component_value(pm, nw, :storage, :se, ids(pm, nw, :storage), se)
 end
 
+"""
+    variable_storage_charge(pm::AbstractPowerModel; nw::Int=nw_id_default, bounded::Bool=true, report::Bool=true)
+"""
 function variable_storage_charge(pm::AbstractPowerModel; nw::Int=nw_id_default, bounded::Bool=true, report::Bool=true)
     sc = var(pm, nw)[:sc] = JuMP.@variable(pm.model,
         [i in ids(pm, nw, :storage)], base_name="$(nw)_sc",
@@ -1015,6 +1028,9 @@ function variable_storage_charge(pm::AbstractPowerModel; nw::Int=nw_id_default, 
     report && sol_component_value(pm, nw, :storage, :sc, ids(pm, nw, :storage), sc)
 end
 
+"""
+    variable_storage_discharge(pm::AbstractPowerModel; nw::Int=nw_id_default, bounded::Bool=true, report::Bool=true)
+"""
 function variable_storage_discharge(pm::AbstractPowerModel; nw::Int=nw_id_default, bounded::Bool=true, report::Bool=true)
     sd = var(pm, nw)[:sd] = JuMP.@variable(pm.model,
         [i in ids(pm, nw, :storage)], base_name="$(nw)_sd",

--- a/src/form/bf.jl
+++ b/src/form/bf.jl
@@ -27,6 +27,9 @@ function variable_buspair_current_magnitude_sqr(pm::AbstractBFModel; nw::Int=nw_
     report && sol_component_value(pm, nw, :branch, :ccm, ids(pm, nw, :branch), ccm)
 end
 
+"""
+    variable_branch_current(pm::AbstractBFModel; kwargs...)
+"""
 function variable_branch_current(pm::AbstractBFModel; kwargs...)
     variable_buspair_current_magnitude_sqr(pm; kwargs...)
 end

--- a/src/form/iv.jl
+++ b/src/form/iv.jl
@@ -35,6 +35,9 @@ function variable_branch_current(pm::AbstractIVRModel; nw::Int=nw_id_default, bo
     variable_branch_series_current_imaginary(pm, nw=nw, bounded=bounded, report=report; kwargs...)
 end
 
+"""
+    variable_gen_current(pm::AbstractIVRModel; nw::Int=nw_id_default, bounded::Bool=true, report::Bool=true, kwargs...)
+"""
 function variable_gen_current(pm::AbstractIVRModel; nw::Int=nw_id_default, bounded::Bool=true, report::Bool=true, kwargs...)
     variable_gen_current_real(pm, nw=nw, bounded=bounded, report=report; kwargs...)
     variable_gen_current_imaginary(pm, nw=nw, bounded=bounded, report=report; kwargs...)

--- a/src/prob/opb.jl
+++ b/src/prob/opb.jl
@@ -8,6 +8,9 @@ function solve_opb(file, model_type::Type, optimizer; kwargs...)
     return solve_model(file, model_type, optimizer, build_opb; ref_extensions=[ref_add_connected_components!], kwargs...)
 end
 
+"""
+    build_opb(pm::AbstractPowerModel)
+"""
 function build_opb(pm::AbstractPowerModel)
     variable_bus_voltage_magnitude_only(pm)
     variable_gen_power(pm)

--- a/src/prob/opf.jl
+++ b/src/prob/opf.jl
@@ -11,6 +11,9 @@ function solve_opf(file, model_type::Type, optimizer; kwargs...)
     return solve_model(file, model_type, optimizer, build_opf; kwargs...)
 end
 
+"""
+    build_opf(pm::AbstractPowerModel)
+"""
 function build_opf(pm::AbstractPowerModel)
     variable_bus_voltage(pm)
     variable_gen_power(pm)
@@ -51,6 +54,9 @@ function solve_mn_opf(file, model_type::Type, optimizer; kwargs...)
     return solve_model(file, model_type, optimizer, build_mn_opf; multinetwork=true, kwargs...)
 end
 
+"""
+    build_mn_opf(pm::AbstractPowerModel)
+"""
 function build_mn_opf(pm::AbstractPowerModel)
     for (n, network) in nws(pm)
         variable_bus_voltage(pm, nw=n)
@@ -92,6 +98,9 @@ function solve_mn_opf_strg(file, model_type::Type, optimizer; kwargs...)
     return solve_model(file, model_type, optimizer, build_mn_opf_strg; multinetwork=true, kwargs...)
 end
 
+"""
+    build_mn_opf_strg(pm::AbstractPowerModel)
+"""
 function build_mn_opf_strg(pm::AbstractPowerModel)
     for (n, network) in nws(pm)
         variable_bus_voltage(pm, nw=n)
@@ -169,6 +178,9 @@ function build_opf_ptdf(pm::AbstractPowerModel)
     Memento.error(_LOGGER, "build_opf_ptdf is only valid for DCPPowerModels")
 end
 
+"""
+    build_opf_ptdf(pm::DCPPowerModel)
+"""
 function build_opf_ptdf(pm::DCPPowerModel)
     variable_gen_power(pm)
 

--- a/src/prob/opf_bf.jl
+++ b/src/prob/opf_bf.jl
@@ -7,6 +7,9 @@ function solve_mn_opf_bf_strg(file, model_type::Type{T}, optimizer; kwargs...) w
     return solve_model(file, model_type, optimizer, build_mn_opf_bf_strg; multinetwork=true, kwargs...)
 end
 
+"""
+    build_opf_bf(pm::AbstractPowerModel)
+"""
 function build_opf_bf(pm::AbstractPowerModel)
     variable_bus_voltage(pm)
     variable_gen_power(pm)

--- a/src/prob/opf_iv.jl
+++ b/src/prob/opf_iv.jl
@@ -3,6 +3,9 @@ function solve_opf_iv(file, model_type::Type, optimizer; kwargs...)
     return solve_model(file, model_type, optimizer, build_opf_iv; kwargs...)
 end
 
+"""
+    build_opf_iv(pm::AbstractPowerModel)
+"""
 function build_opf_iv(pm::AbstractPowerModel)
     variable_bus_voltage(pm)
     variable_branch_current(pm)

--- a/src/prob/ots.jl
+++ b/src/prob/ots.jl
@@ -8,6 +8,9 @@ function solve_ots(file, model_type::Type, optimizer; kwargs...)
     return solve_model(file, model_type, optimizer, build_ots; ref_extensions=[ref_add_on_off_va_bounds!], kwargs...)
 end
 
+"""
+    build_ots(pm::AbstractPowerModel)
+"""
 function build_ots(pm::AbstractPowerModel)
     variable_branch_indicator(pm)
     variable_bus_voltage_on_off(pm)

--- a/src/prob/pf_bf.jl
+++ b/src/prob/pf_bf.jl
@@ -1,8 +1,13 @@
-""
+"""
+    solve_pf_bf(file, model_type::Type, optimizer; kwargs...)
+"""
 function solve_pf_bf(file, model_type::Type, optimizer; kwargs...)
     return solve_model(file, model_type, optimizer, build_pf_bf; kwargs...)
 end
 
+"""
+    build_pf_bf(pm::AbstractPowerModel)
+"""
 function build_pf_bf(pm::AbstractPowerModel)
     variable_bus_voltage(pm, bounded = false)
     variable_gen_power(pm, bounded = false)

--- a/src/prob/pf_iv.jl
+++ b/src/prob/pf_iv.jl
@@ -1,8 +1,13 @@
-""
+"""
+    solve_pf_iv(file, model_type::Type, optimizer; kwargs...)
+"""
 function solve_pf_iv(file, model_type::Type, optimizer; kwargs...)
     return solve_model(file, model_type, optimizer, build_pf_iv; kwargs...)
 end
 
+"""
+    build_pf_iv(pm::AbstractPowerModel)
+"""
 function build_pf_iv(pm::AbstractPowerModel)
     variable_bus_voltage(pm, bounded = false)
     variable_branch_current(pm, bounded = false)


### PR DESCRIPTION
Partial revert of #963. Instead of empty docstrings, we now have a minimal signature. There are open issues to actually improve the documentation.

I've removed `warnonly = Documenter.except(:linkcheck),`, since it actually meant that these missing docstrings were warning instead of erroring.