### PR TITLE
Update to JSON@1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ PowerModels.jl Change Log
 =========================
 
 ### Staged
+- Update to JSON@1 (#986)
 
 ### v0.21.5
 - Relax tests to allow `INFEASIBLE_POINT` (#976)

--- a/Project.toml
+++ b/Project.toml
@@ -1,8 +1,8 @@
 name = "PowerModels"
 uuid = "c36e90e8-916a-50a6-bd94-075b64ef4655"
+version = "0.21.5"
 authors = ["Carleton Coffrin"]
 repo = "https://github.com/lanl-ansi/PowerModels.jl"
-version = "0.21.5"
 
 [deps]
 InfrastructureModels = "2030c09a-7f63-5d83-885d-db604e0e9cc0"
@@ -18,7 +18,7 @@ SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 HiGHS = "1"
 InfrastructureModels = "0.6, 0.7"
 Ipopt = "1"
-JSON = "0.21"
+JSON = "1"
 JuMP = "1.15"
 Juniper = "0.9"
 Memento = "1"

--- a/src/io/common.jl
+++ b/src/io/common.jl
@@ -83,7 +83,11 @@ function export_file(io::IO, data::Dict{String, Any}; filetype="json")
     elseif filetype == "raw"
         PowerModels.export_pti(io, data)
     elseif filetype == "json"
-        JSON.json(io, data; allownan = true)
+        # This call reverts the writing behavior of JSON@1 to the pre-1.0
+        # behavior of `Inf => null` and so on. The new default in JSON@1 is to
+        # error (if allownan is not set), and to print `Inf => "Infinity"` if
+        # `inf` is not set. Ditto for `ninf` (for -Inf) and `nan` (for NaN).
+        JSON.json(io, data; allownan = true, inf = "null", ninf = "null", nan = "null")
     else
         Memento.error(_LOGGER, "Unrecognized filetype: \".$filetype\", Supported extensions are \".raw\", \".m\" and \".json\"")
     end

--- a/src/io/common.jl
+++ b/src/io/common.jl
@@ -83,8 +83,7 @@ function export_file(io::IO, data::Dict{String, Any}; filetype="json")
     elseif filetype == "raw"
         PowerModels.export_pti(io, data)
     elseif filetype == "json"
-        stringdata = JSON.json(data)
-        write(io, stringdata)
+        JSON.json(io, data; allownan = true)
     else
         Memento.error(_LOGGER, "Unrecognized filetype: \".$filetype\", Supported extensions are \".raw\", \".m\" and \".json\"")
     end

--- a/src/io/json.jl
+++ b/src/io/json.jl
@@ -6,8 +6,8 @@ function _jsonver2juliaver!(pm_data)
     end
 end
 
-_json_parse(io::IO) = JSON.parse(io)
-_json_parse(io::String) = JSON.parsefile(io; use_mmap = false)
+_json_parse(io::IO) = JSON.parse(io; dicttype = Dict{String,Any})
+_json_parse(io::String) = JSON.parsefile(io; dicttype = Dict{String,Any})
 
 "Parses json from iostream or string"
 function parse_json(io::Union{IO,String}; validate = true)::Dict{String,Any}

--- a/test/matpower.jl
+++ b/test/matpower.jl
@@ -8,7 +8,7 @@
 
     @testset "30-bus case matpower data (parse_file)" begin
         data = PowerModels.parse_file("../test/data/matpower/case30.m")
-        @test isa(JSON.json(data), String)
+        @test sprint(PowerModels.export_file, data) isa String
 
         result = solve_opf(data, ACPPowerModel, nlp_solver)
 
@@ -18,7 +18,7 @@
 
     @testset "30-bus case matpower data (parse_matpower)" begin
         data = PowerModels.parse_matpower("../test/data/matpower/case30.m")
-        @test isa(JSON.json(data), String)
+        @test sprint(PowerModels.export_file, data) isa String
 
         result = solve_opf(data, ACPPowerModel, nlp_solver)
 
@@ -29,7 +29,7 @@
     @testset "30-bus case matpower data (parse_matpower; iostream)" begin
         open("../test/data/matpower/case30.m") do f
             data = PowerModels.parse_matpower(f)
-            @test isa(JSON.json(data), String)
+            @test sprint(PowerModels.export_file, data) isa String
 
             result = solve_opf(data, ACPPowerModel, nlp_solver)
 
@@ -41,19 +41,19 @@
     @testset "14-bus case file with bus names" begin
         data = PowerModels.parse_file("../test/data/matpower/case14.m")
         @test data["bus"]["1"]["name"] == "Bus 1     HV"
-        @test isa(JSON.json(data), String)
+        @test sprint(PowerModels.export_file, data) isa String
     end
 
     @testset "5-bus case file with pwl cost functions" begin
         data = PowerModels.parse_file("../test/data/matpower/case5_pwlc.m")
         @test data["gen"]["1"]["model"] == 1
-        @test isa(JSON.json(data), String)
+        @test sprint(PowerModels.export_file, data) isa String
     end
 
     @testset "3-bus case file with hvdc lines" begin
         data = PowerModels.parse_file("../test/data/matpower/case3.m")
         @test length(data["dcline"]) > 0
-        @test isa(JSON.json(data), String)
+        @test sprint(PowerModels.export_file, data) isa String
     end
 
     @testset "2-bus case file with spaces" begin
@@ -104,7 +104,7 @@ end
         @test data["const_int"] == 123
         @test data["const_float"] == 4.56
         @test data["const_str"] == "a string"
-        @test isa(JSON.json(data), String)
+        @test sprint(PowerModels.export_file, data) isa String
     end
 
     @testset "3-bus extended matrix" begin
@@ -115,7 +115,7 @@ end
         @test data["areas"]["1"]["col_2"] == 1
         @test data["areas"]["2"]["col_1"] == 2
         @test data["areas"]["2"]["col_2"] == 3
-        @test isa(JSON.json(data), String)
+        @test sprint(PowerModels.export_file, data) isa String
     end
 
     @testset "3-bus extended named matrix" begin
@@ -126,7 +126,7 @@ end
         @test data["areas_named"]["1"]["refbus"] == 5
         @test data["areas_named"]["2"]["area"] == 5
         @test data["areas_named"]["2"]["refbus"] == 6
-        @test isa(JSON.json(data), String)
+        @test sprint(PowerModels.export_file, data) isa String
     end
 
     @testset "3-bus extended predefined matrix" begin
@@ -139,7 +139,7 @@ end
         @test data["branch"]["2"]["rate_p"] == 60.1
         @test data["branch"]["3"]["rate_i"] == 12
         @test data["branch"]["3"]["rate_p"] == 30
-        @test isa(JSON.json(data), String)
+        @test sprint(PowerModels.export_file, data) isa String
     end
 
     @testset "3-bus extended matrix from cell" begin
@@ -154,7 +154,7 @@ end
         @test data["areas_cells"]["2"]["col_2"] == 456
         @test data["areas_cells"]["2"]["col_4"] == "Slack Bus 3"
         @test data["areas_cells"]["2"]["col_5"] == 4.56
-        @test isa(JSON.json(data), String)
+        @test sprint(PowerModels.export_file, data) isa String
     end
 
     @testset "3-bus extended named matrix from cell" begin
@@ -171,7 +171,7 @@ end
         @test data["areas_named_cells"]["2"]["area2"] == 987
         @test data["areas_named_cells"]["2"]["refbus_name"] == "Slack Bus 3"
         @test data["areas_named_cells"]["2"]["refbus"] == 4.56
-        @test isa(JSON.json(data), String)
+        @test sprint(PowerModels.export_file, data) isa String
     end
 
     @testset "3-bus extended predefined matrix from cell" begin
@@ -184,7 +184,7 @@ end
         @test data["branch"]["2"]["number_id"] == 456
         @test data["branch"]["3"]["name"] == "Branch 3"
         @test data["branch"]["3"]["number_id"] == 789
-        @test isa(JSON.json(data), String)
+        @test sprint(PowerModels.export_file, data) isa String
     end
 
     @testset "3-bus tnep case" begin
@@ -193,7 +193,7 @@ end
         @test haskey(data, "ne_branch")
         @test data["ne_branch"]["1"]["f_bus"] == 2
         @test data["ne_branch"]["1"]["construction_cost"] == 1
-        @test isa(JSON.json(data), String)
+        @test sprint(PowerModels.export_file, data) isa String
     end
 
     @testset "`build_ref` for 3-bus tnep case" begin

--- a/test/modify.jl
+++ b/test/modify.jl
@@ -31,25 +31,15 @@
     @testset "30-bus case file batch" begin
         data = PowerModels.parse_file("../test/data/matpower/case30.m")
 
-        data_delta = JSON.parse("
-        {
-            \"branch\":{
-                \"6\":{
-                    \"br_status\":0
-                }
-            },
-            \"gen\":{
-                \"6\":{
-                    \"gen_status\":0
-                }
-            },
-            \"load\":{
-                \"4\":{
-                    \"pd\":0,
-                    \"qd\":0
-                }
-            }
-        }")
+        data_delta = JSON.parse(
+            """
+            {
+            "branch":{"6":{"br_status":0}},
+            "gen":{"6":{"gen_status":0}},
+            "load":{"4":{"pd":0,"qd":0}}
+            }""";
+            dicttype = Dict{String,Any},
+        )
 
         PowerModels.update_data!(data, data_delta)
 


