### PR TITLE
Relax tests for NUMERICAL_ERROR or OTHER_ERROR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ PowerModels.jl Change Log
 =========================
 
 ### Staged
+- Relax tests to allow `OTHER_ERROR` (#1010)
 
 ### v0.21.6
 - Update to JSON@1 (#986)

--- a/test/pf-native.jl
+++ b/test/pf-native.jl
@@ -130,7 +130,7 @@ end
                 @test isapprox(bus_qg_nlp[i], bus_qg_nls[i]; atol = 1e-6)
             end
         else
-            @test result["termination_status"] == NUMERICAL_ERROR
+            @test result["termination_status"] in (NUMERICAL_ERROR, OTHER_ERROR)
         end
 
     end
@@ -456,7 +456,7 @@ end
                 @test isapprox(bus_qg_nlp[i], bus_qg_nls[i]; atol = 1e-6)
             end
         else
-            @test result["termination_status"] == NUMERICAL_ERROR
+            @test result["termination_status"] in (NUMERICAL_ERROR, OTHER_ERROR)
         end
     end
     @testset "5-bus case, flat_start" begin
@@ -482,7 +482,7 @@ end
                 @test isapprox(bus_qg_nlp[i], bus_qg_nls[i]; atol = 1e-6)
             end
         else
-            @test result["termination_status"] == NUMERICAL_ERROR
+            @test result["termination_status"] in (NUMERICAL_ERROR, OTHER_ERROR)
         end
     end
     @testset "5-bus case, in-place and nsolve method parameter" begin

--- a/test/pf.jl
+++ b/test/pf.jl
@@ -27,7 +27,7 @@
         if result["termination_status"] == LOCALLY_SOLVED
             @test isapprox(result["objective"], 0; atol = 1e-2)
         else
-            @test result["termination_status"] == NUMERICAL_ERROR
+            @test result["termination_status"] in (NUMERICAL_ERROR, OTHER_ERROR)
         end
     end
     @testset "5-bus asymmetric case" begin


### PR DESCRIPTION
We were failing tests: https://github.com/jump-dev/JuMP.jl/pull/4188