### PR TITLE
Change of docs for shunts in network data format

### DIFF
--- a/docs/src/network-data.md
+++ b/docs/src/network-data.md
@@ -48,8 +48,8 @@ The PowerModels network data dictionary structure is roughly as follows:
 "shunt":{
     "1":{
         "shunt_bus":<int>, # Index of the bus to which the shunt is attached
-        "gs":<float>,      # Active power withdrawn per voltage p.u.
-        "bs":<float>,      # Reactive power withdrawn per voltage p.u.
+        "gs":<float>,      # Active power withdrawn at unity voltage (1 p.u.)
+        "bs":<float>,      # Reactive power injected at unity voltage (1 p.u.)
         ...
     },
     "2":{...},


### PR DESCRIPTION
Changed the network data format shunt description from
```
"gs":<float>,      # Active power withdrawn per voltage p.u.
"bs":<float>,      # Reactive power withdrawn per voltage p.u.
```
to
```
"gs":<float>,      # Active power withdrawn at unity voltage (1 p.u.)
"bs":<float>,      # Reactive power injected at unity voltage (1 p.u.)
```


Reduces the confusion from #978.

Also changed from  `per voltage p.u.` to `at unity voltage (1 p.u.)` as the current phrasing implies a false linearity with voltage (it is quadratic).