### PR DESCRIPTION
Closes #985

@ccoffrin there's one notable change, with how JSON@1 writes `Inf`:

```julia
(js) pkg> st
Status `/private/tmp/js/Project.toml`
⌃ [682c06a0] JSON v0.21.4
Info Packages marked with ⌃ have new versions available and may be upgradable.

julia> import JSON

julia> JSON.json(Inf)
"null"

julia> JSON.json(-Inf)
"null"
```

```julia
(json) pkg> st
Status `/private/tmp/json/Project.toml`
  [682c06a0] JSON v1.1.0

julia> import JSON

julia> JSON.json(Inf)
ERROR: ArgumentError: Inf not allowed to be written in JSON spec; pass `allownan=true` to allow anyway
Stacktrace:
 [1] infcheck(x::Float64, allownan::Bool)
   @ JSON ~/.julia/packages/JSON/jLnej/src/write.jl:694
 [2] _number(buf::Vector{UInt8}, pos::Int64, x::Float64, opts::JSON.WriteOptions{JSON.JSONWriteStyle}, io::Nothing, bufsize::Int64)
   @ JSON ~/.julia/packages/JSON/jLnej/src/write.jl:712
 [3] json!
   @ ~/.julia/packages/JSON/jLnej/src/write.jl:592 [inlined]
 [4] json! (repeats 3 times)
   @ ~/.julia/packages/JSON/jLnej/src/write.jl:562 [inlined]
 [5] json(x::Float64; pretty::Bool, kw::@Kwargs{})
   @ JSON ~/.julia/packages/JSON/jLnej/src/write.jl:433
 [6] json(x::Float64)
   @ JSON ~/.julia/packages/JSON/jLnej/src/write.jl:426
 [7] top-level scope
   @ REPL[3]:1

julia> JSON.json(Inf; allownan=true)
"Infinity"

julia> JSON.json(-Inf; allownan=true)
"-Infinity"
```

It doesn't look like we have a test that parses a file containing `Infinity`. Does that ever come up in a MATPOWER file?