### PR TITLE
Expose `_parse_matlab_data` by moving `_IM.parse_matlab_string` outside

### DIFF
--- a/src/io/matpower.jl
+++ b/src/io/matpower.jl
@@ -125,7 +125,11 @@ const _mp_switch_columns = [
 
 function _parse_matpower_string(data_string::String)
     matlab_data, func_name, colnames = _IM.parse_matlab_string(data_string, extended=true)
+    return _parse_matpower_data(matlab_data, func_name, colnames)
+end
 
+
+function _parse_matpower_data(matlab_data::Dict{String,Any}, func_name::Union{AbstractString,Nothing}, colnames::Dict{String,Any})
     case = Dict{String,Any}()
 
     if func_name != nothing

--- a/src/io/matpower.jl
+++ b/src/io/matpower.jl
@@ -125,11 +125,11 @@ const _mp_switch_columns = [
 
 function _parse_matpower_string(data_string::String)
     matlab_data, func_name, colnames = _IM.parse_matlab_string(data_string, extended=true)
-    return _parse_matpower_data(matlab_data, func_name, colnames)
+    return _parse_matlab_data(matlab_data, func_name, colnames)
 end
 
 
-function _parse_matpower_data(matlab_data::Dict{String,Any}, func_name::Union{AbstractString,Nothing}, colnames::Dict{String,Any})
+function _parse_matlab_data(matlab_data::Dict{String,Any}, func_name::Union{AbstractString,Nothing}, colnames::Dict{String,Any})
     case = Dict{String,Any}()
 
     if func_name != nothing


### PR DESCRIPTION
## Refactor: move `_IM.parse_matlab_string` outside

### Change

Splits `_parse_matpower_string` into two internal functions with **zero logic changes**:
```julia
# Before
function _parse_matpower_string(data_string::String)
    matlab_data, func_name, colnames = _IM.parse_matlab_string(data_string, extended=true)
    # ... all processing logic
end

# After
function _parse_matpower_string(data_string::String)
    matlab_data, func_name, colnames = _IM.parse_matlab_string(data_string, extended=true)
    return _parse_matlab_data(matlab_data, func_name, colnames)
end

function _parse_matlab_data(matlab_data::Dict{String,Any}, func_name::Union{AbstractString,Nothing}, colnames::Dict{String,Any})
    # ... exact same body, untouched
end
```

### What is NOT changed

- `_parse_matpower_string` behavior is identical
- `parse_matpower(io::IO)` and `parse_matpower(file::String)` are identical
- No new public API in this PR
- No new data format, no new dependencies

### Why it matters

This allows downstream packages to wrap PowerModels without serializing back to a `.m` string. For example, someone with matpower dict data use a wrapper that **live outside** PowerModels:

```julia
function parse_matpower(matlab_data::Dict{String,Any};
                        func_name::Union{AbstractString,Nothing}=nothing,
                        colnames::Dict{String,Any}=Dict{String,Any}(),
                        validate=true)::Dict
    mp_data = PowerModels._parse_matpower_data(matlab_data, func_name, colnames)
    pm_data = PowerModels._matpower_to_powermodels!(mp_data)
    if validate
        PowerModels.correct_network_data!(pm_data)
    end
    return pm_data
end
```

As suggested in https://github.com/lanl-ansi/PowerModels.jl/pull/928, this PR will support a wrapper lives outside PowerModels, without rewriting the whole `_parse_matpower_string`, thus safer if in the future someone update `_parse_matpower_string`. This PR will make minimal changes and minimal burden to support this.

___

Alternatively, at least for me, actually, it would be cleaner if the refactor is:

```julia
function parse_matpower(io::IO; validate=true)::Dict
    data_string = read(io, String)
    matlab_data, func_name, colnames = _IM.parse_matlab_string(data_string, extended=true)
    mp_data = _parse_matlab_data(matlab_data, func_name, colnames)
    pm_data = _matpower_to_powermodels!(mp_data)
    if validate
        correct_network_data!(pm_data)
    end
    return pm_data
end
```

But, this alternative refactor remove `_parse_matpower_string`.